### PR TITLE
Add category and product management pages

### DIFF
--- a/models.py
+++ b/models.py
@@ -80,6 +80,8 @@ class Category(Base):
     id = Column(Integer, primary_key=True)
     bar_id = Column(Integer, ForeignKey("bars.id"), nullable=False)
     name = Column(String(100), nullable=False)
+    description = Column(Text)
+    photo_url = Column(String(255))
     sort_order = Column(Integer, default=0)
     active = Column(Boolean, default=True)
 

--- a/templates/admin_edit_bar_options.html
+++ b/templates/admin_edit_bar_options.html
@@ -3,7 +3,7 @@
 <h1>Edit {{ bar.name }}</h1>
 <ul class="list">
   <li><a href="/admin/bars/edit/{{ bar.id }}/info">Edit Basic Info</a></li>
-  <li><a href="/bar/{{ bar.id }}/categories/new">Manage Menu & Categories</a></li>
+  <li><a href="/bar/{{ bar.id }}/categories">Manage Menu & Categories</a></li>
   <li><a href="/admin/bars/{{ bar.id }}/add_user">Manage Users</a></li>
 </ul>
 {% endblock %}

--- a/templates/bar_category_products.html
+++ b/templates/bar_category_products.html
@@ -1,0 +1,33 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>Products in {{ category.name }} for {{ bar.name }}</h1>
+
+<div class="toolbar" style="margin-bottom:1rem;">
+  <a class="btn btn--primary" href="/bar/{{ bar.id }}/categories/{{ category.id }}/products/new">Add Product</a>
+</div>
+
+{% if products %}
+<table class="table">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Description</th>
+      <th>Price (CHF)</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for product in products %}
+    <tr>
+      <td>{{ product.name }}</td>
+      <td>{{ product.description }}</td>
+      <td>{{ "%.2f"|format(product.price) }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p>No products in this category.</p>
+{% endif %}
+
+{% endblock %}
+

--- a/templates/bar_manage_categories.html
+++ b/templates/bar_manage_categories.html
@@ -1,0 +1,41 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>Manage Categories for {{ bar.name }}</h1>
+
+<div class="toolbar" style="margin-bottom:1rem;">
+  <a class="btn btn--primary" href="/bar/{{ bar.id }}/categories/new">Add Category</a>
+</div>
+
+{% if categories %}
+<table class="table">
+  <thead>
+    <tr>
+      <th>#</th>
+      <th>Name</th>
+      <th>Description</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for category in categories %}
+    <tr>
+      <td>{{ loop.index }}</td>
+      <td>{{ category.name }}</td>
+      <td>{{ category.description }}</td>
+      <td>
+        <a class="btn" href="/bar/{{ bar.id }}/categories/{{ category.id }}/products">Products</a>
+        <a class="btn" href="/bar/{{ bar.id }}/categories/{{ category.id }}/edit">Edit</a>
+        <form method="post" action="/bar/{{ bar.id }}/categories/{{ category.id }}/delete" style="display:inline">
+          <button class="btn" type="submit">Delete</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p>No categories yet.</p>
+{% endif %}
+
+{% endblock %}
+

--- a/templates/bar_new_product.html
+++ b/templates/bar_new_product.html
@@ -1,0 +1,21 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>Add Product to {{ category.name }}</h1>
+{% if error %}<p class="error">{{ error }}</p>{% endif %}
+<form class="form" method="post" enctype="multipart/form-data">
+  <label for="name">Name
+    <input id="name" name="name" required>
+  </label>
+  <label for="price">Price (CHF)
+    <input id="price" type="number" step="0.01" name="price" required>
+  </label>
+  <label for="description">Description
+    <input id="description" name="description" required>
+  </label>
+  <label for="photo">Photo
+    <input id="photo" type="file" name="photo">
+  </label>
+  <button class="btn btn--primary" type="submit">Create</button>
+</form>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- Persist category details including description and photo to the database
- Load bars with their categories and products from the database and refresh on demand
- Save new categories and products to the database via admin routes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac77e69b708320b097b50dbe4030e1