### PR TITLE
Add top location display and search bar

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -1,57 +1,113 @@
 document.addEventListener('DOMContentLoaded', function() {
   const searchInput = document.getElementById('barSearch');
   const barList = document.getElementById('barList');
-  if (searchInput && barList) {
-    searchInput.addEventListener('keyup', function() {
-      const term = this.value.toLowerCase();
-      barList.querySelectorAll('li').forEach(item => {
-        const {name, address, city = '', state = ''} = item.dataset;
-        item.style.display = (name.includes(term) || address.includes(term) || city.includes(term) || state.includes(term)) ? '' : 'none';
-      });
+  const nearestBarEl = document.getElementById('nearestBar');
+  const locationDisplay = document.getElementById('currentLocation');
+  const manualLocation = document.getElementById('manualLocation');
+  const setLocationBtn = document.getElementById('setLocationBtn');
+
+  function filterBars(term) {
+    if (!barList) return;
+    const t = term.toLowerCase();
+    barList.querySelectorAll('li').forEach(item => {
+      const {name, address, city = '', state = ''} = item.dataset;
+      item.style.display = (name.includes(t) || address.includes(t) || city.includes(t) || state.includes(t)) ? '' : 'none';
     });
   }
 
+  if (searchInput && barList) {
+    searchInput.addEventListener('keyup', () => filterBars(searchInput.value));
+  }
+
   const allBarItems = document.querySelectorAll('ul.bars li');
-  if (allBarItems.length && navigator.geolocation) {
-    const nearestBarEl = document.getElementById('nearestBar');
-    navigator.geolocation.getCurrentPosition(pos => {
-      const {latitude: uLat, longitude: uLon} = pos.coords;
 
-      allBarItems.forEach(item => {
-        const bLat = parseFloat(item.dataset.latitude);
-        const bLon = parseFloat(item.dataset.longitude);
-        if (!isFinite(bLat) || !isFinite(bLon)) return;
-        const dist = haversine(uLat, uLon, bLat, bLon);
-        item.dataset.distance = dist;
-        const distEl = item.querySelector('.distance');
-        if (distEl) {
-          const link = document.createElement('a');
-          link.textContent = `📍 ${dist.toFixed(1)} km away`;
-          link.href = '#';
-          link.addEventListener('click', (e) => {
-            e.preventDefault();
-            const isApple = /iPad|iPhone|Mac/i.test(navigator.platform);
-            const url = isApple
-              ? `https://maps.apple.com/?daddr=${bLat},${bLon}`
-              : `https://www.google.com/maps/dir/?api=1&destination=${bLat},${bLon}`;
-            window.open(url, '_blank');
-          });
-          distEl.innerHTML = '';
-          distEl.appendChild(link);
-        }
-      });
-
-      if (barList) {
-        const items = Array.from(barList.querySelectorAll('li'));
-        items.sort((a, b) => parseFloat(a.dataset.distance) - parseFloat(b.dataset.distance));
-        items.forEach(item => barList.appendChild(item));
-        if (nearestBarEl && items.length) {
-          const nearest = items[0];
-          const name = nearest.querySelector('.card__title').textContent;
-          nearestBarEl.textContent = `Nearest bar: ${name} (${parseFloat(nearest.dataset.distance).toFixed(1)} km)`;
-        }
+  function updateDistances(uLat, uLon) {
+    allBarItems.forEach(item => {
+      const bLat = parseFloat(item.dataset.latitude);
+      const bLon = parseFloat(item.dataset.longitude);
+      if (!isFinite(bLat) || !isFinite(bLon)) return;
+      const dist = haversine(uLat, uLon, bLat, bLon);
+      item.dataset.distance = dist;
+      const distEl = item.querySelector('.distance');
+      if (distEl) {
+        const link = document.createElement('a');
+        link.textContent = `📍 ${dist.toFixed(1)} km away`;
+        link.href = '#';
+        link.addEventListener('click', (e) => {
+          e.preventDefault();
+          const isApple = /iPad|iPhone|Mac/i.test(navigator.platform);
+          const url = isApple
+            ? `https://maps.apple.com/?daddr=${bLat},${bLon}`
+            : `https://www.google.com/maps/dir/?api=1&destination=${bLat},${bLon}`;
+          window.open(url, '_blank');
+        });
+        distEl.innerHTML = '';
+        distEl.appendChild(link);
       }
     });
+
+    if (barList) {
+      const items = Array.from(barList.querySelectorAll('li')).filter(li => li.style.display !== 'none');
+      items.sort((a, b) => parseFloat(a.dataset.distance) - parseFloat(b.dataset.distance));
+      items.forEach(item => barList.appendChild(item));
+      if (nearestBarEl && items.length) {
+        const nearest = items[0];
+        const name = nearest.querySelector('.card__title').textContent;
+        nearestBarEl.textContent = `Nearest bar: ${name} (${parseFloat(nearest.dataset.distance).toFixed(1)} km)`;
+      }
+    }
+  }
+
+  function reverseGeocode(lat, lon) {
+    fetch(`https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lon}`)
+      .then(res => res.json())
+      .then(data => {
+        if (!locationDisplay) return;
+        if (data.address && data.address.city) {
+          locationDisplay.textContent = `${data.address.city}, ${data.address.country}`;
+        } else {
+          locationDisplay.textContent = data.display_name || `${lat.toFixed(3)}, ${lon.toFixed(3)}`;
+        }
+      })
+      .catch(() => {
+        if (locationDisplay) locationDisplay.textContent = `${lat.toFixed(3)}, ${lon.toFixed(3)}`;
+      });
+  }
+
+  function setLocation(lat, lon, label) {
+    updateDistances(lat, lon);
+    if (locationDisplay) {
+      locationDisplay.textContent = label || `${lat.toFixed(3)}, ${lon.toFixed(3)}`;
+    }
+    reverseGeocode(lat, lon);
+  }
+
+  if (allBarItems.length) {
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(pos => {
+        const {latitude, longitude} = pos.coords;
+        setLocation(latitude, longitude);
+      });
+    }
+
+    if (setLocationBtn && manualLocation) {
+      setLocationBtn.addEventListener('click', () => {
+        const city = manualLocation.value.trim();
+        if (!city) return;
+        fetch(`https://nominatim.openstreetmap.org/search?format=json&limit=1&q=${encodeURIComponent(city)}`)
+          .then(res => res.json())
+          .then(data => {
+            if (data && data.length) {
+              const {lat, lon, display_name} = data[0];
+              setLocation(parseFloat(lat), parseFloat(lon), display_name);
+              if (searchInput) {
+                searchInput.value = city;
+                filterBars(city);
+              }
+            }
+          });
+      });
+    }
   }
 
   function haversine(lat1, lon1, lat2, lon2) {

--- a/static/style.css
+++ b/static/style.css
@@ -70,6 +70,9 @@ body.dark-mode{
 
 .search{margin-bottom:var(--space-3);}
 
+.top-controls{display:flex;align-items:center;gap:var(--space-2);background:var(--surface);padding:var(--space-2) var(--space-3);}
+.top-controls input{padding:var(--space-1);}
+
 @media (prefers-reduced-motion: reduce){*{animation:none;transition:none}}
 
 .site-footer{margin-top:var(--space-4);padding:var(--space-3) 0;background:var(--surface);text-align:center;}

--- a/templates/home.html
+++ b/templates/home.html
@@ -48,7 +48,6 @@
 {% endif %}
 
 <section>
-  <div class="search"><input type="text" id="barSearch" placeholder="Search bars..."></div>
   <h2 id="bars">Available Bars</h2>
   <p id="nearestBar" aria-live="polite"></p>
   <ul class="bars" id="barList">

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -46,6 +46,12 @@
       {% endif %}
     </div>
   </header>
+  <div class="top-controls container">
+    <span id="currentLocation">Detecting location...</span>
+    <input type="text" id="manualLocation" placeholder="Enter city">
+    <button id="setLocationBtn" class="btn btn--secondary btn--small">Set</button>
+    <input type="text" id="barSearch" placeholder="Search bars...">
+  </div>
   <main id="main" class="container">
       {% block content %}{% endblock %}
   </main>


### PR DESCRIPTION
## Summary
- Show current or manually set location at the top of the site
- Move bar search field to the header
- Allow users to change location to explore bars in any city

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a6d2865f608320816d8bb8dec6c380