### PR TITLE
Remove add-user link and add bar deletion with confirmation

### DIFF
--- a/templates/admin_bars.html
+++ b/templates/admin_bars.html
@@ -22,7 +22,8 @@
       <td>{{ bar.state }}</td>
       <td>
         <a href="/admin/bars/edit/{{ bar.id }}">Edit</a> |
-        <a href="/admin/bars/{{ bar.id }}/add_user">Add User</a>
+        <a href="#" onclick="if(confirm('Are you sure you want to delete this bar?')){document.getElementById('delete-bar-{{ bar.id }}').submit();} return false;">Delete</a>
+        <form id="delete-bar-{{ bar.id }}" method="post" action="/admin/bars/{{ bar.id }}/delete" style="display:none;"></form>
       </td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
## Summary
- replace Add User action in admin bar list with a Delete Bar control
- add backend route to delete bars and clean up related data

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac69944c9483209643e939cdec0699