### PR TITLE
feat: add dark mode toggle for premium UI

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -13,15 +13,18 @@ document.addEventListener('DOMContentLoaded', function() {
 
   const toggle = document.getElementById('themeToggle');
   if (toggle) {
-    toggle.addEventListener('click', function() {
-      document.body.classList.toggle('dark-mode');
-      const mode = document.body.classList.contains('dark-mode') ? 'dark' : 'light';
+    const applyTheme = (mode) => {
+      document.body.classList.toggle('dark-mode', mode === 'dark');
+      toggle.textContent = mode === 'dark' ? '☀️' : '🌙';
+      toggle.setAttribute('aria-label', mode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode');
+    };
+    toggle.addEventListener('click', () => {
+      const mode = document.body.classList.contains('dark-mode') ? 'light' : 'dark';
+      applyTheme(mode);
       localStorage.setItem('theme', mode);
     });
-    const stored = localStorage.getItem('theme');
-    if (stored === 'dark') {
-      document.body.classList.add('dark-mode');
-    }
+    const stored = localStorage.getItem('theme') || 'light';
+    applyTheme(stored);
   }
 
   const menuToggle = document.getElementById('menuToggle');

--- a/static/style.css
+++ b/static/style.css
@@ -6,7 +6,14 @@
   --font-sans:"Inter", ui-sans-serif, system-ui;
 }
 
-body{background:var(--bg);color:var(--text);font-family:var(--font-sans);}
+*,*::before,*::after{box-sizing:border-box;}
+
+body{background:var(--bg);color:var(--text);font-family:var(--font-sans);transition:background .3s,color .3s;}
+
+body.dark-mode{
+  --bg:#0f172a; --surface:#1e293b; --text:#f8fafc; --muted:#94a3b8;
+  --brand:#38bdf8; --brand-600:#0ea5e9;
+}
 
 .container{max-width:1200px;margin-inline:auto;padding-inline:clamp(var(--space-2),4vw,var(--space-4));}
 
@@ -22,6 +29,7 @@ body{background:var(--bg);color:var(--text);font-family:var(--font-sans);}
 .nav-left,.nav-right{display:flex;align-items:center;gap:var(--space-2);}
 .nav-right{gap:var(--space-3);}
 
+.theme-toggle{background:none;border:0;padding:var(--space-1);cursor:pointer;font-size:1.25rem;color:var(--text);transition:color .2s;}
 .hamburger{display:flex;flex-direction:column;gap:4px;background:none;border:0;padding:var(--space-1);cursor:pointer;}
 .hamburger span{width:24px;height:2px;background:var(--text);}
 

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -21,14 +21,15 @@
         <a class="btn" href="/register">Register</a>
         {% endif %}
       </div>
-      <div class="nav-right">
-        <a class="cart" href="/cart" aria-label="Cart ({% if cart_count %}{{ cart_count }}{% else %}0{% endif %} items)">
-          <span class="badge">{% if cart_count %}{{ cart_count }}{% else %}0{% endif %}</span>
-        </a>
-        <button id="menuToggle" class="hamburger" aria-label="Menu" aria-expanded="false">
-          <span></span><span></span><span></span>
-        </button>
-      </div>
+        <div class="nav-right">
+          <a class="cart" href="/cart" aria-label="Cart ({% if cart_count %}{{ cart_count }}{% else %}0{% endif %} items)">
+            <span class="badge">{% if cart_count %}{{ cart_count }}{% else %}0{% endif %}</span>
+          </a>
+          <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">🌙</button>
+          <button id="menuToggle" class="hamburger" aria-label="Menu" aria-expanded="false">
+            <span></span><span></span><span></span>
+          </button>
+        </div>
     </nav>
     <div id="mobileMenu" class="menu" hidden>
       <a href="#bars">Browse Bars</a>


### PR DESCRIPTION
## Summary
- add theme toggle in header and persist choice
- introduce dark mode palette and transitions for smoother UI

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a5ee732b5083208207b8761b29b252