### PR TITLE
Refine location input handling

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -2,7 +2,7 @@ document.addEventListener('DOMContentLoaded', function() {
   const searchInput = document.getElementById('barSearch');
   const barList = document.getElementById('barList');
   const nearestBarEl = document.getElementById('nearestBar');
-  const locationDisplay = document.getElementById('currentLocation');
+  const locationInput = document.getElementById('locationInput');
 
   function filterBars(term) {
     if (!barList) return;
@@ -60,26 +60,26 @@ document.addEventListener('DOMContentLoaded', function() {
     fetch(`https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lon}`)
       .then(res => res.json())
       .then(data => {
-        if (!locationDisplay) return;
+        if (!locationInput) return;
         if (data.address) {
           const {city, town, village, postcode} = data.address;
           const place = city || town || village;
           if (place) {
-            locationDisplay.textContent = postcode ? `${place} ${postcode}` : place;
+            locationInput.value = postcode ? `${place} ${postcode}` : place;
             return;
           }
         }
-        locationDisplay.textContent = data.display_name || `${lat.toFixed(3)}, ${lon.toFixed(3)}`;
+        locationInput.value = data.display_name || `${lat.toFixed(3)}, ${lon.toFixed(3)}`;
       })
       .catch(() => {
-        if (locationDisplay) locationDisplay.textContent = `${lat.toFixed(3)}, ${lon.toFixed(3)}`;
+        if (locationInput) locationInput.value = `${lat.toFixed(3)}, ${lon.toFixed(3)}`;
       });
   }
 
   function setLocation(lat, lon, label) {
     updateDistances(lat, lon);
-    if (locationDisplay) {
-      locationDisplay.textContent = label || `${lat.toFixed(3)}, ${lon.toFixed(3)}`;
+    if (locationInput) {
+      locationInput.value = label || `${lat.toFixed(3)}, ${lon.toFixed(3)}`;
     }
     reverseGeocode(lat, lon);
   }
@@ -92,28 +92,23 @@ document.addEventListener('DOMContentLoaded', function() {
       });
     }
 
-    function editLocation() {
-      const current = locationDisplay ? locationDisplay.textContent.trim() : '';
-      const city = prompt('Enter city or ZIP code:', current);
-      if (!city) return;
+    function geocodeAndSet(city) {
       fetch(`https://nominatim.openstreetmap.org/search?format=json&limit=1&q=${encodeURIComponent(city)}`)
         .then(res => res.json())
         .then(data => {
           if (data && data.length) {
             const {lat, lon} = data[0];
-            setLocation(parseFloat(lat), parseFloat(lon));
-            if (searchInput) {
-              searchInput.value = city;
-              filterBars(city);
-            }
+            setLocation(parseFloat(lat), parseFloat(lon), city);
           }
         });
     }
 
-    if (locationDisplay) {
-      locationDisplay.addEventListener('click', editLocation);
-      locationDisplay.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') editLocation();
+    if (locationInput) {
+      locationInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+          const city = locationInput.value.trim();
+          if (city) geocodeAndSet(city);
+        }
       });
     }
   }

--- a/static/style.css
+++ b/static/style.css
@@ -72,7 +72,15 @@ body.dark-mode{
 
 .top-controls{display:flex;align-items:center;gap:var(--space-2);}
 .top-controls input{padding:var(--space-1);}
-.location-display{cursor:pointer;}
+.location-display{
+  cursor:text;
+  border:0;
+  background:transparent;
+  color:inherit;
+}
+.location-display:focus{
+  outline:1px solid #d1d5db;
+}
 
 @media (prefers-reduced-motion: reduce){*{animation:none;transition:none}}
 

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -25,7 +25,7 @@
         {% endif %}
       </div>
       <div class="top-controls">
-        <span id="currentLocation" class="location-display" role="button" tabindex="0">Detecting location...</span>
+        <input type="text" id="locationInput" class="location-display" value="Detecting location..." placeholder="Enter city or ZIP" aria-label="Current location">
         <input type="text" id="barSearch" placeholder="Search bars...">
       </div>
         <div class="nav-right">


### PR DESCRIPTION
## Summary
- Replace popup-based location prompt with inline text input in header
- Style location field for seamless appearance and focus handling
- Remove coupling between location entry and bar search filter

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node --check static/script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a6ddc982e48320a41633d1ca397cd8