### PR TITLE
Fix Google Maps integration and set API key

### DIFF
--- a/main.py
+++ b/main.py
@@ -354,13 +354,14 @@ def render_template(template_name: str, **context) -> HTMLResponse:
         last_bar_id = request.session.get("last_bar_id")
         if last_bar_id is not None:
             context.setdefault("last_bar", bars.get(last_bar_id))
- codex/fix-google-maps-search-functionality-2j5anw
-    # Ensure Google Maps API key is always provided to templates
-    context["GOOGLE_MAPS_API_KEY"] = os.getenv("GOOGLE_MAPS_API_KEY", "")
 
-    # Ensure Google Maps API key is available in all templates
-    context.setdefault("GOOGLE_MAPS_API_KEY", os.getenv("GOOGLE_MAPS_API_KEY", ""))
-main
+    # Ensure Google Maps API key is available to templates. Allow an
+    # environment variable to override the default key.
+    default_api_key = "AIzaSyCFwtfzGRqUke-OclxMoXfZJFjNE2um23k"
+    context.setdefault(
+        "GOOGLE_MAPS_API_KEY", os.getenv("GOOGLE_MAPS_API_KEY", default_api_key)
+    )
+
     template = templates_env.get_template(template_name)
     return HTMLResponse(template.render(**context))
 

--- a/templates/admin_edit_bar.html
+++ b/templates/admin_edit_bar.html
@@ -1,10 +1,10 @@
 {% extends "layout.html" %}
 {% block content %}
 <h1>Edit Bar</h1>
+<label for="placeSearch">Search Google Maps
+  <input id="placeSearch" type="text" placeholder="Type bar name">
+</label>
 <form class="form" method="get">
-  <label for="placeSearch">Search Google Maps
-    <input id="placeSearch" type="text" placeholder="Type bar name">
-  </label>
   <label for="name">Name
     <input id="name" name="name" value="{{ bar.name }}">
   </label>
@@ -31,14 +31,10 @@
         e.preventDefault();
       }
     });
- codex/fix-google-maps-search-functionality-2j5anw
     autocomplete = new google.maps.places.Autocomplete(input, {
       types: ['establishment'],
       fields: ['address_components', 'geometry', 'name']
     });
-
-    autocomplete = new google.maps.places.Autocomplete(input, { types: ['establishment'] });
- main
     autocomplete.addListener('place_changed', () => {
       const place = autocomplete.getPlace();
       if (!place.geometry) return;

--- a/templates/admin_new_bar.html
+++ b/templates/admin_new_bar.html
@@ -1,10 +1,10 @@
 {% extends "layout.html" %}
 {% block content %}
 <h1>Create New Bar</h1>
+<label for="placeSearch">Search Google Maps
+  <input id="placeSearch" type="text" placeholder="Type bar name">
+</label>
 <form class="form" method="get" action="/admin/bars/new">
-  <label for="placeSearch">Search Google Maps
-    <input id="placeSearch" type="text" placeholder="Type bar name">
-  </label>
   <label for="name">Name
     <input id="name" type="text" name="name" required>
   </label>
@@ -19,9 +19,9 @@
   </label>
   <input id="latitude" type="hidden" name="latitude" required>
   <input id="longitude" type="hidden" name="longitude" required>
-    <button class="btn btn--primary" type="submit">Create Bar</button>
-  </form>
-  <script>
+  <button class="btn btn--primary" type="submit">Create Bar</button>
+</form>
+<script>
   let autocomplete;
   function initAutocomplete() {
     const input = document.getElementById('placeSearch');
@@ -31,13 +31,10 @@
         e.preventDefault();
       }
     });
- codex/fix-google-maps-search-functionality-2j5anw
     autocomplete = new google.maps.places.Autocomplete(input, {
       types: ['establishment'],
       fields: ['address_components', 'geometry', 'name']
     });
-
-    autocomplete = new google.maps.places.Autocomplete(input, { types: ['establishment'] }); main
     autocomplete.addListener('place_changed', () => {
       const place = autocomplete.getPlace();
       if (!place.geometry) return;
@@ -61,22 +58,9 @@
     });
   }
   window.initAutocomplete = initAutocomplete;
-  </script>
-  {% if GOOGLE_MAPS_API_KEY %}
- codex/fix-google-maps-search-functionality-2j5anw
-
- codex/fix-google-maps-search-functionality-nlxvne
- main
-  <script
-      async
-      defer
-      src="https://maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}&libraries=places&callback=initAutocomplete">
-  </script>
- codex/fix-google-maps-search-functionality-2j5anw
-
-
-  <script async defer src="https://maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}&libraries=places&callback=initAutocomplete"></script>
- main
- main
-  {% endif %}
+</script>
+{% if GOOGLE_MAPS_API_KEY %}
+<script async defer src="https://maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}&libraries=places&callback=initAutocomplete"></script>
+{% endif %}
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- remove leftover merge artifacts from bar admin templates
- default Google Maps API key to user-provided key and expose in templates
- keep Google Maps search outside admin forms to prevent accidental submissions

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6186b60108320947e2bf4414d965f