### PR TITLE
Improve search bar with suggestions

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -3,6 +3,9 @@ document.addEventListener('DOMContentLoaded', function() {
   const barList = document.getElementById('barList');
   const nearestBarEl = document.getElementById('nearestBar');
   const locationInput = document.getElementById('locationInput');
+  const searchResults = document.getElementById('searchResults');
+
+  const barItems = barList ? Array.from(barList.querySelectorAll('li')) : [];
 
   function filterBars(term) {
     if (!barList) return;
@@ -13,8 +16,52 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
 
-  if (searchInput && barList) {
-    searchInput.addEventListener('keyup', () => filterBars(searchInput.value));
+  function showSuggestions(term = '') {
+    if (!searchResults) return;
+    let items = barItems.slice();
+    items.sort((a, b) => (parseFloat(a.dataset.distance) || Infinity) - (parseFloat(b.dataset.distance) || Infinity));
+    if (term) {
+      const t = term.toLowerCase();
+      items = items.filter(li => li.dataset.name.includes(t));
+    }
+    searchResults.innerHTML = '';
+    if (!items.length) {
+      const li = document.createElement('li');
+      li.textContent = 'No bars found';
+      li.classList.add('no-results');
+      searchResults.appendChild(li);
+      return;
+    }
+    items.slice(0, 5).forEach(item => {
+      const li = document.createElement('li');
+      const name = item.querySelector('.card__title').textContent;
+      const href = item.querySelector('a.btn').getAttribute('href');
+      const a = document.createElement('a');
+      a.textContent = name;
+      a.href = href;
+      li.appendChild(a);
+      searchResults.appendChild(li);
+    });
+  }
+
+  if (searchInput) {
+    searchInput.addEventListener('focus', () => {
+      searchInput.classList.add('expanded');
+      if (searchResults) {
+        searchResults.hidden = false;
+        showSuggestions(searchInput.value);
+      }
+    });
+    searchInput.addEventListener('input', () => {
+      if (barList) filterBars(searchInput.value);
+      showSuggestions(searchInput.value);
+    });
+    searchInput.addEventListener('blur', () => {
+      searchInput.classList.remove('expanded');
+      if (searchResults) {
+        setTimeout(() => searchResults.hidden = true, 100);
+      }
+    });
   }
 
   const allBarItems = document.querySelectorAll('ul.bars li');

--- a/static/style.css
+++ b/static/style.css
@@ -70,8 +70,16 @@ body.dark-mode{
 
 .search{margin-bottom:var(--space-3);}
 
-.top-controls{display:flex;align-items:center;gap:var(--space-2);}
+.top-controls{display:flex;align-items:center;gap:var(--space-2);position:relative;}
 .top-controls input{padding:var(--space-1);}
+
+#barSearch{width:150px;transition:width .3s,transform .3s;}
+#barSearch.expanded{width:300px;transform:translateX(-150px);}
+
+.search-results{position:absolute;top:calc(100% + 4px);left:0;background:var(--surface);border:1px solid #d1d5db;border-radius:var(--radius);box-shadow:var(--shadow);list-style:none;margin:0;padding:0;width:300px;max-height:240px;overflow:auto;z-index:1000;}
+.search-results li{padding:var(--space-1) var(--space-2);cursor:pointer;}
+.search-results li:hover{background:var(--brand);color:#fff;}
+.search-results .no-results{color:var(--muted);cursor:default;}
 .location-display{
   cursor:text;
   border:0;

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -27,6 +27,7 @@
       <div class="top-controls">
         <input type="text" id="locationInput" class="location-display" value="Detecting location..." placeholder="Enter city or ZIP" aria-label="Current location">
         <input type="text" id="barSearch" placeholder="Search bars...">
+        <ul id="searchResults" class="search-results" hidden></ul>
       </div>
         <div class="nav-right">
           <a class="cart" href="/cart" aria-label="Cart ({% if cart_count %}{{ cart_count }}{% else %}0{% endif %} items)">


### PR DESCRIPTION
## Summary
- Expand search bar on focus and display nearby bars
- Provide live suggestions and "No bars found" message
- Style search results dropdown and expansion

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a6dfd684e08320925df5311c6aa6e0