### PR TITLE
Remove hardcoded Google Maps API key

### DIFF
--- a/main.py
+++ b/main.py
@@ -355,12 +355,10 @@ def render_template(template_name: str, **context) -> HTMLResponse:
         if last_bar_id is not None:
             context.setdefault("last_bar", bars.get(last_bar_id))
 
-    # Ensure Google Maps API key is available to templates. Allow an
-    # environment variable to override the default key.
-    default_api_key = "AIzaSyCFwtfzGRqUke-OclxMoXfZJFjNE2um23k"
-    context.setdefault(
-        "GOOGLE_MAPS_API_KEY", os.getenv("GOOGLE_MAPS_API_KEY", default_api_key)
-    )
+    # Ensure Google Maps API key is available to templates from environment.
+    api_key = os.getenv("GOOGLE_MAPS_API_KEY")
+    if api_key:
+        context.setdefault("GOOGLE_MAPS_API_KEY", api_key)
 
     template = templates_env.get_template(template_name)
     return HTMLResponse(template.render(**context))


### PR DESCRIPTION
## Summary
- load Google Maps API key only from environment without hard-coded default

## Testing
- `python -m py_compile main.py`
- `uvicorn main:app --port 8000 --log-level info`

------
https://chatgpt.com/codex/tasks/task_e_68a6b7add0548320abc8a2f22d905878