### PR TITLE
Fix duplicate Google Maps script on bar edit page

### DIFF
--- a/templates/admin_edit_bar.html
+++ b/templates/admin_edit_bar.html
@@ -46,11 +46,8 @@
     });
   }
 </script>
- codex/fix-edit-bar-visibility-issue-tb83md
 {% if GOOGLE_MAPS_API_KEY %}
 <script async defer src="https://maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}&libraries=places&callback=initAutocomplete"></script>
 {% endif %}
-<script async defer src="https://maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}&libraries=places&callback=initAutocomplete"></script>
- main
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- remove stray text and duplicate Google Maps script tag on bar edit page

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a604a829dc8320ab2ecedf5cb42a62