### PR TITLE
Add Bootswatch theme and hero section for improved UI

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,8 @@
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+.hero {
+  background: linear-gradient(120deg, #00b4d8, #90e0ef);
+  color: #fff;
+}

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,6 +1,13 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1 class="mb-4">Available Bars</h1>
+<div class="p-5 mb-4 hero rounded-3">
+  <div class="container-fluid py-5">
+    <h1 class="display-5 fw-bold">Find your next drink</h1>
+    <p class="col-md-8 fs-4">Browse nearby bars and order directly from your table.</p>
+  </div>
+</div>
+
+<h2 class="mb-4">Available Bars</h2>
 <div class="row">
   {% for bar in bars %}
   <div class="col-md-4 mb-3">

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -4,10 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>SiplyGo Prototype</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-g1T4I8o1gChX2NDVY5QZnQEqplLWYwgd0CQpZK0s8AjtKoa6HgMHqYjgJv1LGj6Y" crossorigin="anonymous">
+  <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/lumen/bootstrap.min.css" rel="stylesheet" integrity="sha384-m0nEIiDhcE7UZ5EONosFVJeFt3PcTJS3BM4tiTqcKoy0eZZ+j9RnBbTK1Z4qVaki" crossorigin="anonymous">
+  <link href="/static/style.css" rel="stylesheet">
 </head>
 <body>
-  <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+  <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
     <div class="container-fluid">
       <a class="navbar-brand" href="/">SiplyGo</a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">


### PR DESCRIPTION
## Summary
- switch to Bootswatch Lumen theme and load custom stylesheet
- add hero section to home page
- create base stylesheet for fonts and hero gradient

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5a8c6b7388320ac5ddc32d9232f1e