### PR TITLE
Remove location selector arrow

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -109,7 +109,6 @@ body.dark-mode{
   border-color:#007bff;
 }
 .location-icon{margin-right:var(--space-1);}
-.location-arrow{margin-left:var(--space-1);pointer-events:none;}
 .location-display{
   flex:1;
   border:0;

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -28,7 +28,6 @@
         <div class="location-selector">
           <span class="location-icon">📍</span>
           <input type="text" id="locationInput" class="location-display" value="Detecting location..." placeholder="Enter city or ZIP" aria-label="Current location" list="citySuggestions">
-          <span class="location-arrow">▼</span>
           <datalist id="citySuggestions">
             <option value="Lugano"></option>
             <option value="Locarno"></option>


### PR DESCRIPTION
## Summary
- Remove dropdown arrow from header location selector
- Clean up unused location-arrow CSS

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a70c552b948320a4567047dcac37d3