### PR TITLE
Fix search results layout to show bars as cards

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -1,9 +1,8 @@
 {% extends "layout.html" %}
 {% block content %}
 <section class="search">
-  <h2>Search results for "{{ query }}"</h2>
   {% if bars %}
-  <ul class="bars">
+  <ul class="bars" id="barList">
     {% for bar in bars %}
     <li data-name="{{ bar.name|lower }}" data-address="{{ bar.address|lower }}" data-city="{{ bar.city|lower }}" data-state="{{ bar.state|lower }}" data-latitude="{{ bar.latitude }}" data-longitude="{{ bar.longitude }}">
       <article class="card" itemscope itemtype="https://schema.org/BarOrPub">


### PR DESCRIPTION
## Summary
- Remove search heading and ensure results render solely as bar cards
- Give search results grid the `barList` id so filtering and layout work

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a6fe2402188320b035987bd81395ff