### PR TITLE
Hide default datalist arrow for location input

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -115,8 +115,16 @@ body.dark-mode{
   background:transparent;
   color:inherit;
   min-width:0;
+  appearance:none;
+  -webkit-appearance:none;
 }
 .location-display:focus{outline:none;}
+
+.location-display::-webkit-calendar-picker-indicator,
+.location-display::-webkit-list-button,
+.location-display::-ms-expand{
+  display:none;
+}
 
 @media (prefers-reduced-motion: reduce){*{animation:none;transition:none}}
 


### PR DESCRIPTION
## Summary
- Remove default dropdown arrow from location selector input by adding cross-browser CSS rules.

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7138ea3008320b29647c08e6cdf63