### PR TITLE
Simplify bar forms by removing map and hiding coordinates

### DIFF
--- a/templates/admin_edit_bar.html
+++ b/templates/admin_edit_bar.html
@@ -17,48 +17,23 @@
   <label for="state">State
     <input id="state" name="state" value="{{ bar.state }}">
   </label>
-  <label for="latitude">Latitude
-    <input id="latitude" name="latitude" value="{{ bar.latitude }}">
-  </label>
-  <label for="longitude">Longitude
-    <input id="longitude" name="longitude" value="{{ bar.longitude }}">
-  </label>
+  <input id="latitude" name="latitude" type="hidden" value="{{ bar.latitude }}">
+  <input id="longitude" name="longitude" type="hidden" value="{{ bar.longitude }}">
   <button class="btn btn--primary" type="submit">Save</button>
 </form>
-<div id="map" style="height:300px;margin-top:1rem;"></div>
 <script>
-  let map, marker, autocomplete;
-  function initMap() {
-    const latField = document.getElementById('latitude');
-    const lngField = document.getElementById('longitude');
-    const lat = parseFloat(latField.value) || 0;
-    const lng = parseFloat(lngField.value) || 0;
-    map = new google.maps.Map(document.getElementById('map'), {
-      center: {lat, lng},
-      zoom: 15,
-    });
-    marker = new google.maps.Marker({position: {lat, lng}, map: map, draggable: true});
-    marker.addListener('dragend', () => {
-      const pos = marker.getPosition();
-      latField.value = pos.lat().toFixed(6);
-      lngField.value = pos.lng().toFixed(6);
-    });
-    map.addListener('click', (e) => {
-      marker.setPosition(e.latLng);
-      latField.value = e.latLng.lat().toFixed(6);
-      lngField.value = e.latLng.lng().toFixed(6);
-    });
+  let autocomplete;
+  function initAutocomplete() {
     const input = document.getElementById('placeSearch');
+    if (!input) return;
     autocomplete = new google.maps.places.Autocomplete(input, {types:['establishment']});
     autocomplete.addListener('place_changed', () => {
       const place = autocomplete.getPlace();
       if (!place.geometry) return;
-      map.setCenter(place.geometry.location);
-      marker.setPosition(place.geometry.location);
-      latField.value = place.geometry.location.lat().toFixed(6);
-      lngField.value = place.geometry.location.lng().toFixed(6);
       document.getElementById('name').value = place.name || '';
       document.getElementById('address').value = place.formatted_address || '';
+      document.getElementById('latitude').value = place.geometry.location.lat().toFixed(6);
+      document.getElementById('longitude').value = place.geometry.location.lng().toFixed(6);
       let city = '', state = '';
       if (place.address_components) {
         for (const comp of place.address_components) {
@@ -71,6 +46,6 @@
     });
   }
 </script>
-<script async defer src="https://maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}&libraries=places&callback=initMap"></script>
+<script async defer src="https://maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}&libraries=places&callback=initAutocomplete"></script>
 {% endblock %}
 

--- a/templates/admin_new_bar.html
+++ b/templates/admin_new_bar.html
@@ -17,12 +17,8 @@
   <label for="state">State
     <input id="state" type="text" name="state" required>
   </label>
-  <label for="latitude">Latitude
-    <input id="latitude" type="number" step="0.0001" name="latitude" required>
-  </label>
-  <label for="longitude">Longitude
-    <input id="longitude" type="number" step="0.0001" name="longitude" required>
-  </label>
+  <input id="latitude" type="hidden" name="latitude" required>
+  <input id="longitude" type="hidden" name="longitude" required>
     <button class="btn btn--primary" type="submit">Create Bar</button>
   </form>
   <script>


### PR DESCRIPTION
## Summary
- remove map from bar edit form and hide latitude/longitude fields
- hide coordinates in new bar form and auto-fill via Google Places Autocomplete

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a60069638483209dc0779ee029045b