### PR TITLE
Enhance auth UI and show user details on dashboards

### DIFF
--- a/main.py
+++ b/main.py
@@ -246,6 +246,8 @@ def seed_super_admin():
         username="andreastojov",
         password="Andrea24",
         email="andreastojov@gmail.com",
+        phone="5551234",
+        prefix="+41",
         role="super_admin",
     )
     users[admin.id] = admin
@@ -267,6 +269,8 @@ def seed_bar_staff():
         username="baradmin",
         password="baradmin",
         email="baradmin@example.com",
+        phone="5555678",
+        prefix="+41",
         role="bar_admin",
         bar_id=bar_id,
     )
@@ -281,6 +285,8 @@ def seed_bar_staff():
         username="bartender",
         password="bartender",
         email="bartender@example.com",
+        phone="5559012",
+        prefix="+41",
         role="bartender",
         bar_id=bar_id,
     )

--- a/static/style.css
+++ b/static/style.css
@@ -65,3 +65,17 @@ body{background:var(--bg);color:var(--text);font-family:var(--font-sans);}
 .site-footer{margin-top:var(--space-4);padding:var(--space-3) 0;background:var(--surface);text-align:center;}
 .site-footer a{color:var(--text);text-decoration:none;}
 
+.auth-card{max-width:400px;margin:var(--space-4) auto;padding:var(--space-3);background:var(--surface);border-radius:var(--radius);box-shadow:var(--shadow);display:flex;flex-direction:column;gap:var(--space-2);}
+.auth-card h1{margin:0;text-align:center;}
+.auth-card .alert{color:#dc2626;text-align:center;}
+.auth-card form{display:flex;flex-direction:column;gap:var(--space-2);}
+.auth-card label{display:flex;flex-direction:column;font-weight:600;gap:var(--space-1);}
+.auth-card input,.auth-card select{padding:var(--space-2);border:1px solid #d1d5db;border-radius:var(--radius);}
+.auth-card button{align-self:center;margin-top:var(--space-1);}
+
+.dashboard-info{margin-bottom:var(--space-4);}
+.dashboard-info .card{padding:var(--space-3);gap:var(--space-1);}
+.dashboard-actions{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:var(--space-3);}
+.dashboard-actions .card{padding:var(--space-3);text-align:center;gap:var(--space-2);}
+.dashboard-actions .card h3{margin-top:0;}
+

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -1,33 +1,29 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1 class="mb-4">Admin Dashboard</h1>
-<div class="row">
-  <div class="col-md-4 mb-3">
-    <div class="card h-100">
-      <div class="card-body text-center">
-        <h5 class="card-title">Bars</h5>
-        <p class="card-text">Create and manage bars.</p>
-        <a class="btn btn-primary" href="/admin/bars">Manage Bars</a>
-      </div>
-    </div>
+<h1>Admin Dashboard</h1>
+<div class="dashboard-info">
+  <div class="card">
+    <h2>{{ user.username }}</h2>
+    <p>{{ user.email }}</p>
+    <p>{{ user.prefix }} {{ user.phone }}</p>
   </div>
-  <div class="col-md-4 mb-3">
-    <div class="card h-100">
-      <div class="card-body text-center">
-        <h5 class="card-title">Users</h5>
-        <p class="card-text">Manage platform users.</p>
-        <a class="btn btn-primary" href="/admin/users">Manage Users</a>
-      </div>
-    </div>
+</div>
+<div class="dashboard-actions">
+  <div class="card">
+    <h3>Bars</h3>
+    <p>Create and manage bars.</p>
+    <a class="btn btn--primary" href="/admin/bars">Manage Bars</a>
   </div>
-  <div class="col-md-4 mb-3">
-    <div class="card h-100">
-      <div class="card-body text-center">
-        <h5 class="card-title">Profile</h5>
-        <p class="card-text">View your admin profile.</p>
-        <a class="btn btn-primary" href="/admin/profile">View Profile</a>
-      </div>
-    </div>
+  <div class="card">
+    <h3>Users</h3>
+    <p>Manage platform users.</p>
+    <a class="btn btn--primary" href="/admin/users">Manage Users</a>
+  </div>
+  <div class="card">
+    <h3>Profile</h3>
+    <p>View your admin profile.</p>
+    <a class="btn btn--primary" href="/admin/profile">View Profile</a>
   </div>
 </div>
 {% endblock %}
+

--- a/templates/bar_admin_dashboard.html
+++ b/templates/bar_admin_dashboard.html
@@ -1,12 +1,24 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1 class="mb-4">Bar Admin Dashboard</h1>
+<h1>Bar Admin Dashboard</h1>
+<div class="dashboard-info">
+  <div class="card">
+    <h2>{{ user.username }}</h2>
+    <p>{{ user.email }}</p>
+    <p>{{ user.prefix }} {{ user.phone }}</p>
+  </div>
+</div>
 {% if bar %}
-<p>Managing {{ bar.name }}</p>
-<a class="btn btn-primary" href="/admin/bars/edit/{{ bar.id }}">Edit Bar</a>
-<a class="btn btn-secondary" href="/admin/bars/{{ bar.id }}/add_user">Add Staff</a>
-<a class="btn btn-success" href="/bar/{{ bar.id }}/categories/new">Add Category</a>
+<div class="dashboard-actions">
+  <div class="card">
+    <h3>{{ bar.name }}</h3>
+    <a class="btn btn--primary" href="/admin/bars/edit/{{ bar.id }}">Edit Bar</a>
+    <a class="btn" href="/admin/bars/{{ bar.id }}/add_user">Add Staff</a>
+    <a class="btn" href="/bar/{{ bar.id }}/categories/new">Add Category</a>
+  </div>
+</div>
 {% else %}
 <p>No bar assigned.</p>
 {% endif %}
 {% endblock %}
+

--- a/templates/bartender_dashboard.html
+++ b/templates/bartender_dashboard.html
@@ -1,9 +1,21 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1 class="mb-4">Bartender Dashboard</h1>
+<h1>Bartender Dashboard</h1>
+<div class="dashboard-info">
+  <div class="card">
+    <h2>{{ user.username }}</h2>
+    <p>{{ user.email }}</p>
+    <p>{{ user.prefix }} {{ user.phone }}</p>
+  </div>
+</div>
 {% if bar %}
-<p>Working at {{ bar.name }}</p>
+<div class="dashboard-actions">
+  <div class="card">
+    <h3>Working at {{ bar.name }}</h3>
+  </div>
+</div>
 {% else %}
 <p>No bar assigned.</p>
 {% endif %}
 {% endblock %}
+

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,16 +1,17 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1 class="mb-4">Login</h1>
-{% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
-<form method="get" action="/login" class="mx-auto" style="max-width:320px;">
-  <div class="mb-3">
-    <label class="form-label">Email</label>
-    <input class="form-control" type="email" name="email">
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Password</label>
-    <input class="form-control" type="password" name="password">
-  </div>
-  <button class="btn btn-primary" type="submit">Login</button>
-</form>
+<div class="auth-card">
+  <h1>Login</h1>
+  {% if error %}<p class="alert">{{ error }}</p>{% endif %}
+  <form method="get" action="/login">
+    <label>Email
+      <input type="email" name="email" required>
+    </label>
+    <label>Password
+      <input type="password" name="password" required>
+    </label>
+    <button class="btn btn--primary" type="submit">Login</button>
+  </form>
+</div>
 {% endblock %}
+

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,32 +1,30 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1 class="mb-4">Register</h1>
-{% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
-<form method="get" action="/register" class="mx-auto" style="max-width:320px;">
-  <div class="mb-3">
-    <label class="form-label">Username</label>
-    <input class="form-control" type="text" name="username">
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Email</label>
-    <input class="form-control" type="email" name="email">
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Password</label>
-    <input class="form-control" type="password" name="password">
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Phone Prefix</label>
-    <select class="form-control" name="prefix">
-      <option value="+41">+41 (Switzerland)</option>
-      <option value="+1">+1 (USA)</option>
-      <option value="+44">+44 (UK)</option>
-    </select>
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Phone Number</label>
-    <input class="form-control" type="text" name="phone">
-  </div>
-  <button class="btn btn-primary" type="submit">Register</button>
-</form>
+<div class="auth-card">
+  <h1>Register</h1>
+  {% if error %}<p class="alert">{{ error }}</p>{% endif %}
+  <form method="get" action="/register">
+    <label>Username
+      <input type="text" name="username" required>
+    </label>
+    <label>Email
+      <input type="email" name="email" required>
+    </label>
+    <label>Password
+      <input type="password" name="password" required>
+    </label>
+    <label>Phone Prefix
+      <select name="prefix">
+        <option value="+41">+41 (Switzerland)</option>
+        <option value="+1">+1 (USA)</option>
+        <option value="+44">+44 (UK)</option>
+      </select>
+    </label>
+    <label>Phone Number
+      <input type="text" name="phone">
+    </label>
+    <button class="btn btn--primary" type="submit">Register</button>
+  </form>
+</div>
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- display username, email, and phone on all dashboards
- refresh login and registration pages with card-based layout
- add phone/prefix to seed users and supporting styles

## Testing
- `python -m py_compile main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5e8ed81b8832097dfa6afe5e7e0cf