### PR TITLE
Refine search overlay behavior

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -55,8 +55,15 @@ document.addEventListener('DOMContentLoaded', function() {
     }
     searchPreview.innerHTML = '';
     if (items.length) {
-      const card = items[0].querySelector('.card').cloneNode(true);
-      searchPreview.appendChild(card);
+      const list = document.createElement('ul');
+      list.classList.add('bars');
+      items.slice(0, 4).forEach(barItem => {
+        const li = document.createElement('li');
+        const card = barItem.querySelector('.card').cloneNode(true);
+        li.appendChild(card);
+        list.appendChild(li);
+      });
+      searchPreview.appendChild(list);
     }
   }
 

--- a/static/style.css
+++ b/static/style.css
@@ -76,7 +76,7 @@ body.dark-mode{
 #barSearch{width:150px;transition:width .3s,transform .3s;}
 #barSearch.expanded{width:400px;transform:translateX(-250px);}
 
-.search-overlay{position:fixed;inset:0;background:rgba(0,0,0,.5);display:flex;align-items:center;justify-content:center;z-index:1000;}
+.search-overlay{position:fixed;inset:0;background:transparent;display:flex;align-items:flex-start;justify-content:center;padding-top:80px;z-index:40;}
 .search-overlay[hidden]{display:none;}
 .search-overlay .card{max-width:320px;}
 


### PR DESCRIPTION
## Summary
- Keep navigation visible by making search overlay transparent and lowering its z-index
- Show multiple search results preview cards in a responsive grid

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a6f39e60088320af17820454f0ed38