### PR TITLE
Handle cascading data when deleting bars

### DIFF
--- a/main.py
+++ b/main.py
@@ -56,7 +56,7 @@ from models import (
     User,
     RoleEnum,
     UserBarRole,
-    Category,
+    Category as CategoryModel,
 )
 from pydantic import BaseModel
 from decimal import Decimal
@@ -1080,7 +1080,7 @@ async def delete_bar(request: Request, bar_id: int, db: Session = Depends(get_db
         db.query(MenuVariant).filter(MenuVariant.menu_item_id.in_(menu_item_ids)).delete(synchronize_session=False)
     db.query(MenuItem).filter(MenuItem.bar_id == bar_id).delete(synchronize_session=False)
 
-    db.query(Category).filter(Category.bar_id == bar_id).delete(synchronize_session=False)
+    db.query(CategoryModel).filter(CategoryModel.bar_id == bar_id).delete(synchronize_session=False)
     db.query(UserBarRole).filter(UserBarRole.bar_id == bar_id).delete(synchronize_session=False)
 
     order_ids = [o.id for o in db.query(Order.id).filter(Order.bar_id == bar_id)]

--- a/main.py
+++ b/main.py
@@ -49,6 +49,7 @@ from database import Base, SessionLocal, engine, get_db
 from models import (
     Bar as BarModel,
     MenuItem,
+    MenuVariant,
     Order,
     OrderItem,
     Payout,
@@ -1073,9 +1074,22 @@ async def delete_bar(request: Request, bar_id: int, db: Session = Depends(get_db
     bar = db.get(BarModel, bar_id)
     if not bar:
         raise HTTPException(status_code=404, detail="Bar not found")
-    db.query(MenuItem).filter(MenuItem.bar_id == bar_id).delete()
-    db.query(Category).filter(Category.bar_id == bar_id).delete()
-    db.query(UserBarRole).filter(UserBarRole.bar_id == bar_id).delete()
+    # Remove dependent records to satisfy foreign key constraints
+    menu_item_ids = [m.id for m in db.query(MenuItem.id).filter(MenuItem.bar_id == bar_id)]
+    if menu_item_ids:
+        db.query(MenuVariant).filter(MenuVariant.menu_item_id.in_(menu_item_ids)).delete(synchronize_session=False)
+    db.query(MenuItem).filter(MenuItem.bar_id == bar_id).delete(synchronize_session=False)
+
+    db.query(Category).filter(Category.bar_id == bar_id).delete(synchronize_session=False)
+    db.query(UserBarRole).filter(UserBarRole.bar_id == bar_id).delete(synchronize_session=False)
+
+    order_ids = [o.id for o in db.query(Order.id).filter(Order.bar_id == bar_id)]
+    if order_ids:
+        db.query(OrderItem).filter(OrderItem.order_id.in_(order_ids)).delete(synchronize_session=False)
+    db.query(Order).filter(Order.bar_id == bar_id).delete(synchronize_session=False)
+
+    db.query(Payout).filter(Payout.bar_id == bar_id).delete(synchronize_session=False)
+
     db.delete(bar)
     db.commit()
     bars.pop(bar_id, None)

--- a/templates/admin_bars.html
+++ b/templates/admin_bars.html
@@ -23,7 +23,12 @@
       <td>
         <a href="/admin/bars/edit/{{ bar.id }}">Edit</a> |
         <a href="#" onclick="if(confirm('Are you sure you want to delete this bar?')){document.getElementById('delete-bar-{{ bar.id }}').submit();} return false;">Delete</a>
-        <form id="delete-bar-{{ bar.id }}" method="post" action="/admin/bars/{{ bar.id }}/delete" style="display:none;"></form>
+        <form
+          id="delete-bar-{{ bar.id }}"
+          method="post"
+          action="{{ request.url_for('delete_bar', bar_id=bar.id) }}"
+          style="display:none;"
+        ></form>
       </td>
     </tr>
     {% endfor %}

--- a/tests/test_delete_bar_html.py
+++ b/tests/test_delete_bar_html.py
@@ -1,0 +1,58 @@
+import os
+import pathlib
+import sys
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, SessionLocal, engine  # noqa: E402
+from models import Bar  # noqa: E402
+from main import app, DemoUser, users, users_by_email, users_by_username  # noqa: E402
+
+
+def setup_module(module):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()
+
+
+def teardown_module(module):
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()
+
+
+def test_admin_bars_delete_form_and_delete():
+    db = SessionLocal()
+    bar = Bar(name="Test Bar", slug="test-bar")
+    db.add(bar)
+    db.commit()
+    db.refresh(bar)
+    db.close()
+
+    admin = DemoUser(
+        id=1,
+        username="admin",
+        password="secret",
+        email="admin@example.com",
+        role="super_admin",
+    )
+    users[admin.id] = admin
+    users_by_email[admin.email] = admin
+    users_by_username[admin.username] = admin
+
+    client = TestClient(app)
+    client.post("/login", data={"email": admin.email, "password": admin.password})
+
+    resp = client.get("/admin/bars")
+    assert resp.status_code == 200
+    assert f'id="delete-bar-{bar.id}"' in resp.text
+
+    resp = client.post(f"/admin/bars/{bar.id}/delete", follow_redirects=False)
+    assert resp.status_code == 303
+    check_db = SessionLocal()
+    assert check_db.get(Bar, bar.id) is None
+    check_db.close()


### PR DESCRIPTION
## Summary
- delete bars along with related menu variants, orders, payouts, roles, and categories
- import MenuVariant model

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68ac6c8ccba48320b4c8c3fd907a2a5d