### PR TITLE
Implement persistent search and activatable filter sheet

### DIFF
--- a/static/css/components.css
+++ b/static/css/components.css
@@ -251,6 +251,11 @@ body.dark-mode{
 .filter-sheet{background:var(--bg);width:100%;max-height:85vh;border-radius:16px 16px 0 0;padding:16px;padding-bottom:calc(16px + env(safe-area-inset-bottom));box-shadow:0 -4px 20px rgba(0,0,0,.2);transform:translateY(100%);transition:transform .3s ease;overflow-y:auto;}
 .filter-overlay.show .filter-sheet{transform:translateY(0);}
 .grabber{width:48px;height:5px;border-radius:8px;background:var(--muted);margin:0 auto 16px;}
+.filter-sheet .group{margin-top:16px;}
+.filter-sheet .group-head{display:flex;justify-content:space-between;align-items:center;}
+.filter-sheet .group.inactive{opacity:.55;}
+.filter-sheet .group:not(.inactive) .inactive-hint{display:none;}
+.filter-sheet .group .value-chip{margin-left:auto;}
 .sheet-footer{position:sticky;bottom:0;display:flex;gap:12px;padding-top:16px;margin-top:16px;background:var(--bg);}
 .sheet-footer .apply{flex:1;}
 @media (prefers-color-scheme: dark){

--- a/templates/search.html
+++ b/templates/search.html
@@ -57,20 +57,27 @@
     <div class="grabber" aria-hidden="true"></div>
     <h2 id="filterTitle">Filtri</h2>
     <form id="filterForm">
-      <div class="group">
-        <label for="filterSearch">Search</label>
-        <input type="search" id="filterSearch" aria-label="Cerca bar o città" inputmode="search" autocomplete="off">
+      <div class="group inactive" data-key="max_km">
+        <div class="group-head">
+          <label for="filterDistance">Max distance</label>
+          <span id="filterDistanceVal" class="chip value-chip" hidden></span>
+        </div>
+        <input type="range" id="filterDistance" name="distance" min="1" max="50" step="1" value="50">
+        <p class="help inactive-hint">Sposta lo slider per attivare</p>
       </div>
-      <div class="group">
-        <label for="filterDistance">Max distance <span id="filterDistanceVal">10 km</span></label>
-        <input type="range" id="filterDistance" name="distance" min="1" max="50" value="10">
-      </div>
-      <div class="group">
-        <label for="filterRating">Min rating <span id="filterRatingVal">≥ 0</span></label>
+      <div class="group inactive" data-key="min_rating">
+        <div class="group-head">
+          <label for="filterRating">Min rating</label>
+          <span id="filterRatingVal" class="chip value-chip" hidden></span>
+        </div>
         <input type="range" id="filterRating" name="rating" min="0" max="5" step="0.1" value="0">
+        <p class="help inactive-hint">Sposta lo slider per attivare</p>
       </div>
-      <div class="group">
-        <p>Category</p>
+      <div class="group inactive" data-key="categories">
+        <div class="group-head">
+          <p>Category</p>
+          <span id="filterCategoryVal" class="chip value-chip" hidden></span>
+        </div>
         {% set cats = namespace(names=[]) %}
         {% for bar in bars %}
           {% for c in bar.categories.values() %}
@@ -80,15 +87,20 @@
           {% endfor %}
         {% endfor %}
         <div id="filterCategoryChips" class="chips">
-          <button type="button" class="chip active" data-value="">All</button>
+          <button type="button" class="chip" data-value="">All</button>
           {% for name in cats.names %}
           <button type="button" class="chip" data-value="{{ name|lower }}">{{ name }}</button>
           {% endfor %}
         </div>
+        <p class="help inactive-hint">Seleziona per attivare</p>
       </div>
-      <div class="group">
-        <label for="filterOpen">Open now</label>
+      <div class="group inactive" data-key="open_now">
+        <div class="group-head">
+          <label for="filterOpen">Open now</label>
+          <span id="filterOpenVal" class="chip value-chip" hidden></span>
+        </div>
         <input type="checkbox" id="filterOpen" name="open">
+        <p class="help inactive-hint">Attiva per filtrare</p>
       </div>
       <div class="sheet-footer">
         <button type="button" class="btn reset">Reset</button>


### PR DESCRIPTION
## Summary
- Debounce top search box and persist query via URL and localStorage
- Add filter sheet controls that activate on first use with value chips and state persistence
- Style filter sheet controls with inactive opacity and badge count

## Testing
- `node --check static/js/search.js`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a76b4ce09c8320899fcad65d6766bf