### PR TITLE
Replace Google Maps integration with draggable map

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,7 +33,6 @@ Limitations:
 
 from typing import Dict, List, Optional
 
-import os
 from dotenv import load_dotenv
 from fastapi import FastAPI, Request, HTTPException, status
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -354,13 +353,7 @@ def render_template(template_name: str, **context) -> HTMLResponse:
         last_bar_id = request.session.get("last_bar_id")
         if last_bar_id is not None:
             context.setdefault("last_bar", bars.get(last_bar_id))
- codex/fix-google-maps-search-functionality-2j5anw
-    # Ensure Google Maps API key is always provided to templates
-    context["GOOGLE_MAPS_API_KEY"] = os.getenv("GOOGLE_MAPS_API_KEY", "")
 
-    # Ensure Google Maps API key is available in all templates
-    context.setdefault("GOOGLE_MAPS_API_KEY", os.getenv("GOOGLE_MAPS_API_KEY", ""))
-main
     template = templates_env.get_template(template_name)
     return HTMLResponse(template.render(**context))
 

--- a/templates/admin_edit_bar.html
+++ b/templates/admin_edit_bar.html
@@ -1,10 +1,9 @@
 {% extends "layout.html" %}
 {% block content %}
 <h1>Edit Bar</h1>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
+<div id="map" style="height:400px;"></div>
 <form class="form" method="get">
-  <label for="placeSearch">Search Google Maps
-    <input id="placeSearch" type="text" placeholder="Type bar name">
-  </label>
   <label for="name">Name
     <input id="name" name="name" value="{{ bar.name }}">
   </label>
@@ -21,54 +20,23 @@
   <input id="longitude" name="longitude" type="hidden" value="{{ bar.longitude }}">
   <button class="btn btn--primary" type="submit">Save</button>
 </form>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
-  let autocomplete;
-  function initAutocomplete() {
-    const input = document.getElementById('placeSearch');
-    if (!input) return;
-    input.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter') {
-        e.preventDefault();
-      }
-    });
- codex/fix-google-maps-search-functionality-2j5anw
-    autocomplete = new google.maps.places.Autocomplete(input, {
-      types: ['establishment'],
-      fields: ['address_components', 'geometry', 'name']
-    });
-
-    autocomplete = new google.maps.places.Autocomplete(input, { types: ['establishment'] });
- main
-    autocomplete.addListener('place_changed', () => {
-      const place = autocomplete.getPlace();
-      if (!place.geometry) return;
-      document.getElementById('name').value = place.name || '';
-      // Parse address components so street, city and state are populated separately
-      let street = '', city = '', state = '';
-      if (place.address_components) {
-        for (const comp of place.address_components) {
-          const types = comp.types;
-          if (types.includes('street_number')) street = comp.long_name + (street ? ' ' + street : '');
-          if (types.includes('route')) street = street ? street + ' ' + comp.long_name : comp.long_name;
-          if (types.includes('locality')) city = comp.long_name;
-          if (types.includes('administrative_area_level_1')) state = comp.short_name;
-        }
-      }
-      document.getElementById('address').value = street || place.formatted_address || '';
-      document.getElementById('city').value = city;
-      document.getElementById('state').value = state;
-      document.getElementById('latitude').value = place.geometry.location.lat().toFixed(6);
-      document.getElementById('longitude').value = place.geometry.location.lng().toFixed(6);
-    });
+  const initialLat = {{ bar.latitude }};
+  const initialLng = {{ bar.longitude }};
+  const map = L.map('map').setView([initialLat, initialLng], 13);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 19,
+    attribution: '© OpenStreetMap contributors'
+  }).addTo(map);
+  const marker = L.marker([initialLat, initialLng], {draggable:true}).addTo(map);
+  function updateInputs(e) {
+    const pos = e.target.getLatLng();
+    document.getElementById('latitude').value = pos.lat.toFixed(6);
+    document.getElementById('longitude').value = pos.lng.toFixed(6);
   }
-  window.initAutocomplete = initAutocomplete;
+  marker.on('dragend', updateInputs);
+  updateInputs({target: marker});
 </script>
-{% if GOOGLE_MAPS_API_KEY %}
-<script
-    async
-    defer
-    src="https://maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}&libraries=places&callback=initAutocomplete">
-</script>
-{% endif %}
 {% endblock %}
 

--- a/templates/admin_new_bar.html
+++ b/templates/admin_new_bar.html
@@ -1,10 +1,9 @@
 {% extends "layout.html" %}
 {% block content %}
 <h1>Create New Bar</h1>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
+<div id="map" style="height:400px;"></div>
 <form class="form" method="get" action="/admin/bars/new">
-  <label for="placeSearch">Search Google Maps
-    <input id="placeSearch" type="text" placeholder="Type bar name">
-  </label>
   <label for="name">Name
     <input id="name" type="text" name="name" required>
   </label>
@@ -19,64 +18,25 @@
   </label>
   <input id="latitude" type="hidden" name="latitude" required>
   <input id="longitude" type="hidden" name="longitude" required>
-    <button class="btn btn--primary" type="submit">Create Bar</button>
-  </form>
-  <script>
-  let autocomplete;
-  function initAutocomplete() {
-    const input = document.getElementById('placeSearch');
-    if (!input) return;
-    input.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter') {
-        e.preventDefault();
-      }
-    });
- codex/fix-google-maps-search-functionality-2j5anw
-    autocomplete = new google.maps.places.Autocomplete(input, {
-      types: ['establishment'],
-      fields: ['address_components', 'geometry', 'name']
-    });
-
-    autocomplete = new google.maps.places.Autocomplete(input, { types: ['establishment'] }); main
-    autocomplete.addListener('place_changed', () => {
-      const place = autocomplete.getPlace();
-      if (!place.geometry) return;
-      document.getElementById('name').value = place.name || '';
-      // Extract street, city and state from the selected place
-      let street = '', city = '', state = '';
-      if (place.address_components) {
-        for (const comp of place.address_components) {
-          const types = comp.types;
-          if (types.includes('street_number')) street = comp.long_name + (street ? ' ' + street : '');
-          if (types.includes('route')) street = street ? street + ' ' + comp.long_name : comp.long_name;
-          if (types.includes('locality')) city = comp.long_name;
-          if (types.includes('administrative_area_level_1')) state = comp.short_name;
-        }
-      }
-      document.getElementById('address').value = street || place.formatted_address || '';
-      document.getElementById('city').value = city;
-      document.getElementById('state').value = state;
-      document.getElementById('latitude').value = place.geometry.location.lat().toFixed(6);
-      document.getElementById('longitude').value = place.geometry.location.lng().toFixed(6);
-    });
+  <button class="btn btn--primary" type="submit">Create Bar</button>
+</form>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<script>
+  const initialLat = 45.4642;
+  const initialLng = 9.1900;
+  const map = L.map('map').setView([initialLat, initialLng], 13);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 19,
+    attribution: '© OpenStreetMap contributors'
+  }).addTo(map);
+  const marker = L.marker([initialLat, initialLng], {draggable:true}).addTo(map);
+  function updateInputs(e) {
+    const pos = e.target.getLatLng();
+    document.getElementById('latitude').value = pos.lat.toFixed(6);
+    document.getElementById('longitude').value = pos.lng.toFixed(6);
   }
-  window.initAutocomplete = initAutocomplete;
-  </script>
-  {% if GOOGLE_MAPS_API_KEY %}
- codex/fix-google-maps-search-functionality-2j5anw
-
- codex/fix-google-maps-search-functionality-nlxvne
- main
-  <script
-      async
-      defer
-      src="https://maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}&libraries=places&callback=initAutocomplete">
-  </script>
- codex/fix-google-maps-search-functionality-2j5anw
-
-
-  <script async defer src="https://maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}&libraries=places&callback=initAutocomplete"></script>
- main
- main
-  {% endif %}
+  marker.on('dragend', updateInputs);
+  updateInputs({target: marker});
+</script>
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- remove Google Maps API key usage from templates and server
- add Leaflet-based map with draggable marker for setting bar position
- keep manual entry of bar information

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6186b60108320947e2bf4414d965f