### PR TITLE
Add overlay search preview and results page

### DIFF
--- a/main.py
+++ b/main.py
@@ -384,6 +384,16 @@ async def home(request: Request):
     return render_template("home.html", request=request, bars=bars.values())
 
 
+@app.get("/search", response_class=HTMLResponse)
+async def search_bars(request: Request, q: str = ""):
+    term = q.lower()
+    results = [
+        bar for bar in bars.values()
+        if term in bar.name.lower() or term in bar.address.lower() or term in bar.city.lower() or term in bar.state.lower()
+    ]
+    return render_template("search.html", request=request, bars=results, query=q)
+
+
 @app.get("/bars/{bar_id}", response_class=HTMLResponse)
 async def bar_detail(request: Request, bar_id: int):
     bar = bars.get(bar_id)

--- a/static/script.js
+++ b/static/script.js
@@ -4,6 +4,8 @@ document.addEventListener('DOMContentLoaded', function() {
   const nearestBarEl = document.getElementById('nearestBar');
   const locationInput = document.getElementById('locationInput');
   const searchResults = document.getElementById('searchResults');
+  const searchOverlay = document.getElementById('searchOverlay');
+  const searchPreview = document.getElementById('searchPreview');
 
   const barItems = barList ? Array.from(barList.querySelectorAll('li')) : [];
 
@@ -44,6 +46,20 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
 
+  function updatePreview(term = '') {
+    if (!searchPreview) return;
+    let items = barItems.slice();
+    if (term) {
+      const t = term.toLowerCase();
+      items = items.filter(li => li.dataset.name.includes(t));
+    }
+    searchPreview.innerHTML = '';
+    if (items.length) {
+      const card = items[0].querySelector('.card').cloneNode(true);
+      searchPreview.appendChild(card);
+    }
+  }
+
   if (searchInput) {
     searchInput.addEventListener('focus', () => {
       searchInput.classList.add('expanded');
@@ -51,17 +67,35 @@ document.addEventListener('DOMContentLoaded', function() {
         searchResults.hidden = false;
         showSuggestions(searchInput.value);
       }
+      if (searchOverlay) {
+        searchOverlay.hidden = false;
+        updatePreview(searchInput.value);
+      }
     });
     searchInput.addEventListener('input', () => {
       if (barList) filterBars(searchInput.value);
       showSuggestions(searchInput.value);
+      updatePreview(searchInput.value);
     });
     searchInput.addEventListener('blur', () => {
       searchInput.classList.remove('expanded');
       if (searchResults) {
         setTimeout(() => searchResults.hidden = true, 100);
       }
+      if (searchOverlay) {
+        setTimeout(() => searchOverlay.hidden = true, 100);
+      }
     });
+    searchInput.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        window.location.href = `/search?q=${encodeURIComponent(searchInput.value)}`;
+      }
+    });
+  }
+
+  if (searchOverlay) {
+    searchOverlay.addEventListener('click', () => searchInput.blur());
   }
 
   const allBarItems = document.querySelectorAll('ul.bars li');

--- a/static/style.css
+++ b/static/style.css
@@ -74,7 +74,11 @@ body.dark-mode{
 .top-controls input{padding:var(--space-1);}
 
 #barSearch{width:150px;transition:width .3s,transform .3s;}
-#barSearch.expanded{width:300px;transform:translateX(-150px);}
+#barSearch.expanded{width:400px;transform:translateX(-250px);}
+
+.search-overlay{position:fixed;inset:0;background:rgba(0,0,0,.5);display:flex;align-items:center;justify-content:center;z-index:1000;}
+.search-overlay[hidden]{display:none;}
+.search-overlay .card{max-width:320px;}
 
 .search-results{position:absolute;top:calc(100% + 4px);left:0;background:var(--surface);border:1px solid #d1d5db;border-radius:var(--radius);box-shadow:var(--shadow);list-style:none;margin:0;padding:0;width:300px;max-height:240px;overflow:auto;z-index:1000;}
 .search-results li{padding:var(--space-1) var(--space-2);cursor:pointer;}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -51,6 +51,9 @@
       {% endif %}
     </div>
   </header>
+  <div id="searchOverlay" class="search-overlay" hidden>
+    <div id="searchPreview"></div>
+  </div>
   <main id="main" class="container">
       {% block content %}{% endblock %}
   </main>

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,0 +1,27 @@
+{% extends "layout.html" %}
+{% block content %}
+<section class="search">
+  <h2>Search results for "{{ query }}"</h2>
+  {% if bars %}
+  <ul class="bars">
+    {% for bar in bars %}
+    <li data-name="{{ bar.name|lower }}" data-address="{{ bar.address|lower }}" data-city="{{ bar.city|lower }}" data-state="{{ bar.state|lower }}" data-latitude="{{ bar.latitude }}" data-longitude="{{ bar.longitude }}">
+      <article class="card" itemscope itemtype="https://schema.org/BarOrPub">
+        <img class="card__media" src="https://source.unsplash.com/random/400x250?bar,{{ bar.id }}" alt="{{ bar.name }}" itemprop="image" loading="lazy" decoding="async">
+        <div class="card__body">
+          <h3 class="card__title" itemprop="name">{{ bar.name }}</h3>
+          <p class="card__desc">{{ bar.description }}</p>
+          <address itemprop="address">{{ bar.address }}, {{ bar.city }}, {{ bar.state }}</address>
+          <p class="rating" aria-label="Rated 4.7 out of 5">★ 4.7</p>
+          <p class="distance" aria-live="polite"></p>
+          <a class="btn btn--primary" href="/bars/{{ bar.id }}">View Menu</a>
+        </div>
+      </article>
+    </li>
+    {% endfor %}
+  </ul>
+  {% else %}
+  <p>No bars found.</p>
+  {% endif %}
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Expand bar search to reach logo and show preview overlay while searching
- Redirect Enter key to new `/search` page and darken background in search mode
- Add `/search` route and template listing bar results

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6f0acc1f08320b2a30fc74f1eede8