### PR TITLE
Fix duplicate Google Maps script on bar edit page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy to .env and set your Google Maps API key
+GOOGLE_MAPS_API_KEY=YOUR_API_KEY_HERE

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+__pycache__/
+*.pyc

--- a/main.py
+++ b/main.py
@@ -34,11 +34,15 @@ Limitations:
 from typing import Dict, List, Optional
 
 import os
+from dotenv import load_dotenv
 from fastapi import FastAPI, Request, HTTPException, status
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from starlette.middleware.sessions import SessionMiddleware
+
+# Load environment variables from a .env file if present
+load_dotenv()
 
 # -----------------------------------------------------------------------------
 # Data models (in-memory for demonstration purposes)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 jinja2
 itsdangerous
 starlette
+python-dotenv

--- a/templates/admin_edit_bar.html
+++ b/templates/admin_edit_bar.html
@@ -46,11 +46,8 @@
     });
   }
 </script>
- codex/fix-edit-bar-visibility-issue-tb83md
 {% if GOOGLE_MAPS_API_KEY %}
 <script async defer src="https://maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}&libraries=places&callback=initAutocomplete"></script>
 {% endif %}
-<script async defer src="https://maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}&libraries=places&callback=initAutocomplete"></script>
- main
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- remove stray text and duplicate Google Maps script tag on bar edit page
- load Google Maps API key from `.env` and keep secrets out of version control

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a604a829dc8320ab2ecedf5cb42a62