### PR TITLE
Integrate editable location bar into site header

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -70,8 +70,9 @@ body.dark-mode{
 
 .search{margin-bottom:var(--space-3);}
 
-.top-controls{display:flex;align-items:center;gap:var(--space-2);background:var(--surface);padding:var(--space-2) var(--space-3);}
+.top-controls{display:flex;align-items:center;gap:var(--space-2);}
 .top-controls input{padding:var(--space-1);}
+.location-display{cursor:pointer;}
 
 @media (prefers-reduced-motion: reduce){*{animation:none;transition:none}}
 

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -24,6 +24,10 @@
         <a class="btn" href="/topup">Top Up</a>
         {% endif %}
       </div>
+      <div class="top-controls">
+        <span id="currentLocation" class="location-display" role="button" tabindex="0">Detecting location...</span>
+        <input type="text" id="barSearch" placeholder="Search bars...">
+      </div>
         <div class="nav-right">
           <a class="cart" href="/cart" aria-label="Cart ({% if cart_count %}{{ cart_count }}{% else %}0{% endif %} items)">
             <span class="badge">{% if cart_count %}{{ cart_count }}{% else %}0{% endif %}</span>
@@ -46,12 +50,6 @@
       {% endif %}
     </div>
   </header>
-  <div class="top-controls container">
-    <span id="currentLocation">Detecting location...</span>
-    <input type="text" id="manualLocation" placeholder="Enter city">
-    <button id="setLocationBtn" class="btn btn--secondary btn--small">Set</button>
-    <input type="text" id="barSearch" placeholder="Search bars...">
-  </div>
   <main id="main" class="container">
       {% block content %}{% endblock %}
   </main>


### PR DESCRIPTION
## Summary
- Move location and search controls into the main header alongside the logo
- Show city and ZIP code only for current location and allow inline editing by clicking the text
- Adjust styles for integrated top controls

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a6da059a488320b863b932d1cee3ac