### PR TITLE
Fix Google Maps search in bar forms

### DIFF
--- a/main.py
+++ b/main.py
@@ -191,7 +191,6 @@ templates_env = Environment(
     loader=FileSystemLoader("templates"),
     autoescape=select_autoescape(["html", "xml"]),
 )
-templates_env.globals["GOOGLE_MAPS_API_KEY"] = os.getenv("GOOGLE_MAPS_API_KEY", "")
 
 # -----------------------------------------------------------------------------
 # In-memory store with sample data
@@ -355,6 +354,8 @@ def render_template(template_name: str, **context) -> HTMLResponse:
         last_bar_id = request.session.get("last_bar_id")
         if last_bar_id is not None:
             context.setdefault("last_bar", bars.get(last_bar_id))
+    # Ensure Google Maps API key is available in all templates
+    context.setdefault("GOOGLE_MAPS_API_KEY", os.getenv("GOOGLE_MAPS_API_KEY", ""))
     template = templates_env.get_template(template_name)
     return HTMLResponse(template.render(**context))
 

--- a/templates/admin_edit_bar.html
+++ b/templates/admin_edit_bar.html
@@ -26,6 +26,11 @@
   function initAutocomplete() {
     const input = document.getElementById('placeSearch');
     if (!input) return;
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+      }
+    });
     autocomplete = new google.maps.places.Autocomplete(input, { types: ['establishment'] });
     autocomplete.addListener('place_changed', () => {
       const place = autocomplete.getPlace();
@@ -49,9 +54,14 @@
       document.getElementById('longitude').value = place.geometry.location.lng().toFixed(6);
     });
   }
+  window.initAutocomplete = initAutocomplete;
 </script>
 {% if GOOGLE_MAPS_API_KEY %}
-<script async defer src="https://maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}&libraries=places&callback=initAutocomplete"></script>
+<script
+    async
+    defer
+    src="https://maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}&libraries=places&callback=initAutocomplete">
+</script>
 {% endif %}
 {% endblock %}
 

--- a/templates/admin_new_bar.html
+++ b/templates/admin_new_bar.html
@@ -26,6 +26,11 @@
   function initAutocomplete() {
     const input = document.getElementById('placeSearch');
     if (!input) return;
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+      }
+    });
     autocomplete = new google.maps.places.Autocomplete(input, { types: ['establishment'] });
     autocomplete.addListener('place_changed', () => {
       const place = autocomplete.getPlace();
@@ -49,8 +54,13 @@
       document.getElementById('longitude').value = place.geometry.location.lng().toFixed(6);
     });
   }
-    </script>
-    {% if GOOGLE_MAPS_API_KEY %}
-    <script async defer src="https://maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}&libraries=places&callback=initAutocomplete"></script>
-    {% endif %}
-  {% endblock %}
+  window.initAutocomplete = initAutocomplete;
+  </script>
+  {% if GOOGLE_MAPS_API_KEY %}
+  <script
+      async
+      defer
+      src="https://maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}&libraries=places&callback=initAutocomplete">
+  </script>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- prevent form submission when pressing Enter in Google Maps search inputs
- load Google Maps script with API key and callback in bar forms

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a60dcda08c832088fe208889f3c0b7