### PR TITLE
Fix Google Maps autocomplete not using API key

### DIFF
--- a/main.py
+++ b/main.py
@@ -191,7 +191,6 @@ templates_env = Environment(
     loader=FileSystemLoader("templates"),
     autoescape=select_autoescape(["html", "xml"]),
 )
-templates_env.globals["GOOGLE_MAPS_API_KEY"] = os.getenv("GOOGLE_MAPS_API_KEY", "")
 
 # -----------------------------------------------------------------------------
 # In-memory store with sample data
@@ -355,6 +354,8 @@ def render_template(template_name: str, **context) -> HTMLResponse:
         last_bar_id = request.session.get("last_bar_id")
         if last_bar_id is not None:
             context.setdefault("last_bar", bars.get(last_bar_id))
+    # Ensure Google Maps API key is available in all templates
+    context.setdefault("GOOGLE_MAPS_API_KEY", os.getenv("GOOGLE_MAPS_API_KEY", ""))
     template = templates_env.get_template(template_name)
     return HTMLResponse(template.render(**context))
 

--- a/templates/admin_edit_bar.html
+++ b/templates/admin_edit_bar.html
@@ -49,6 +49,7 @@
       document.getElementById('longitude').value = place.geometry.location.lng().toFixed(6);
     });
   }
+  window.initAutocomplete = initAutocomplete;
 </script>
 {% if GOOGLE_MAPS_API_KEY %}
 <script async defer src="https://maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}&libraries=places&callback=initAutocomplete"></script>

--- a/templates/admin_new_bar.html
+++ b/templates/admin_new_bar.html
@@ -49,8 +49,9 @@
       document.getElementById('longitude').value = place.geometry.location.lng().toFixed(6);
     });
   }
-    </script>
-    {% if GOOGLE_MAPS_API_KEY %}
-    <script async defer src="https://maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}&libraries=places&callback=initAutocomplete"></script>
-    {% endif %}
-  {% endblock %}
+  window.initAutocomplete = initAutocomplete;
+  </script>
+  {% if GOOGLE_MAPS_API_KEY %}
+  <script async defer src="https://maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}&libraries=places&callback=initAutocomplete"></script>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- refresh Google Maps API key for templates on each request
- expose Google Autocomplete callback globally so search works in bar forms

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a60dcda08c832088fe208889f3c0b7