### PR TITLE
feat: add mobile-first base styles

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -1,11 +1,22 @@
 /* base.css */
 *,*::before,*::after{box-sizing:border-box;}
-html{font-family:var(--font-sans);font-size:var(--fs-300);}
-body{margin:0;background:var(--color-bg);color:var(--color-text);transition:background var(--dur) var(--ease),color var(--dur) var(--ease);}
-img{max-width:100%;display:block;}
+html{font-family:var(--font-sans);font-size:var(--step-0);-webkit-text-size-adjust:100%;}
+body{margin:0;font-size:var(--step-0);line-height:1.5;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;background:var(--bg,#fff);color:var(--fg,#111);transition:background var(--dur) var(--ease),color var(--dur) var(--ease);padding-top:env(safe-area-inset-top);padding-bottom:env(safe-area-inset-bottom);}
+img{max-width:100%;display:block;height:auto;}
 a{color:inherit;}
-.container{max-width:1200px;margin-inline:auto;padding-inline:clamp(var(--space-2),4vw,var(--space-5));}
+.container{max-width:72rem;margin-inline:auto;padding-inline:clamp(16px,4vw,24px);}
+
+button, .btn, a[role="button"]{min-height:44px;min-width:44px;border-radius:var(--radius);padding:10px 16px;}
 .visually-hidden{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0;}
 .skip-link{position:absolute;top:-40px;left:0;background:var(--color-primary);color:#fff;padding:.5rem 1rem;z-index:100;transition:top var(--dur) var(--ease);}
 .skip-link:focus{top:0;}
 :focus-visible{outline:2px solid var(--color-primary);outline-offset:2px;}
+
+@media (prefers-color-scheme: dark){
+  :root{ --bg:#0b0b0b; --fg:#f2f2f2; }
+  body{ background:var(--bg); color:var(--fg); }
+  .navbar{ background:rgba(20,20,20,0.8); border-color:rgba(255,255,255,0.08); }
+}
+@media (prefers-reduced-motion: reduce){
+  *{ animation-duration:0.01ms !important; animation-iteration-count:1 !important; transition-duration:0.01ms !important; }
+}

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -23,7 +23,7 @@ body.dark-mode{
 .visually-hidden{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0;}
 
 .site-header{position:sticky;top:0;z-index:50;backdrop-filter:saturate(180%) blur(10px);background:color-mix(in srgb,var(--bg) 85%,transparent);display:flex;align-items:center;justify-content:space-between;padding:var(--space-2) var(--space-3);}
-.navbar{display:flex;align-items:center;gap:var(--space-3);justify-content:space-between;width:100%;transition:box-shadow var(--dur) var(--ease),background var(--dur) var(--ease);}
+.navbar{position:sticky;top:0;inset-inline:0;display:flex;gap:var(--gap-1);justify-content:space-around;align-items:center;padding:calc(8px + env(safe-area-inset-top)) 8px 8px;background:rgba(255,255,255,0.92);backdrop-filter:blur(10px);border-bottom:1px solid rgba(0,0,0,0.06);width:100%;transition:box-shadow var(--dur) var(--ease),background var(--dur) var(--ease);}
 .navbar a{color:var(--text);text-decoration:none;}
 .navbar.is-scrolled{box-shadow:var(--shadow);background:var(--surface);}
 
@@ -37,6 +37,9 @@ body.dark-mode{
 .menu{position:absolute;top:100%;right:var(--space-3);background:var(--surface);border-radius:var(--radius);padding:var(--space-3);box-shadow:var(--shadow);display:none;flex-direction:column;gap:var(--space-2);}
 .menu a{color:var(--text);text-decoration:none;}
 .menu.open{display:flex;}
+
+.navbtn{min-width:44px;min-height:44px;display:inline-flex;align-items:center;justify-content:center;padding:8px 12px;border-radius:12px;text-decoration:none;}
+.navbtn:focus-visible{outline:2px solid Highlight;outline-offset:2px;}
 
 .logo{font-weight:600;color:var(--text);text-decoration:none;font-size:1.25rem;}
 .cart{position:relative;display:inline-flex;align-items:center;text-decoration:none;color:var(--text);}

--- a/static/css/tokens.css
+++ b/static/css/tokens.css
@@ -1,4 +1,11 @@
 :root{
+  /* Tipografia e scala fluida */
+  --step--1: clamp(0.85rem, 0.8rem + 0.2vw, 0.95rem);
+  --step-0:  clamp(1rem, 0.9rem + 0.5vw, 1.125rem);
+  --step-1:  clamp(1.125rem, 1rem + 0.8vw, 1.375rem);
+  --radius:  12px;
+  --gap-1:   clamp(8px, 1.5vw, 12px);
+  --gap-2:   clamp(12px, 2vw, 16px);
   /* colori */
   --color-bg:#0B0D12; --color-surface:#12151C; --color-text:#E9EEF5;
   --color-muted:#9AA4B2; --color-primary:#5B8CFF; --color-primary-600:#3E6EF2;
@@ -19,6 +26,5 @@
   --surface: var(--color-surface);
   --text: var(--color-text);
   --muted: var(--color-muted);
-  --radius: var(--radius-lg);
   --shadow: var(--shadow-1);
 }

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -2,7 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="theme-color" content="#ffffff">
+  <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <title>SiplyGo Prototype</title>
   <meta name="description" content="SiplyGo helps you discover bars nearby and manage your orders effortlessly.">
   <link rel="canonical" href="https://siplygo.example.com/">
@@ -16,10 +20,10 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <link href="/static/css/tokens.min.css" rel="stylesheet">
-  <link href="/static/css/base.min.css" rel="stylesheet">
-  <link href="/static/css/components.min.css" rel="stylesheet">
-  <link href="/static/css/utilities.min.css" rel="stylesheet">
+  <link href="/static/css/tokens.css" rel="stylesheet">
+  <link href="/static/css/base.css" rel="stylesheet">
+  <link href="/static/css/components.css" rel="stylesheet">
+  <link href="/static/css/utilities.css" rel="stylesheet">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>


### PR DESCRIPTION
## Summary
- add Apple PWA meta tags and load unminified CSS for easier customization
- introduce fluid typographic and spacing scale with safe-area padding
- make nav sticky with touch-friendly targets and dark mode support

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a72634252c8320942bee71d519a49c