### PR TITLE
feat: add dark mode toggle for premium UI

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -13,15 +13,18 @@ document.addEventListener('DOMContentLoaded', function() {
 
   const toggle = document.getElementById('themeToggle');
   if (toggle) {
-    toggle.addEventListener('click', function() {
-      document.body.classList.toggle('dark-mode');
-      const mode = document.body.classList.contains('dark-mode') ? 'dark' : 'light';
+    const applyTheme = (mode) => {
+      document.body.classList.toggle('dark-mode', mode === 'dark');
+      toggle.textContent = mode === 'dark' ? '☀️' : '🌙';
+      toggle.setAttribute('aria-label', mode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode');
+    };
+    toggle.addEventListener('click', () => {
+      const mode = document.body.classList.contains('dark-mode') ? 'light' : 'dark';
+      applyTheme(mode);
       localStorage.setItem('theme', mode);
     });
-    const stored = localStorage.getItem('theme');
-    if (stored === 'dark') {
-      document.body.classList.add('dark-mode');
-    }
+    const stored = localStorage.getItem('theme') || 'light';
+    applyTheme(stored);
   }
 
   const menuToggle = document.getElementById('menuToggle');

--- a/static/style.css
+++ b/static/style.css
@@ -6,7 +6,14 @@
   --font-sans:"Inter", ui-sans-serif, system-ui;
 }
 
-body{background:var(--bg);color:var(--text);font-family:var(--font-sans);}
+*,*::before,*::after{box-sizing:border-box;}
+
+body{background:var(--bg);color:var(--text);font-family:var(--font-sans);transition:background .3s,color .3s;}
+
+body.dark-mode{
+  --bg:#0f172a; --surface:#1e293b; --text:#f8fafc; --muted:#94a3b8;
+  --brand:#38bdf8; --brand-600:#0ea5e9;
+}
 
 .container{max-width:1200px;margin-inline:auto;padding-inline:clamp(var(--space-2),4vw,var(--space-4));}
 
@@ -22,6 +29,7 @@ body{background:var(--bg);color:var(--text);font-family:var(--font-sans);}
 .nav-left,.nav-right{display:flex;align-items:center;gap:var(--space-2);}
 .nav-right{gap:var(--space-3);}
 
+.theme-toggle{background:none;border:0;padding:var(--space-1);cursor:pointer;font-size:1.25rem;color:var(--text);transition:color .2s;}
 .hamburger{display:flex;flex-direction:column;gap:4px;background:none;border:0;padding:var(--space-1);cursor:pointer;}
 .hamburger span{width:24px;height:2px;background:var(--text);}
 
@@ -78,4 +86,36 @@ body{background:var(--bg);color:var(--text);font-family:var(--font-sans);}
 .dashboard-actions{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:var(--space-3);}
 .dashboard-actions .card{padding:var(--space-3);text-align:center;gap:var(--space-2);}
 .dashboard-actions .card h3{margin-top:0;}
+
+/* generic form styles */
+.form{max-width:400px;margin:var(--space-4) auto;display:flex;flex-direction:column;gap:var(--space-2);}
+.form label{display:flex;flex-direction:column;font-weight:600;gap:var(--space-1);}
+.form input,.form select{padding:var(--space-2);border:1px solid #d1d5db;border-radius:var(--radius);}
+.form .btn{align-self:center;margin-top:var(--space-1);}
+.form--inline{flex-direction:row;align-items:center;gap:var(--space-1);max-width:none;margin:0;}
+.form--inline input{width:4rem;}
+.form--inline .btn{margin-top:0;}
+
+/* table styles */
+.table{width:100%;border-collapse:collapse;margin:var(--space-3) 0;}
+.table th,.table td{padding:var(--space-2);text-align:left;border-bottom:1px solid #e5e7eb;}
+.table th{background:var(--surface);}
+
+/* button variants */
+.btn--secondary{background:var(--surface);color:var(--text);border-color:#d1d5db;}
+.btn--secondary:hover{background:#e5e7eb;}
+.btn--danger{background:#dc2626;color:#fff;}
+.btn--danger:hover{background:#b91c1c;}
+.btn--success{background:#16a34a;color:#fff;}
+.btn--success:hover{background:#15803d;}
+.btn--small{padding:.5rem .75rem;font-size:.875rem;}
+
+/* product grid */
+.products{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:var(--space-3);list-style:none;padding:0;}
+
+/* utilities */
+.alert{padding:var(--space-2);border-radius:var(--radius);margin-bottom:var(--space-3);}
+.alert-danger{background:#fee2e2;color:#991b1b;}
+.alert-success{background:#d1fae5;color:#065f46;}
+.text-center{text-align:center;}
 

--- a/templates/admin_add_user_to_bar.html
+++ b/templates/admin_add_user_to_bar.html
@@ -1,28 +1,24 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1 class="mb-4">Add User to {{ bar.name }}</h1>
+<h1>Add User to {{ bar.name }}</h1>
 {% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
 {% if message %}<div class="alert alert-success">{{ message }}</div>{% endif %}
-<form method="get">
-  <div class="mb-3">
-    <label class="form-label">Username</label>
-    <input class="form-control" name="username">
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Email</label>
-    <input class="form-control" name="email">
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Password</label>
-    <input class="form-control" name="password" type="password">
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Role</label>
-    <select class="form-control" name="role">
+<form class="form" method="get">
+  <label for="username">Username
+    <input id="username" name="username">
+  </label>
+  <label for="email">Email
+    <input id="email" name="email">
+  </label>
+  <label for="password">Password
+    <input id="password" name="password" type="password">
+  </label>
+  <label for="role">Role
+    <select id="role" name="role">
       <option value="bar_admin">Bar Admin</option>
       <option value="bartender">Bartender</option>
     </select>
-  </div>
-  <button type="submit" class="btn btn-primary">Submit</button>
+  </label>
+  <button class="btn btn--primary" type="submit">Submit</button>
 </form>
 {% endblock %}

--- a/templates/admin_bars.html
+++ b/templates/admin_bars.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1 class="mb-4">Manage Bars</h1>
+<h1>Manage Bars</h1>
 <div class="dashboard-info">
   <div class="card">
     <h2>{{ user.username }}</h2>
@@ -8,7 +8,7 @@
     <p>{{ user.prefix }} {{ user.phone }}</p>
   </div>
 </div>
-<a class="btn btn-success mb-3" href="/admin/bars/new">Add Bar</a>
+<a class="btn btn--success" href="/admin/bars/new">Add Bar</a>
 <table class="table">
   <thead>
     <tr><th>Name</th><th>Address</th><th>Actions</th></tr>

--- a/templates/admin_edit_bar.html
+++ b/templates/admin_edit_bar.html
@@ -1,23 +1,19 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1 class="mb-4">Edit Bar</h1>
-<form method="get">
-  <div class="mb-3">
-    <label class="form-label">Name</label>
-    <input class="form-control" name="name" value="{{ bar.name }}">
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Address</label>
-    <input class="form-control" name="address" value="{{ bar.address }}">
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Latitude</label>
-    <input class="form-control" name="latitude" value="{{ bar.latitude }}">
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Longitude</label>
-    <input class="form-control" name="longitude" value="{{ bar.longitude }}">
-  </div>
-  <button type="submit" class="btn btn-primary">Save</button>
+<h1>Edit Bar</h1>
+<form class="form" method="get">
+  <label for="name">Name
+    <input id="name" name="name" value="{{ bar.name }}">
+  </label>
+  <label for="address">Address
+    <input id="address" name="address" value="{{ bar.address }}">
+  </label>
+  <label for="latitude">Latitude
+    <input id="latitude" name="latitude" value="{{ bar.latitude }}">
+  </label>
+  <label for="longitude">Longitude
+    <input id="longitude" name="longitude" value="{{ bar.longitude }}">
+  </label>
+  <button class="btn btn--primary" type="submit">Save</button>
 </form>
 {% endblock %}

--- a/templates/admin_edit_user.html
+++ b/templates/admin_edit_user.html
@@ -1,34 +1,30 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1 class="mb-4">Edit User {{ user.username }}</h1>
+<h1>Edit User {{ user.username }}</h1>
 {% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
-<form method="get">
-  <div class="mb-3">
-    <label class="form-label">Username</label>
-    <input class="form-control" name="username" value="{{ user.username }}">
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Password</label>
-    <input class="form-control" name="password" value="{{ user.password }}">
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Role</label>
-    <select class="form-control" name="role">
+<form class="form" method="get">
+  <label for="username">Username
+    <input id="username" name="username" value="{{ user.username }}">
+  </label>
+  <label for="password">Password
+    <input id="password" name="password" value="{{ user.password }}">
+  </label>
+  <label for="role">Role
+    <select id="role" name="role">
       <option value="super_admin" {% if user.role=='super_admin' %}selected{% endif %}>Super Admin</option>
       <option value="bar_admin" {% if user.role=='bar_admin' %}selected{% endif %}>Bar Admin</option>
       <option value="bartender" {% if user.role=='bartender' %}selected{% endif %}>Bartender</option>
       <option value="customer" {% if user.role=='customer' %}selected{% endif %}>Customer</option>
     </select>
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Bar</label>
-    <select class="form-control" name="bar_id">
+  </label>
+  <label for="bar_id">Bar
+    <select id="bar_id" name="bar_id">
       <option value="" {% if not user.bar_id %}selected{% endif %}>None</option>
       {% for b in bars %}
       <option value="{{ b.id }}" {% if user.bar_id==b.id %}selected{% endif %}>{{ b.name }}</option>
       {% endfor %}
     </select>
-  </div>
-  <button type="submit" class="btn btn-primary">Save</button>
+  </label>
+  <button class="btn btn--primary" type="submit">Save</button>
 </form>
 {% endblock %}

--- a/templates/admin_new_bar.html
+++ b/templates/admin_new_bar.html
@@ -1,23 +1,19 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1 class="mb-4">Create New Bar</h1>
-<form method="get" action="/admin/bars/new" class="mx-auto" style="max-width:400px;">
-  <div class="mb-3">
-    <label class="form-label" for="name">Name</label>
-    <input class="form-control" type="text" id="name" name="name" required>
-  </div>
-  <div class="mb-3">
-    <label class="form-label" for="address">Address</label>
-    <input class="form-control" type="text" id="address" name="address" required>
-  </div>
-  <div class="mb-3">
-    <label class="form-label" for="latitude">Latitude</label>
-    <input class="form-control" type="number" step="0.0001" id="latitude" name="latitude" required>
-  </div>
-  <div class="mb-3">
-    <label class="form-label" for="longitude">Longitude</label>
-    <input class="form-control" type="number" step="0.0001" id="longitude" name="longitude" required>
-  </div>
-  <button class="btn btn-primary" type="submit">Create Bar</button>
+<h1>Create New Bar</h1>
+<form class="form" method="get" action="/admin/bars/new">
+  <label for="name">Name
+    <input id="name" type="text" name="name" required>
+  </label>
+  <label for="address">Address
+    <input id="address" type="text" name="address" required>
+  </label>
+  <label for="latitude">Latitude
+    <input id="latitude" type="number" step="0.0001" name="latitude" required>
+  </label>
+  <label for="longitude">Longitude
+    <input id="longitude" type="number" step="0.0001" name="longitude" required>
+  </label>
+  <button class="btn btn--primary" type="submit">Create Bar</button>
 </form>
 {% endblock %}

--- a/templates/admin_profile.html
+++ b/templates/admin_profile.html
@@ -1,11 +1,11 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1 class="mb-4">Profile</h1>
+<h1>Profile</h1>
 <div class="card">
-  <div class="card-body">
-    <p class="mb-0"><strong>Username:</strong> {{ user.username }}</p>
-    <p class="mb-0"><strong>Email:</strong> {{ user.email }}</p>
-    <p class="mb-0"><strong>Phone:</strong> {{ user.prefix }} {{ user.phone }}</p>
+  <div class="card__body">
+    <p><strong>Username:</strong> {{ user.username }}</p>
+    <p><strong>Email:</strong> {{ user.email }}</p>
+    <p><strong>Phone:</strong> {{ user.prefix }} {{ user.phone }}</p>
   </div>
 </div>
 {% endblock %}

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1 class="mb-4">Manage Users</h1>
+<h1>Manage Users</h1>
 <div class="dashboard-info">
   <div class="card">
     <h2>{{ user.username }}</h2>

--- a/templates/bar_detail.html
+++ b/templates/bar_detail.html
@@ -1,30 +1,32 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1 class="mb-3">{{ bar.name }}</h1>
-<p class="mb-4">{{ bar.address }}</p>
+<h1>{{ bar.name }}</h1>
+<p>{{ bar.address }}</p>
 {% for category, products in products_by_category.items() %}
-  <h2 class="mt-4">{{ category.name }}</h2>
-  <p>{{ category.description }}</p>
-  <div class="row">
-    {% for product in products %}
-    <div class="col-md-4 mb-3">
-      <div class="card h-100">
-        <div class="card-body">
-          <h5 class="card-title">{{ product.name }}</h5>
-          <p class="card-text">{{ product.description }}</p>
-          <p class="fw-bold">CHF {{ product.price }}</p>
-          {% if user %}
-          <form method="get" action="/bars/{{ bar.id }}/add_to_cart">
-            <input type="hidden" name="product_id" value="{{ product.id }}">
-            <button class="btn btn-primary" type="submit">Add to Cart</button>
-          </form>
-          {% else %}
-          <a class="btn btn-secondary" href="/login">Login to order</a>
-          {% endif %}
-        </div>
-      </div>
-    </div>
-    {% endfor %}
-  </div>
+  <section class="category">
+    <h2>{{ category.name }}</h2>
+    <p>{{ category.description }}</p>
+    <ul class="products">
+      {% for product in products %}
+      <li>
+        <article class="card">
+          <div class="card__body">
+            <h3 class="card__title">{{ product.name }}</h3>
+            <p>{{ product.description }}</p>
+            <p><strong>CHF {{ product.price }}</strong></p>
+            {% if user %}
+            <form class="form form--inline" method="get" action="/bars/{{ bar.id }}/add_to_cart">
+              <input type="hidden" name="product_id" value="{{ product.id }}">
+              <button class="btn btn--primary btn--small" type="submit">Add to Cart</button>
+            </form>
+            {% else %}
+            <a class="btn" href="/login">Login to order</a>
+            {% endif %}
+          </div>
+        </article>
+      </li>
+      {% endfor %}
+    </ul>
+  </section>
 {% endfor %}
 {% endblock %}

--- a/templates/bar_new_category.html
+++ b/templates/bar_new_category.html
@@ -1,15 +1,13 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1 class="mb-4">Add Category for {{ bar.name }}</h1>
-<form method="get">
-  <div class="mb-3">
-    <label class="form-label">Name</label>
-    <input class="form-control" name="name">
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Description</label>
-    <input class="form-control" name="description">
-  </div>
-  <button type="submit" class="btn btn-primary">Create</button>
+<h1>Add Category for {{ bar.name }}</h1>
+<form class="form" method="get">
+  <label for="name">Name
+    <input id="name" name="name">
+  </label>
+  <label for="description">Description
+    <input id="description" name="description">
+  </label>
+  <button class="btn btn--primary" type="submit">Create</button>
 </form>
 {% endblock %}

--- a/templates/bartender_confirm.html
+++ b/templates/bartender_confirm.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1 class="mb-4">Bartender Registration</h1>
+<h1>Bartender Registration</h1>
 <p>You are now registered as a bartender for {{ bar.name }}.</p>
-<a class="btn btn-primary" href="/dashboard">Go to Dashboard</a>
+<a class="btn btn--primary" href="/dashboard">Go to Dashboard</a>
 {% endblock %}

--- a/templates/cart.html
+++ b/templates/cart.html
@@ -1,52 +1,50 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1 class="mb-4">Your Cart</h1>
+<h1>Your Cart</h1>
 {% if cart.items %}
 <table class="table">
   <thead>
-    <tr><th>Item</th><th style="width:120px;">Quantity</th><th>Price</th><th>Total</th><th>Actions</th></tr>
+    <tr><th>Item</th><th>Quantity</th><th>Price</th><th>Total</th><th>Actions</th></tr>
   </thead>
   <tbody>
     {% for item in cart.items.values() %}
     <tr>
       <td>{{ item.product.name }}</td>
       <td>
-        <form class="d-flex" method="get" action="/cart/update">
+        <form class="form form--inline" method="get" action="/cart/update">
           <input type="hidden" name="product_id" value="{{ item.product.id }}">
-          <input class="form-control me-2" type="number" name="quantity" min="0" value="{{ item.quantity }}">
-          <button class="btn btn-sm btn-primary" type="submit">Update</button>
+          <input type="number" name="quantity" min="0" value="{{ item.quantity }}">
+          <button class="btn btn--small btn--primary" type="submit">Update</button>
         </form>
       </td>
       <td>CHF {{ "%.2f"|format(item.product.price) }}</td>
       <td>CHF {{ "%.2f"|format(item.total) }}</td>
       <td>
-        <form method="get" action="/cart/update">
+        <form method="get" action="/cart/update" class="form form--inline">
           <input type="hidden" name="product_id" value="{{ item.product.id }}">
           <input type="hidden" name="quantity" value="0">
-          <button class="btn btn-sm btn-danger" type="submit">Remove</button>
+          <button class="btn btn--small btn--danger" type="submit">Remove</button>
         </form>
       </td>
     </tr>
     {% endfor %}
   </tbody>
 </table>
-<p class="fw-bold">Total: CHF {{ "%.2f"|format(cart.total_price()) }}</p>
-<h2 class="mt-4">Select Table</h2>
-<form class="row g-3 align-items-center" method="get" action="/cart/select_table">
-  <div class="col-auto">
-    <select class="form-select" name="table_id">
+<p><strong>Total: CHF {{ "%.2f"|format(cart.total_price()) }}</strong></p>
+<h2>Select Table</h2>
+<form class="form" method="get" action="/cart/select_table">
+  <label for="table_id">Table
+    <select id="table_id" name="table_id">
       {% for table in bar.tables.values() %}
         <option value="{{ table.id }}" {% if cart.table_id == table.id %}selected{% endif %}>{{ table.name }}</option>
       {% endfor %}
     </select>
-  </div>
-  <div class="col-auto">
-    <button class="btn btn-secondary" type="submit">Confirm</button>
-  </div>
+  </label>
+  <button class="btn" type="submit">Confirm</button>
 </form>
-<h2 class="mt-4">Checkout</h2>
+<h2>Checkout</h2>
 <form method="get" action="/cart/checkout">
-  <button class="btn btn-success" type="submit">Place Order</button>
+  <button class="btn btn--success" type="submit">Place Order</button>
 </form>
 {% else %}
 <p>Your cart is empty.</p>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -21,14 +21,15 @@
         <a class="btn" href="/register">Register</a>
         {% endif %}
       </div>
-      <div class="nav-right">
-        <a class="cart" href="/cart" aria-label="Cart ({% if cart_count %}{{ cart_count }}{% else %}0{% endif %} items)">
-          <span class="badge">{% if cart_count %}{{ cart_count }}{% else %}0{% endif %}</span>
-        </a>
-        <button id="menuToggle" class="hamburger" aria-label="Menu" aria-expanded="false">
-          <span></span><span></span><span></span>
-        </button>
-      </div>
+        <div class="nav-right">
+          <a class="cart" href="/cart" aria-label="Cart ({% if cart_count %}{{ cart_count }}{% else %}0{% endif %} items)">
+            <span class="badge">{% if cart_count %}{{ cart_count }}{% else %}0{% endif %}</span>
+          </a>
+          <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">🌙</button>
+          <button id="menuToggle" class="hamburger" aria-label="Menu" aria-expanded="false">
+            <span></span><span></span><span></span>
+          </button>
+        </div>
     </nav>
     <div id="mobileMenu" class="menu" hidden>
       <a href="#bars">Browse Bars</a>

--- a/templates/login.html
+++ b/templates/login.html
@@ -4,11 +4,11 @@
   <h1>Login</h1>
   {% if error %}<p class="alert">{{ error }}</p>{% endif %}
   <form method="get" action="/login">
-    <label>Email
-      <input type="email" name="email" required>
+    <label for="email">Email
+      <input id="email" type="email" name="email" required autocomplete="email">
     </label>
-    <label>Password
-      <input type="password" name="password" required>
+    <label for="password">Password
+      <input id="password" type="password" name="password" required autocomplete="current-password">
     </label>
     <button class="btn btn--primary" type="submit">Login</button>
   </form>

--- a/templates/order_success.html
+++ b/templates/order_success.html
@@ -1,10 +1,10 @@
 {% extends "layout.html" %}
 {% block content %}
 <div class="text-center">
-  <h1 class="mb-3">Order Placed</h1>
+  <h1>Order Placed</h1>
   <p>Your order has been placed successfully!</p>
   <p>Total paid: CHF {{ "%.2f"|format(total) }}</p>
   <p>Thank you for ordering with SiplyGo.</p>
-  <a class="btn btn-primary" href="/">Return to home</a>
+  <a class="btn btn--primary" href="/">Return to home</a>
 </div>
 {% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -4,24 +4,24 @@
   <h1>Register</h1>
   {% if error %}<p class="alert">{{ error }}</p>{% endif %}
   <form method="get" action="/register">
-    <label>Username
-      <input type="text" name="username" required>
+    <label for="username">Username
+      <input id="username" type="text" name="username" required autocomplete="username">
     </label>
-    <label>Email
-      <input type="email" name="email" required>
+    <label for="email">Email
+      <input id="email" type="email" name="email" required autocomplete="email">
     </label>
-    <label>Password
-      <input type="password" name="password" required>
+    <label for="password">Password
+      <input id="password" type="password" name="password" required autocomplete="new-password">
     </label>
-    <label>Phone Prefix
-      <select name="prefix">
+    <label for="prefix">Phone Prefix
+      <select id="prefix" name="prefix">
         <option value="+41">+41 (Switzerland)</option>
         <option value="+1">+1 (USA)</option>
         <option value="+44">+44 (UK)</option>
       </select>
     </label>
-    <label>Phone Number
-      <input type="text" name="phone">
+    <label for="phone">Phone Number
+      <input id="phone" type="text" name="phone" autocomplete="tel">
     </label>
     <button class="btn btn--primary" type="submit">Register</button>
   </form>


### PR DESCRIPTION
## Summary
- add theme toggle in header and persist choice
- introduce dark mode palette and transitions for smoother UI
- standardize templates with new form, table, and button styles for premium look across pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a5ee732b5083208207b8761b29b252