### PR TITLE
Enable full user detail editing in admin panel

### DIFF
--- a/templates/admin_edit_user.html
+++ b/templates/admin_edit_user.html
@@ -2,12 +2,12 @@
 {% block content %}
 <h1>Edit User {{ user.username }}</h1>
 {% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
-<form class="form" method="get">
+<form class="form" method="post">
   <label for="username">Username
     <input id="username" name="username" value="{{ user.username }}">
   </label>
   <label for="password">Password
-    <input id="password" name="password" value="{{ user.password }}">
+    <input id="password" name="password" type="password" placeholder="Leave blank to keep current">
   </label>
   <label for="email">Email
     <input id="email" name="email" value="{{ user.email }}">

--- a/tests/test_update_user.py
+++ b/tests/test_update_user.py
@@ -1,0 +1,73 @@
+import os
+import sys
+import pathlib
+import hashlib
+
+# Use shared in-memory SQLite database
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, SessionLocal, engine  # noqa: E402
+from models import User, RoleEnum  # noqa: E402
+from main import app  # noqa: E402
+
+
+def setup_module(module):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def _login_super_admin(client: TestClient) -> None:
+    resp = client.post(
+        "/login",
+        data={"email": "admin@example.com", "password": "ChangeMe!123"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+def test_update_user_details_without_password():
+    db = SessionLocal()
+    password_hash = hashlib.sha256("oldpass".encode("utf-8")).hexdigest()
+    user = User(
+        username="olduser",
+        email="old@example.com",
+        password_hash=password_hash,
+        role=RoleEnum.CUSTOMER,
+        phone="123",
+        prefix="+1",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    db.close()
+
+    with TestClient(app) as client:
+        _login_super_admin(client)
+
+        form = {
+        "username": "newuser",
+        "password": "",
+        "email": "new@example.com",
+        "prefix": "+41",
+        "phone": "763661800",
+        "role": "bar_admin",
+        "bar_id": "",
+        "credit": "5.0",
+    }
+        resp = client.post(
+            f"/admin/users/edit/{user.id}", data=form, follow_redirects=False
+        )
+        assert resp.status_code == 303
+
+    db = SessionLocal()
+    updated = db.query(User).filter(User.id == user.id).first()
+    assert updated.username == "newuser"
+    assert updated.email == "new@example.com"
+    assert updated.prefix == "+41"
+    assert updated.phone == "763661800"
+    assert updated.role == RoleEnum.BARADMIN
+    # password should remain unchanged
+    assert updated.password_hash == password_hash
+    db.close()


### PR DESCRIPTION
## Summary
- Remove password requirement so admins can update username, email, phone, prefix, role, bar, and credit
- Only hash and store a new password when one is provided
- Clarify in template that password is optional
- Add regression test covering updating user info without changing password

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac59950e5c832099343c95ee1565a9