### PR TITLE
feat: show user info on admin pages

### DIFF
--- a/templates/admin_bars.html
+++ b/templates/admin_bars.html
@@ -1,6 +1,13 @@
 {% extends "layout.html" %}
 {% block content %}
 <h1 class="mb-4">Manage Bars</h1>
+<div class="dashboard-info">
+  <div class="card">
+    <h2>{{ user.username }}</h2>
+    <p>{{ user.email }}</p>
+    <p>{{ user.prefix }} {{ user.phone }}</p>
+  </div>
+</div>
 <a class="btn btn-success mb-3" href="/admin/bars/new">Add Bar</a>
 <table class="table">
   <thead>

--- a/templates/admin_profile.html
+++ b/templates/admin_profile.html
@@ -4,6 +4,8 @@
 <div class="card">
   <div class="card-body">
     <p class="mb-0"><strong>Username:</strong> {{ user.username }}</p>
+    <p class="mb-0"><strong>Email:</strong> {{ user.email }}</p>
+    <p class="mb-0"><strong>Phone:</strong> {{ user.prefix }} {{ user.phone }}</p>
   </div>
 </div>
 {% endblock %}

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -1,14 +1,23 @@
 {% extends "layout.html" %}
 {% block content %}
 <h1 class="mb-4">Manage Users</h1>
+<div class="dashboard-info">
+  <div class="card">
+    <h2>{{ user.username }}</h2>
+    <p>{{ user.email }}</p>
+    <p>{{ user.prefix }} {{ user.phone }}</p>
+  </div>
+</div>
 <table class="table">
   <thead>
-    <tr><th>Username</th><th>Role</th><th>Bar</th><th></th></tr>
+    <tr><th>Username</th><th>Email</th><th>Phone</th><th>Role</th><th>Bar</th><th></th></tr>
   </thead>
   <tbody>
     {% for u in users %}
     <tr>
       <td>{{ u.username }}</td>
+      <td>{{ u.email }}</td>
+      <td>{{ u.prefix }} {{ u.phone }}</td>
       <td>{{ u.role }}</td>
       <td>{% if u.bar_id %}{{ bars[u.bar_id].name }}{% else %}-{% endif %}</td>
       <td><a href="/admin/users/edit/{{ u.id }}">Edit</a></td>


### PR DESCRIPTION
## Summary
- show logged-in admin contact details on bar and user manager pages
- display email and phone columns in user manager table
- add email and phone to admin profile view

## Testing
- `python -m py_compile main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5eb4dc23883208d05b44953c1cb75