### PR TITLE
Remove search suggestions from bar search

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -3,11 +3,7 @@ document.addEventListener('DOMContentLoaded', function() {
   const barList = document.getElementById('barList');
   const nearestBarEl = document.getElementById('nearestBar');
   const locationInput = document.getElementById('locationInput');
-  const searchResults = document.getElementById('searchResults');
-  const searchOverlay = document.getElementById('searchOverlay');
-  const searchPreview = document.getElementById('searchPreview');
-
-  const barItems = barList ? Array.from(barList.querySelectorAll('li')) : [];
+  // Elements used solely for search suggestions have been removed
 
   function filterBars(term) {
     if (!barList) return;
@@ -18,95 +14,24 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
 
-  function showSuggestions(term = '') {
-    if (!searchResults) return;
-    let items = barItems.slice();
-    items.sort((a, b) => (parseFloat(a.dataset.distance) || Infinity) - (parseFloat(b.dataset.distance) || Infinity));
-    if (term) {
-      const t = term.toLowerCase();
-      items = items.filter(li => li.dataset.name.includes(t));
-    }
-    searchResults.innerHTML = '';
-    if (!items.length) {
-      const li = document.createElement('li');
-      li.textContent = 'No bars found';
-      li.classList.add('no-results');
-      searchResults.appendChild(li);
-      return;
-    }
-    items.slice(0, 5).forEach(item => {
-      const li = document.createElement('li');
-      const name = item.querySelector('.card__title').textContent;
-      const href = item.querySelector('a.btn').getAttribute('href');
-      const a = document.createElement('a');
-      a.textContent = name;
-      a.href = href;
-      li.appendChild(a);
-      searchResults.appendChild(li);
-    });
-  }
-
-  function updatePreview(term = '') {
-    if (!searchPreview) return;
-    let items = barItems.slice();
-    if (term) {
-      const t = term.toLowerCase();
-      items = items.filter(li => li.dataset.name.includes(t));
-    }
-    searchPreview.innerHTML = '';
-    if (items.length) {
-      const list = document.createElement('ul');
-      list.classList.add('bars');
-      items.slice(0, 4).forEach(barItem => {
-        const li = document.createElement('li');
-        const card = barItem.querySelector('.card').cloneNode(true);
-        li.appendChild(card);
-        list.appendChild(li);
-      });
-      searchPreview.appendChild(list);
-    }
-  }
+  // Suggestion dropdown and preview overlay have been removed
 
   if (searchInput) {
     searchInput.addEventListener('focus', () => {
       searchInput.classList.add('expanded');
-      if (searchResults) {
-        searchResults.hidden = false;
-        showSuggestions(searchInput.value);
-      }
-      if (searchOverlay) {
-        searchOverlay.hidden = false;
-        updatePreview(searchInput.value);
-      }
     });
     searchInput.addEventListener('input', () => {
       if (barList) filterBars(searchInput.value);
-      showSuggestions(searchInput.value);
-      updatePreview(searchInput.value);
     });
     searchInput.addEventListener('blur', () => {
       if (searchInput.value.trim() === '') {
         searchInput.classList.remove('expanded');
-        if (searchResults) {
-          setTimeout(() => searchResults.hidden = true, 100);
-        }
-        if (searchOverlay) {
-          setTimeout(() => searchOverlay.hidden = true, 100);
-        }
       }
     });
     searchInput.addEventListener('keydown', (e) => {
       if (e.key === 'Enter') {
         e.preventDefault();
         window.location.href = `/search?q=${encodeURIComponent(searchInput.value)}`;
-      }
-    });
-  }
-
-  if (searchOverlay) {
-    searchOverlay.addEventListener('click', () => {
-      if (searchInput.value.trim() === '') {
-        searchInput.blur();
       }
     });
   }

--- a/static/style.css
+++ b/static/style.css
@@ -75,15 +75,6 @@ body.dark-mode{
 
 #barSearch{width:150px;transition:width .3s,transform .3s;}
 #barSearch.expanded{width:400px;transform:translateX(-250px);}
-
-.search-overlay{position:fixed;inset:0;background:transparent;display:flex;align-items:flex-start;justify-content:center;padding-top:80px;z-index:40;}
-.search-overlay[hidden]{display:none;}
-.search-overlay .card{max-width:320px;}
-
-.search-results{position:absolute;top:calc(100% + 4px);left:0;background:var(--surface);border:1px solid #d1d5db;border-radius:var(--radius);box-shadow:var(--shadow);list-style:none;margin:0;padding:0;width:300px;max-height:240px;overflow:auto;z-index:1000;}
-.search-results li{padding:var(--space-1) var(--space-2);cursor:pointer;}
-.search-results li:hover{background:var(--brand);color:#fff;}
-.search-results .no-results{color:var(--muted);cursor:default;}
 .location-display{
   cursor:text;
   border:0;

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -27,7 +27,6 @@
       <div class="top-controls">
         <input type="text" id="locationInput" class="location-display" value="Detecting location..." placeholder="Enter city or ZIP" aria-label="Current location">
         <input type="text" id="barSearch" placeholder="Search bars...">
-        <ul id="searchResults" class="search-results" hidden></ul>
       </div>
         <div class="nav-right">
           <a class="cart" href="/cart" aria-label="Cart ({% if cart_count %}{{ cart_count }}{% else %}0{% endif %} items)">
@@ -51,9 +50,6 @@
       {% endif %}
     </div>
   </header>
-  <div id="searchOverlay" class="search-overlay" hidden>
-    <div id="searchPreview"></div>
-  </div>
   <main id="main" class="container">
       {% block content %}{% endblock %}
   </main>


### PR DESCRIPTION
## Summary
- simplify search input by removing dropdown and overlay suggestions
- update styles and layout to drop unused suggestion elements

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a6fbc897848320b71d033f995824a4