### PR TITLE
Persist user edits and sync admin user list

### DIFF
--- a/templates/admin_edit_user.html
+++ b/templates/admin_edit_user.html
@@ -9,6 +9,15 @@
   <label for="password">Password
     <input id="password" name="password" value="{{ user.password }}">
   </label>
+  <label for="email">Email
+    <input id="email" name="email" value="{{ user.email }}">
+  </label>
+  <label for="prefix">Prefix
+    <input id="prefix" name="prefix" value="{{ user.prefix }}">
+  </label>
+  <label for="phone">Phone
+    <input id="phone" name="phone" value="{{ user.phone }}">
+  </label>
   <label for="role">Role
     <select id="role" name="role">
       <option value="super_admin" {% if user.role=='super_admin' %}selected{% endif %}>Super Admin</option>


### PR DESCRIPTION
## Summary
- Load users from the database for the admin user list to keep data after restarts
- Save edits to user accounts (name, password, role, etc.) directly in the database
- Add email, prefix and phone fields to the edit user form and persist them in the database

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac53f9c4c08320ae3e0738065e63a4