### PR TITLE
Add wallet page and single-bar ordering enforcement

### DIFF
--- a/templates/bar_detail.html
+++ b/templates/bar_detail.html
@@ -2,6 +2,9 @@
 {% block content %}
 <h1>{{ bar.name }}</h1>
 <p>{{ bar.address }}, {{ bar.city }}, {{ bar.state }}</p>
+{% if error %}
+<p class="error">{{ error }}</p>
+{% endif %}
 {% for category, products in products_by_category.items() %}
   <section class="category">
     <h2>{{ category.name }}</h2>

--- a/templates/cart.html
+++ b/templates/cart.html
@@ -32,18 +32,14 @@
 </table>
 <p><strong>Total: CHF {{ "%.2f"|format(cart.total_price()) }}</strong></p>
 <h2>Select Table</h2>
-<form class="form" method="get" action="/cart/select_table">
+<form class="form" method="get" action="/cart/checkout">
   <label for="table_id">Table
-    <select id="table_id" name="table_id">
+    <select id="table_id" name="table_id" required>
       {% for table in bar.tables.values() %}
         <option value="{{ table.id }}" {% if cart.table_id == table.id %}selected{% endif %}>{{ table.name }}</option>
       {% endfor %}
     </select>
   </label>
-  <button class="btn" type="submit">Confirm</button>
-</form>
-<h2>Checkout</h2>
-<form method="get" action="/cart/checkout">
   <button class="btn btn--success" type="submit">Place Order</button>
 </form>
 {% else %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -33,9 +33,6 @@
         {% if not user %}
         <a class="btn" href="/login">Login</a>
         <a class="btn" href="/register">Register</a>
-        {% else %}
-        <span class="chip">Credit: CHF {{ "%.2f"|format(user.credit) }}</span>
-        <a class="btn" href="/topup">Top Up</a>
         {% endif %}
       </div>
       <div class="top-controls">
@@ -52,6 +49,9 @@
         <div id="searchSuggestions" class="search-suggestions"></div>
       </div>
       <div class="nav-right">
+        {% if user %}
+        <a class="chip" href="/wallet">Credit: CHF {{ "%.2f"|format(user.credit) }}</a>
+        {% endif %}
         <a class="cart" href="/cart" aria-label="Cart ({% if cart_count %}{{ cart_count }}{% else %}0{% endif %} items)">
           <span class="badge">{% if cart_count %}{{ cart_count }}{% else %}0{% endif %}</span>
         </a>
@@ -68,7 +68,7 @@
       <a href="/dashboard">Dashboard</a>
       {% endif %}
       {% if user %}
-      <a href="/topup">Top Up</a>
+      <a href="/wallet">Wallet</a>
       <a href="/logout">Logout</a>
       {% endif %}
     </div>

--- a/templates/transaction_detail.html
+++ b/templates/transaction_detail.html
@@ -1,0 +1,12 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>Transaction Details</h1>
+<p>Bar: {{ tx.bar_name }}</p>
+<p>Total: CHF {{ "%.2f"|format(tx.total) }}</p>
+<ul>
+  {% for item in tx.items %}
+  <li>{{ item.name }} x{{ item.quantity }} - CHF {{ "%.2f"|format(item.total) }}</li>
+  {% endfor %}
+</ul>
+<a class="btn" href="/wallet">Back to Wallet</a>
+{% endblock %}

--- a/templates/wallet.html
+++ b/templates/wallet.html
@@ -1,0 +1,14 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>Wallet</h1>
+<p>Your current credit: CHF {{ "%.2f"|format(user.credit) }}</p>
+<a class="btn" href="/topup">Top Up</a>
+<h2>Recent Expenses</h2>
+<ul>
+  {% for tx in transactions %}
+  <li><a href="/wallet/tx/{{ loop.index0 }}">{{ tx.bar_name }} - CHF {{ "%.2f"|format(tx.total) }}</a></li>
+  {% else %}
+  <li>No transactions yet.</li>
+  {% endfor %}
+</ul>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Move credit display to navbar right and link to new wallet page
- Track transactions and show wallet with top up button and details per purchase
- Prevent cart from mixing bars and require table selection at checkout

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a72ee9b0c48320b457d220fa69e8c4