### PR TITLE
feat: remove home map and link distance to maps

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -25,7 +25,19 @@ document.addEventListener('DOMContentLoaded', function() {
         item.dataset.distance = dist;
         const distEl = item.querySelector('.distance');
         if (distEl) {
-          distEl.textContent = `📍 ${dist.toFixed(1)} km away`;
+          const link = document.createElement('a');
+          link.textContent = `📍 ${dist.toFixed(1)} km away`;
+          link.href = '#';
+          link.addEventListener('click', (e) => {
+            e.preventDefault();
+            const isApple = /iPad|iPhone|Mac/i.test(navigator.platform);
+            const url = isApple
+              ? `https://maps.apple.com/?daddr=${bLat},${bLon}`
+              : `https://www.google.com/maps/dir/?api=1&destination=${bLat},${bLon}`;
+            window.open(url, '_blank');
+          });
+          distEl.innerHTML = '';
+          distEl.appendChild(link);
         }
       });
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -83,11 +83,5 @@
   </blockquote>
 </section>
 
-<section>
-  <h2>Find us on the map</h2>
-  <iframe width="100%" height="300" frameborder="0" style="border:0"
-    src="https://www.openstreetmap.org/export/embed.html?bbox=8.6000,46.5200,8.6200,46.5350&layer=mapnik" allowfullscreen></iframe>
-</section>
-
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- remove the static map section from the home page
- make bar distance clickable and open Google or Apple Maps

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6cce7e1e48320abf4aa5e06a419b5