### PR TITLE
Add bartender invitation flow and email-based auth

### DIFF
--- a/templates/admin_add_user_to_bar.html
+++ b/templates/admin_add_user_to_bar.html
@@ -2,10 +2,15 @@
 {% block content %}
 <h1 class="mb-4">Add User to {{ bar.name }}</h1>
 {% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
+{% if message %}<div class="alert alert-success">{{ message }}</div>{% endif %}
 <form method="get">
   <div class="mb-3">
     <label class="form-label">Username</label>
     <input class="form-control" name="username">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Email</label>
+    <input class="form-control" name="email">
   </div>
   <div class="mb-3">
     <label class="form-label">Password</label>
@@ -18,6 +23,6 @@
       <option value="bartender">Bartender</option>
     </select>
   </div>
-  <button type="submit" class="btn btn-primary">Create</button>
+  <button type="submit" class="btn btn-primary">Submit</button>
 </form>
 {% endblock %}

--- a/templates/bartender_confirm.html
+++ b/templates/bartender_confirm.html
@@ -1,0 +1,6 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1 class="mb-4">Bartender Registration</h1>
+<p>You are now registered as a bartender for {{ bar.name }}.</p>
+<a class="btn btn-primary" href="/dashboard">Go to Dashboard</a>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -4,8 +4,8 @@
 {% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
 <form method="get" action="/login" class="mx-auto" style="max-width:320px;">
   <div class="mb-3">
-    <label class="form-label">Username</label>
-    <input class="form-control" type="text" name="username">
+    <label class="form-label">Email</label>
+    <input class="form-control" type="email" name="email">
   </div>
   <div class="mb-3">
     <label class="form-label">Password</label>

--- a/templates/register.html
+++ b/templates/register.html
@@ -8,8 +8,24 @@
     <input class="form-control" type="text" name="username">
   </div>
   <div class="mb-3">
+    <label class="form-label">Email</label>
+    <input class="form-control" type="email" name="email">
+  </div>
+  <div class="mb-3">
     <label class="form-label">Password</label>
     <input class="form-control" type="password" name="password">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Phone Prefix</label>
+    <select class="form-control" name="prefix">
+      <option value="+41">+41 (Switzerland)</option>
+      <option value="+1">+1 (USA)</option>
+      <option value="+44">+44 (UK)</option>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Phone Number</label>
+    <input class="form-control" type="text" name="phone">
   </div>
   <button class="btn btn-primary" type="submit">Register</button>
 </form>


### PR DESCRIPTION
## Summary
- support email-based login and registration with phone and prefix fields
- allow bar admins to invite bartenders who confirm their role before activation
- add template for bartender confirmation

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5e62f46c08320b7d8a8819b90416f