### PR TITLE
Add CORS configuration and health check endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ integration:
 - `POST /api/payouts/run` – aggregate completed orders for a bar within a
   date range and create a payout entry. Each invocation is recorded in the
   `audit_logs` table for traceability.
+- `GET /healthz` – returns `{"status": "ok"}` when the database connection is
+  healthy.
 
 A sample bar is automatically created on startup if the database is empty so the
 listing endpoint immediately returns data.
@@ -41,6 +43,8 @@ listing endpoint immediately returns data.
 - `API_BASE_URL` – base URL for API requests (defaults to `http://localhost:8000`).
 - `ADMIN_EMAIL` – email for the SuperAdmin account.
 - `ADMIN_PASSWORD` – password for the SuperAdmin account.
+- `FRONTEND_ORIGINS` – comma-separated list of allowed frontend URLs for CORS
+  (defaults to `http://localhost:5173`).
 
 On startup the application ensures a SuperAdmin user exists using these
 credentials. If the user is missing, it is created with the provided values. For

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -24,6 +24,11 @@
     <p>View your admin profile.</p>
     <a class="btn btn--primary" href="/admin/profile">View Profile</a>
   </div>
+  <div class="card">
+    <h3>System Health</h3>
+    <p>Check backend status.</p>
+    <a class="btn btn--primary" href="/healthz" target="_blank" rel="noopener">Check Health</a>
+  </div>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- allow cross-origin requests via configurable `FRONTEND_ORIGINS`
- expose `/healthz` endpoint verifying database connectivity
- document new endpoint and CORS env var in README
- link admin dashboard to new health check

## Testing
- `pip install httpx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac2713eecc8320a188db1ca07756ae