### PR TITLE
Add audit logging for payout runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ integration:
 - `POST /api/bars` – create a new bar by providing `name` and `slug`.
 - `POST /api/orders` – create an order and automatically compute VAT,
   the 5% platform fee and the payout due to the bar.
+- `POST /api/payouts/run` – aggregate completed orders for a bar within a
+  date range and create a payout entry. Each invocation is recorded in the
+  `audit_logs` table for traceability.
 
 A sample bar is automatically created on startup if the database is empty so the
 listing endpoint immediately returns data.

--- a/audit.py
+++ b/audit.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+import json
+from typing import Optional, Dict, Any
+
+from sqlalchemy.orm import Session
+
+from models import AuditLog
+
+
+def log_action(
+    db: Session,
+    *,
+    actor_user_id: Optional[int],
+    action: str,
+    entity_type: str,
+    entity_id: Optional[int] = None,
+    payload: Optional[Dict[str, Any]] = None,
+    ip: Optional[str] = None,
+    user_agent: Optional[str] = None,
+) -> AuditLog:
+    """Persist an audit log entry to the database."""
+    log = AuditLog(
+        actor_user_id=actor_user_id,
+        action=action,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        payload_json=json.dumps(payload) if payload else None,
+        ip=ip,
+        user_agent=user_agent,
+        created_at=datetime.utcnow(),
+    )
+    db.add(log)
+    db.commit()
+    db.refresh(log)
+    return log

--- a/database.py
+++ b/database.py
@@ -1,10 +1,21 @@
 import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
+from sqlalchemy.pool import StaticPool
 
 DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://siply:siply@db:5432/siply")
 
-engine = create_engine(DATABASE_URL, future=True)
+# Use a StaticPool for in-memory SQLite so connections share the same DB.
+if DATABASE_URL.startswith("sqlite"):
+    engine = create_engine(
+        DATABASE_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        future=True,
+    )
+else:
+    engine = create_engine(DATABASE_URL, future=True)
+
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()

--- a/payouts.py
+++ b/payouts.py
@@ -1,0 +1,49 @@
+from datetime import datetime
+from decimal import Decimal, ROUND_HALF_UP
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from models import Order, Payout
+
+
+def schedule_payout(db: Session, bar_id: int, period_start: datetime, period_end: datetime) -> Payout:
+    """Aggregate completed orders for a bar and create a payout entry.
+
+    Args:
+        db: Database session.
+        bar_id: Bar identifier for which to schedule the payout.
+        period_start: Start datetime of the aggregation window (inclusive).
+        period_end: End datetime of the aggregation window (inclusive).
+
+    Returns:
+        The created ``Payout`` instance.
+
+    Raises:
+        ValueError: If no completed orders exist in the given range.
+    """
+    totals = db.query(
+        func.sum(Order.payout_due_to_bar).label("payout_total")
+    ).filter(
+        Order.bar_id == bar_id,
+        Order.status == "completed",
+        Order.created_at >= period_start,
+        Order.created_at <= period_end,
+    ).first()
+
+    if not totals or totals.payout_total is None:
+        raise ValueError("No completed orders for given range")
+
+    payout_total = Decimal(totals.payout_total).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+    payout = Payout(
+        bar_id=bar_id,
+        amount_chf=payout_total,
+        period_start=period_start,
+        period_end=period_end,
+        status="scheduled",
+    )
+    db.add(payout)
+    db.commit()
+    db.refresh(payout)
+    return payout

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -1,0 +1,59 @@
+import os
+from decimal import Decimal
+from datetime import datetime, timedelta
+import pathlib
+import sys
+
+# Use shared in-memory SQLite database
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, SessionLocal, engine  # noqa: E402
+from models import Bar, Order, AuditLog  # noqa: E402
+from main import app  # noqa: E402
+
+
+def setup_module(module):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def test_run_payout_creates_audit_log():
+    db = SessionLocal()
+    bar = Bar(name="Audit Bar", slug="audit-bar")
+    db.add(bar)
+    db.commit()
+    db.refresh(bar)
+
+    now = datetime.utcnow()
+    order = Order(
+        bar_id=bar.id,
+        subtotal=Decimal("100.00"),
+        vat_total=Decimal("7.70"),
+        fee_platform_5pct=Decimal("5.00"),
+        payout_due_to_bar=Decimal("102.70"),
+        status="completed",
+        created_at=now,
+    )
+    db.add(order)
+    db.commit()
+
+    client = TestClient(app)
+    payload = {
+        "bar_id": bar.id,
+        "period_start": (now - timedelta(days=1)).isoformat(),
+        "period_end": (now + timedelta(days=1)).isoformat(),
+        "actor_user_id": 42,
+    }
+    resp = client.post("/api/payouts/run", json=payload)
+    assert resp.status_code == 201
+    payout_id = resp.json()["id"]
+
+    logs = db.query(AuditLog).all()
+    assert len(logs) == 1
+    log = logs[0]
+    assert log.actor_user_id == 42
+    assert log.action == "payout_run"
+    assert log.entity_type == "payout"
+    assert log.entity_id == payout_id

--- a/tests/test_payouts.py
+++ b/tests/test_payouts.py
@@ -1,0 +1,55 @@
+import os
+from decimal import Decimal
+from datetime import datetime, timedelta
+import pathlib
+import sys
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from database import Base, SessionLocal, engine  # noqa: E402
+from models import Bar, Order  # noqa: E402
+from payouts import schedule_payout  # noqa: E402
+
+
+def setup_module(module):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def test_schedule_payout_creates_record():
+    db = SessionLocal()
+    bar = Bar(name="Test Bar", slug="test-bar")
+    db.add(bar)
+    db.commit()
+    db.refresh(bar)
+
+    now = datetime.utcnow()
+    orders = [
+        Order(
+            bar_id=bar.id,
+            subtotal=Decimal("100.00"),
+            vat_total=Decimal("7.70"),
+            fee_platform_5pct=Decimal("5.00"),
+            payout_due_to_bar=Decimal("102.70"),
+            status="completed",
+            created_at=now,
+        ),
+        Order(
+            bar_id=bar.id,
+            subtotal=Decimal("50.00"),
+            vat_total=Decimal("3.85"),
+            fee_platform_5pct=Decimal("2.50"),
+            payout_due_to_bar=Decimal("51.35"),
+            status="completed",
+            created_at=now,
+        ),
+    ]
+    db.add_all(orders)
+    db.commit()
+
+    payout = schedule_payout(db, bar.id, now - timedelta(days=1), now + timedelta(days=1))
+
+    assert payout.amount_chf == Decimal("154.05")
+    assert payout.status == "scheduled"
+    assert payout.bar_id == bar.id


### PR DESCRIPTION
## Summary
- support SQLite tests with shared in-memory engine
- add audit log helper and record `/api/payouts/run` calls
- document new audit logging and add tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac178e39e88320942e7cb0063297b0