### PR TITLE
Add database-backed Bar API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,14 @@ instance automatically.
 - Tables are created on startup if they do not yet exist.
 
 This is a starting point for adding persistent storage and role-based features.
+
+## API
+
+The application exposes minimal database-backed endpoints to illustrate
+integration:
+
+- `GET /api/bars` – list bars stored in the PostgreSQL database.
+- `POST /api/bars` – create a new bar by providing `name` and `slug`.
+
+A sample bar is automatically created on startup if the database is empty so the
+listing endpoint immediately returns data.


### PR DESCRIPTION
## Summary
- add SQLAlchemy-backed endpoints to list and create bars
- seed database with a sample bar on startup
- document new API in README

## Testing
- `python -m py_compile main.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac0bfc70908320aaa41560db2a2bb9