### PR TITLE
Refactor home markup with semantic structure and design tokens

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,89 +1,86 @@
-:root {
-  --primary: #ff5722;
-  --secondary: #673ab7;
-  --accent: #ffc107;
+:root{
+  --color-primary:#0ea5e9;
+  --color-bg:#0b0b0c;
+  --color-surface:#111216;
+  --color-text:#e7e7ea;
+  --color-muted:#a4a7ae;
+  --radius:16px;
+  --font-sans:"Inter", ui-sans-serif, system-ui;
+  --step-0: clamp(14px, 1.2vw, 16px);
+  --step-3: clamp(28px, 4vw, 40px);
 }
-
-body {
-  font-family: 'Inter', sans-serif;
-  background-color: #f8f9fa;
-  transition: background-color 0.3s, color 0.3s;
+body{
+  background:var(--color-bg);
+  color:var(--color-text);
+  font-family:var(--font-sans);
+  transition:background-color .3s,color .3s;
 }
-
-a {
-  color: var(--primary);
+.container{
+  max-width:1200px;
+  margin-inline:auto;
+  padding-inline:clamp(16px,4vw,32px);
 }
-
-a:hover {
-  color: #e64a19;
+.skip-to-content{
+  position:absolute;
+  top:-40px;
+  left:0;
+  background:var(--color-primary);
+  color:#fff;
+  padding:.5rem 1rem;
+  z-index:100;
+  transition:top .2s;
 }
-
-.navbar {
-  position: sticky;
-  top: 0;
-  z-index: 1020;
+.skip-to-content:focus{top:0;}
+.site-header{
+  position:sticky;
+  top:0;
+  z-index:50;
+  backdrop-filter:saturate(180%) blur(10px);
+  background:color-mix(in srgb,var(--color-bg) 85%,transparent);
+  border-bottom:1px solid #1f232b;
 }
-
-.bg-primary {
-  background-color: var(--primary) !important;
+.hero-banner{
+  background:url('https://images.unsplash.com/photo-1528181304800-259b0884851d?auto=format&fit=crop&w=1350&q=80') center/cover no-repeat;
+  min-height:60vh;
+  display:flex;
+  align-items:center;
 }
-
-.navbar-dark .navbar-nav .nav-link,
-.navbar-dark .navbar-brand {
-  color: #fff;
+.btn{
+  display:inline-flex;
+  align-items:center;
+  gap:.5rem;
+  padding:.75rem 1rem;
+  border-radius:var(--radius);
+  border:1px solid transparent;
+  transition:.2s;
+  text-decoration:none;
 }
-
-.hero-banner {
-  background: url('https://images.unsplash.com/photo-1528181304800-259b0884851d?auto=format&fit=crop&w=1350&q=80') center/cover no-repeat;
-  min-height: 60vh;
+.btn--primary{background:var(--color-primary);color:#fff;}
+.btn--primary:hover{filter:brightness(1.05);transform:translateY(-1px);}
+.btn:focus-visible{outline:3px solid color-mix(in srgb,var(--color-primary),white 30%);outline-offset:2px;}
+.bars{
+  display:grid;
+  grid-template-columns:repeat(auto-fill,minmax(280px,1fr));
+  gap:24px;
+  list-style:none;
+  padding:0;
 }
-
-.card {
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+.card{
+  background:var(--color-surface);
+  border-radius:var(--radius);
+  overflow:hidden;
+  box-shadow:0 6px 24px rgb(0 0 0 / .25);
+  transition:.25s;
 }
-
-.card:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 0.5rem 1rem rgba(0,0,0,0.15);
-}
-
-.bar-card {
-  animation: fadeIn 0.6s ease;
-}
-
-@keyframes fadeIn {
-  from { opacity: 0; transform: translateY(10px); }
-  to { opacity: 1; transform: none; }
-}
-
-.btn-primary {
-  background-color: var(--primary);
-  border-color: var(--primary);
-}
-
-.btn-primary:hover {
-  background-color: #e64a19;
-  border-color: #e64a19;
-}
-
-.badge {
-  margin-right: 0.25rem;
-}
-
-.dark-mode {
-  background-color: #121212;
-  color: #f8f9fa;
-}
-
-.dark-mode a {
-  color: var(--accent);
-}
-
-.dark-mode .navbar {
-  background-color: #222 !important;
-}
-
-.dark-mode .card {
-  background-color: #1e1e1e;
-  color: #f8f9fa;
-}
+.card:hover{transform:translateY(-2px);box-shadow:0 10px 32px rgb(0 0 0 / .35);}
+.card__media{width:100%;aspect-ratio:16/9;object-fit:cover;display:block;}
+.card__body{padding:1rem;display:flex;flex-direction:column;gap:.5rem;}
+.card__title{font-size:1.125rem;margin:0;}
+.rating{color:var(--color-primary);}
+.chips{display:flex;gap:8px;flex-wrap:wrap;margin:.5rem 0 1rem;padding:0;list-style:none;}
+.chips li{font-size:.8rem;padding:.25rem .5rem;border-radius:999px;background:#1c1f26;color:#cbd5e1;}
+.bar-card{animation:fadeIn .6s ease;}
+@keyframes fadeIn{from{opacity:0;transform:translateY(10px);}to{opacity:1;transform:none;}}
+.dark-mode{background-color:#121212;color:#f8f9fa;}
+.dark-mode .card{background-color:#1e1e1e;color:#f8f9fa;}
+.dark-mode a{color:var(--color-muted);}

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,13 +1,13 @@
 {% extends "layout.html" %}
 {% block content %}
 
-<div class="hero-banner text-center text-white d-flex align-items-center mb-5">
+<section class="hero-banner text-center text-white d-flex align-items-center mb-5">
   <div class="container">
     <h1 class="display-5 fw-bold">Order drinks instantly, right from your table.</h1>
     <p class="lead">Skip the wait. Discover nearby bars and order with one tap.</p>
-    <a href="#bars" class="btn btn-primary btn-lg">Browse Bars</a>
+    <a href="#bars" class="btn btn--primary btn-lg">Browse Bars</a>
   </div>
-</div>
+</section>
 
 <div id="offersCarousel" class="carousel slide mb-5" data-bs-ride="carousel">
   <div class="carousel-inner">
@@ -31,50 +31,50 @@
 {% endif %}
 
 {% if last_bar %}
-<div class="mb-5">
-  <h3>Your last visited bar</h3>
-  <div class="row">
-    <div class="col-md-4 mb-3">
-      <div class="card h-100">
-        <img src="https://source.unsplash.com/random/400x250?bar,{{ last_bar.id }}" class="card-img-top" alt="{{ last_bar.name }}">
-        <div class="card-body d-flex flex-column">
-          <h5 class="card-title">{{ last_bar.name }}</h5>
-          <p class="card-text">{{ last_bar.address }}</p>
-          <a class="btn btn-primary mt-auto" href="/bars/{{ last_bar.id }}">View Menu</a>
+<section class="mb-5">
+  <h2>Your last visited bar</h2>
+  <ul class="bars">
+    <li class="bar-card" data-name="{{ last_bar.name|lower }}" data-address="{{ last_bar.address|lower }}">
+      <article class="card">
+        <figure class="card__media">
+          <img src="https://source.unsplash.com/random/400x250?bar,{{ last_bar.id }}" alt="{{ last_bar.name }}">
+        </figure>
+        <div class="card__body">
+          <h3 class="card__title">{{ last_bar.name }}</h3>
+          <address>{{ last_bar.address }}</address>
+          <div class="rating" aria-label="Rated 4.7 out of 5">★ 4.7</div>
+          <ul class="chips"><li>Cocktails</li><li>Sports</li><li>Live Music</li></ul>
+          <a class="btn btn--primary" href="/bars/{{ last_bar.id }}">View Menu</a>
         </div>
-      </div>
-    </div>
-  </div>
-</div>
+      </article>
+    </li>
+  </ul>
+</section>
 {% endif %}
 
-<div class="row mb-4">
-  <div class="col-md-6">
-    <input type="text" id="barSearch" class="form-control" placeholder="Search bars...">
-  </div>
+<div class="mb-4">
+  <input type="text" id="barSearch" class="form-control" placeholder="Search bars...">
 </div>
 
 <h2 id="bars" class="mb-4">Available Bars</h2>
-<div class="row" id="barList">
+<ul class="bars" id="barList">
   {% for bar in bars %}
-  <div class="col-md-4 mb-3 bar-card" data-name="{{ bar.name|lower }}" data-address="{{ bar.address|lower }}">
-    <div class="card h-100 shadow-sm">
-      <img src="https://source.unsplash.com/random/400x250?bar,{{ bar.id }}" class="card-img-top" alt="{{ bar.name }}">
-      <div class="card-body d-flex flex-column">
-        <h5 class="card-title">{{ bar.name }}</h5>
-        <p class="card-text">{{ bar.address }}</p>
-        <div class="mb-2">
-          <span class="text-warning">&#9733; 4.7</span>
-          <span class="badge bg-secondary">Cocktails</span>
-          <span class="badge bg-secondary">Sports</span>
-          <span class="badge bg-secondary">Live Music</span>
-        </div>
-        <a class="btn btn-primary mt-auto" href="/bars/{{ bar.id }}">View Menu</a>
+  <li class="bar-card" data-name="{{ bar.name|lower }}" data-address="{{ bar.address|lower }}">
+    <article class="card">
+      <figure class="card__media">
+        <img src="https://source.unsplash.com/random/400x250?bar,{{ bar.id }}" alt="{{ bar.name }}">
+      </figure>
+      <div class="card__body">
+        <h3 class="card__title">{{ bar.name }}</h3>
+        <address>{{ bar.address }}</address>
+        <div class="rating" aria-label="Rated 4.7 out of 5">★ 4.7</div>
+        <ul class="chips"><li>Cocktails</li><li>Sports</li><li>Live Music</li></ul>
+        <a class="btn btn--primary" href="/bars/{{ bar.id }}">View Menu</a>
       </div>
-    </div>
-  </div>
+    </article>
+  </li>
   {% endfor %}
-</div>
+</ul>
 
 <div class="mt-5">
   <h3>Rewards & Loyalty</h3>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -9,50 +9,53 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/lumen/bootstrap.min.css" rel="stylesheet" integrity="sha384-m0nEIiDhcE7UZ5EONosFVJeFt3PcTJS3BM4tiTqcKoy0eZZ+j9RnBbTK1Z4qVaki" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
-  <link href="/static/style.css" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
+<link href="/static/style.css" rel="stylesheet">
 </head>
 <body>
-  <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
-    <div class="container-fluid">
-      <a class="navbar-brand d-flex align-items-center" href="/">
-        <img src="/static/logo.svg" alt="SiplyGo" height="30" class="me-2"> SiplyGo
-      </a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="navbarNav">
-        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-          <li class="nav-item"><a class="nav-link" href="/"><i class="bi bi-house"></i></a></li>
-          {% if user %}
-            <li class="nav-item">
-              <a class="nav-link" href="/cart">
-                <i class="bi bi-cart"></i>
-                {% if cart_count %}<span class="badge bg-light text-dark ms-1">{{ cart_count }}</span>{% endif %}
-              </a>
-            </li>
-            {% if user.is_super_admin %}
-              <li class="nav-item"><a class="nav-link" href="/admin/dashboard"><i class="bi bi-speedometer2"></i></a></li>
+  <a class="skip-to-content" href="#main">Skip to content</a>
+  <header class="site-header">
+    <nav role="navigation" aria-label="Primary" class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
+      <div class="container-fluid">
+        <a class="navbar-brand d-flex align-items-center" href="/">
+          <img src="/static/logo.svg" alt="SiplyGo" height="30" class="me-2"> SiplyGo
+        </a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+            <li class="nav-item"><a class="nav-link" href="/"><i class="bi bi-house"></i></a></li>
+            {% if user %}
+              <li class="nav-item">
+                <a class="nav-link" href="/cart">
+                  <i class="bi bi-cart"></i>
+                  {% if cart_count %}<span class="badge bg-light text-dark ms-1">{{ cart_count }}</span>{% endif %}
+                </a>
+              </li>
+              {% if user.is_super_admin %}
+                <li class="nav-item"><a class="nav-link" href="/admin/dashboard"><i class="bi bi-speedometer2"></i></a></li>
+              {% endif %}
             {% endif %}
-          {% endif %}
-        </ul>
-        <div class="d-flex align-items-center">
-          <button class="btn btn-outline-light me-2" id="themeToggle" type="button"><i class="bi bi-moon"></i></button>
-          {% if user %}
-            <span class="navbar-text me-2">Welcome, {{ user.username }}</span>
-            <a class="btn btn-outline-light" href="/logout">Logout</a>
-          {% else %}
-            <a class="btn btn-outline-light me-2" href="/login">Login</a>
-            <a class="btn btn-outline-light" href="/register">Register</a>
-          {% endif %}
+          </ul>
+          <div class="d-flex align-items-center">
+            <button class="btn btn-outline-light me-2" id="themeToggle" type="button"><i class="bi bi-moon"></i></button>
+            {% if user %}
+              <span class="navbar-text me-2">Welcome, {{ user.username }}</span>
+              <a class="btn btn-outline-light" href="/logout">Logout</a>
+            {% else %}
+              <a class="btn btn-outline-light me-2" href="/login">Login</a>
+              <a class="btn btn-outline-light" href="/register">Register</a>
+            {% endif %}
+          </div>
         </div>
       </div>
-    </div>
-  </nav>
-  <div class="container">
+    </nav>
+  </header>
+  <main id="main" class="container">
       {% block content %}{% endblock %}
-  </div>
-  <footer class="bg-light text-center mt-5 py-4">
+  </main>
+  <footer class="site-footer bg-light text-center mt-5 py-4">
     <div class="container">
       <img src="/static/logo.svg" alt="SiplyGo" height="30" class="mb-2"><br>
       <a href="#">About</a> · <a href="#">Contact</a> · <a href="#">Terms</a> · <a href="#">Privacy</a>


### PR DESCRIPTION
## Summary
- Replaced page chrome with semantic landmarks, including skip link and main region
- Converted bar listings into a semantic grid of cards with addresses, ratings and CTAs
- Introduced design tokens and reusable card/button styles for consistent theming

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5c0b750688320aee761a6fb7e5470