### PR TITLE
feat: add explicit rating and distance filters

### DIFF
--- a/static/css/components.css
+++ b/static/css/components.css
@@ -233,11 +233,12 @@ body.dark-mode{
 .bar-card{flex:0 0 auto;width:clamp(220px,45vw,320px);border-radius:14px;box-shadow:0 6px 18px rgba(0,0,0,.08);padding:12px;background:var(--surface);scroll-snap-align:start;display:flex;flex-direction:column;gap:12px;text-decoration:none;color:inherit;cursor:pointer;}
 .bar-card .thumb{width:100%;height:100px;object-fit:cover;border-radius:10px;background:#f1f1f1;}
 .bar-card .title{font-size:16px;font-weight:700;margin:0;}
-.bar-card .bar-meta{display:flex;align-items:center;gap:8px;}
-.bar-card .bar-meta .bar-rating{font-size:14px;font-weight:600;display:flex;align-items:center;gap:2px;}
-.bar-card .bar-meta .bar-distance{font-size:13px;color:var(--muted);display:flex;align-items:center;gap:2px;}
-.bar-card .bar-meta .bar-rating[data-has-rating="false"],
-.bar-card .bar-meta .bar-distance[data-has-distance="false"]{display:none;}
+.bar-meta{display:flex;gap:12px;align-items:center;font-weight:500;font-size:.9rem;margin-top:4px;}
+.bar-meta i{margin-right:4px;}
+.bar-meta .bar-rating[data-has-rating="false"],
+.bar-meta .bar-distance[data-has-distance="false"]{display:none;}
+.bar-meta .bar-distance{color:var(--muted);}
+.bar-card,.bar-card:focus,.bar-card:hover{text-decoration:none;}
 .bar-card address{font-style:normal;font-size:13px;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;margin:0;}
 .bar-card .desc{font-size:13px;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;margin:0;}
 .bar-card:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
@@ -255,9 +256,10 @@ body.dark-mode{
 .grabber{width:48px;height:5px;border-radius:8px;background:var(--muted);margin:0 auto 16px;}
 .filter-sheet .group{margin-top:16px;}
 .filter-sheet .group-head{display:flex;justify-content:space-between;align-items:center;}
+.filter-sheet .group-head .group-toggle{display:flex;align-items:center;gap:8px;margin-left:auto;}
 .filter-sheet .group[data-active="false"]{opacity:.55;}
 .filter-sheet .group[data-active="true"] .inactive-hint{display:none;}
-.filter-sheet .group .value-chip{margin-left:auto;}
+.filter-sheet .group .value-chip{margin-left:0;}
 .sheet-footer{position:sticky;bottom:0;display:flex;gap:12px;padding-top:16px;margin-top:16px;background:var(--bg);}
 .sheet-footer .apply{flex:1;}
 @media (prefers-color-scheme: dark){

--- a/templates/home.html
+++ b/templates/home.html
@@ -35,14 +35,8 @@
         <img class="thumb" src="https://source.unsplash.com/random/400x250?bar,{{ last_bar.id }}" alt="{{ last_bar.name }}" itemprop="image" loading="lazy" width="400" height="100">
         <h3 class="title" itemprop="name">{{ last_bar.name }}</h3>
         <div class="bar-meta">
-          <span class="bar-rating" data-has-rating="false" hidden>
-            <i class="bi bi-star-fill" aria-hidden="true"></i>
-            <span class="rating-value"></span>
-          </span>
-          <span class="bar-distance" data-has-distance="false" hidden>
-            <i class="bi bi-geo-alt-fill" aria-hidden="true"></i>
-            <span class="distance-value"></span>
-          </span>
+          <span class="bar-rating" data-has-rating="true" hidden></span>
+          <span class="bar-distance" data-has-distance="true" hidden></span>
         </div>
         <address>{{ last_bar.address }}, {{ last_bar.city }}, {{ last_bar.state }}</address>
         <p class="desc">{{ last_bar.description }}</p>
@@ -62,14 +56,8 @@
         <img class="thumb" src="https://source.unsplash.com/random/400x250?bar,{{ bar.id }}" alt="{{ bar.name }}" itemprop="image" loading="lazy" width="400" height="100">
         <h3 class="title" itemprop="name">{{ bar.name }}</h3>
         <div class="bar-meta">
-          <span class="bar-rating" data-has-rating="false" hidden>
-            <i class="bi bi-star-fill" aria-hidden="true"></i>
-            <span class="rating-value"></span>
-          </span>
-          <span class="bar-distance" data-has-distance="false" hidden>
-            <i class="bi bi-geo-alt-fill" aria-hidden="true"></i>
-            <span class="distance-value"></span>
-          </span>
+          <span class="bar-rating" data-has-rating="true" hidden></span>
+          <span class="bar-distance" data-has-distance="true" hidden></span>
         </div>
         <address>{{ bar.address }}, {{ bar.city }}, {{ bar.state }}</address>
         <p class="desc">{{ bar.description }}</p>

--- a/templates/search.html
+++ b/templates/search.html
@@ -35,14 +35,8 @@
           {% endif %}
           <h3 class="title" itemprop="name">{{ bar.name }}</h3>
           <div class="bar-meta">
-            <span class="bar-rating" data-has-rating="false" hidden>
-              <i class="bi bi-star-fill" aria-hidden="true"></i>
-              <span class="rating-value"></span>
-            </span>
-            <span class="bar-distance" data-has-distance="false" hidden>
-              <i class="bi bi-geo-alt-fill" aria-hidden="true"></i>
-              <span class="distance-value"></span>
-            </span>
+            <span class="bar-rating" data-has-rating="true" hidden></span>
+            <span class="bar-distance" data-has-distance="true" hidden></span>
           </div>
           {% if bar.address_short or bar.address %}<address>{{ bar.address_short or bar.address }}</address>{% endif %}
           {% if bar.description_short or bar.description %}<p class="desc">{{ bar.description_short or bar.description }}</p>{% endif %}
@@ -66,20 +60,26 @@
       <div class="group" data-key="max_km" data-active="false">
         <div class="group-head">
           <label for="filterDistance">Max distance</label>
-          <span id="filterDistanceVal" class="chip value-chip" hidden></span>
+          <div class="group-toggle">
+            <input type="checkbox" id="filterDistanceToggle">
+            <span id="filterDistanceVal" class="chip value-chip" hidden></span>
+          </div>
         </div>
         <input type="range" id="filterDistance" name="distance" min="1" max="50" step="1" value="50" aria-label="Max distance in kilometers" aria-valuenow="50">
         <span id="filterDistanceAnnounce" class="visually-hidden" aria-live="polite"></span>
-        <p class="help inactive-hint">Sposta lo slider per attivare</p>
+        <p class="help inactive-hint">Attiva per filtrare</p>
       </div>
       <div class="group" data-key="min_rating" data-active="false">
         <div class="group-head">
           <label for="filterRating">Min rating</label>
-          <span id="filterRatingVal" class="chip value-chip" hidden></span>
+          <div class="group-toggle">
+            <input type="checkbox" id="filterRatingToggle">
+            <span id="filterRatingVal" class="chip value-chip" hidden></span>
+          </div>
         </div>
         <input type="range" id="filterRating" name="rating" min="0" max="5" step="0.1" value="0" aria-label="Minimum rating" aria-valuenow="0">
         <span id="filterRatingAnnounce" class="visually-hidden" aria-live="polite"></span>
-        <p class="help inactive-hint">Sposta lo slider per attivare</p>
+        <p class="help inactive-hint">Attiva per filtrare</p>
       </div>
       <div class="group" data-key="categories" data-active="false">
         <div class="group-head">


### PR DESCRIPTION
## Summary
- render bar ratings and distances with Bootstrap Icons, parsing varied formats
- add explicit toggles for max distance and min rating filters with badge updates
- improve search and filter logic persistence

## Testing
- `pytest`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a773f2b3f0832097763f8704bcd51f