### PR TITLE
Display bar distances and sort listings consistently

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -11,23 +11,33 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
 
-  if (barList && navigator.geolocation) {
+  const allBarItems = document.querySelectorAll('ul.bars li');
+  if (allBarItems.length && navigator.geolocation) {
     const nearestBarEl = document.getElementById('nearestBar');
     navigator.geolocation.getCurrentPosition(pos => {
       const {latitude: uLat, longitude: uLon} = pos.coords;
-      const items = Array.from(barList.querySelectorAll('li'));
-      items.forEach(item => {
+
+      allBarItems.forEach(item => {
         const bLat = parseFloat(item.dataset.latitude);
         const bLon = parseFloat(item.dataset.longitude);
+        if (!isFinite(bLat) || !isFinite(bLon)) return;
         const dist = haversine(uLat, uLon, bLat, bLon);
         item.dataset.distance = dist;
+        const distEl = item.querySelector('.distance');
+        if (distEl) {
+          distEl.textContent = `${dist.toFixed(1)} km away`;
+        }
       });
-      items.sort((a, b) => a.dataset.distance - b.dataset.distance);
-      items.forEach(item => barList.appendChild(item));
-      if (nearestBarEl && items.length) {
-        const nearest = items[0];
-        const name = nearest.querySelector('.card__title').textContent;
-        nearestBarEl.textContent = `Nearest bar: ${name} (${Number(nearest.dataset.distance).toFixed(1)} km)`;
+
+      if (barList) {
+        const items = Array.from(barList.querySelectorAll('li'));
+        items.sort((a, b) => parseFloat(a.dataset.distance) - parseFloat(b.dataset.distance));
+        items.forEach(item => barList.appendChild(item));
+        if (nearestBarEl && items.length) {
+          const nearest = items[0];
+          const name = nearest.querySelector('.card__title').textContent;
+          nearestBarEl.textContent = `Nearest bar: ${name} (${parseFloat(nearest.dataset.distance).toFixed(1)} km)`;
+        }
       }
     });
   }

--- a/static/style.css
+++ b/static/style.css
@@ -65,6 +65,7 @@ body.dark-mode{
 .bars{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-3);list-style:none;padding:0;}
 
 .rating{color:var(--brand);}
+.distance{color:var(--muted);font-size:.875rem;}
 
 .search{margin-bottom:var(--space-3);}
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -37,6 +37,7 @@
           <h3 class="card__title" itemprop="name">{{ last_bar.name }}</h3>
           <address itemprop="address">{{ last_bar.address }}, {{ last_bar.city }}, {{ last_bar.state }}</address>
           <p class="rating" aria-label="Rated 4.7 out of 5">★ 4.7</p>
+          <p class="distance" aria-live="polite"></p>
           <ul class="chips"><li><span class="chip">Cocktails</span></li><li><span class="chip">Sports</span></li><li><span class="chip">Live Music</span></li></ul>
           <a class="btn btn--primary" href="/bars/{{ last_bar.id }}">View Menu</a>
         </div>
@@ -59,6 +60,7 @@
           <h3 class="card__title" itemprop="name">{{ bar.name }}</h3>
           <address itemprop="address">{{ bar.address }}, {{ bar.city }}, {{ bar.state }}</address>
           <p class="rating" aria-label="Rated 4.7 out of 5">★ 4.7</p>
+          <p class="distance" aria-live="polite"></p>
           <ul class="chips"><li><span class="chip">Cocktails</span></li><li><span class="chip">Sports</span></li><li><span class="chip">Live Music</span></li></ul>
           <a class="btn btn--primary" href="/bars/{{ bar.id }}">View Menu</a>
         </div>


### PR DESCRIPTION
## Summary
- show distance placeholders on bar cards
- compute & display distance using geolocation and sort bars by proximity
- style distance text for a consistent layout

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6bd03e8a4832093d9ab61c2e25139