### PR TITLE
Make bar user forms collapsible and collect phone details

### DIFF
--- a/main.py
+++ b/main.py
@@ -1356,7 +1356,9 @@ async def manage_bar_users_post(
         username = form.get("username")
         email = form.get("email")
         password = form.get("password")
-        if not all([username, email, password]) or role not in role_map:
+        phone = form.get("phone")
+        prefix = form.get("prefix")
+        if not all([username, email, password, phone, prefix]) or role not in role_map:
             error = "All fields are required"
         elif username in users_by_username or db.query(User).filter(User.username == username).first():
             error = "Username already taken"
@@ -1368,6 +1370,8 @@ async def manage_bar_users_post(
                 username=username,
                 email=email,
                 password_hash=password_hash,
+                phone=phone,
+                prefix=prefix,
                 role=role_map[role],
             )
             db.add(db_user)
@@ -1383,6 +1387,8 @@ async def manage_bar_users_post(
                 username=username,
                 password=password,
                 email=email,
+                phone=phone,
+                prefix=prefix,
                 role=role,
                 bar_id=bar_id,
             )

--- a/templates/admin_bar_users.html
+++ b/templates/admin_bar_users.html
@@ -4,43 +4,57 @@
 {% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
 {% if message %}<div class="alert alert-success">{{ message }}</div>{% endif %}
 
-<h2>Add Existing User</h2>
-<form class="form" method="post">
-  <input type="hidden" name="action" value="existing">
-  <label for="existing_email">Email
-    <input id="existing_email" name="email" type="email" required>
-  </label>
-  <label for="existing_role">Role
-    <select id="existing_role" name="role">
-      <option value="bar_admin">Bar Admin</option>
-      <option value="bartender">Bartender</option>
-    </select>
-  </label>
-  <p>Assigning to {{ bar.name }}</p>
-  <button class="btn btn--primary" type="submit">Add</button>
-</form>
+<details>
+  <summary>Add Existing User</summary>
+  <form class="form" method="post">
+    <input type="hidden" name="action" value="existing">
+    <label for="existing_email">Email
+      <input id="existing_email" name="email" type="email" required>
+    </label>
+    <label for="existing_role">Role
+      <select id="existing_role" name="role">
+        <option value="bar_admin">Bar Admin</option>
+        <option value="bartender">Bartender</option>
+      </select>
+    </label>
+    <p>Assigning to {{ bar.name }}</p>
+    <button class="btn btn--primary" type="submit">Add</button>
+  </form>
+</details>
 
-<h2>Add New User</h2>
-<form class="form" method="post">
-  <input type="hidden" name="action" value="new">
-  <label for="username">Username
-    <input id="username" name="username" required>
-  </label>
-  <label for="email">Email
-    <input id="email" name="email" type="email" required>
-  </label>
-  <label for="password">Password
-    <input id="password" name="password" type="password" required>
-  </label>
-  <label for="role">Role
-    <select id="role" name="role">
-      <option value="bar_admin">Bar Admin</option>
-      <option value="bartender">Bartender</option>
-    </select>
-  </label>
-  <p>Assigning to {{ bar.name }}</p>
-  <button class="btn btn--primary" type="submit">Create</button>
-</form>
+<details>
+  <summary>Add New User</summary>
+  <form class="form" method="post">
+    <input type="hidden" name="action" value="new">
+    <label for="username">Username
+      <input id="username" name="username" required>
+    </label>
+    <label for="email">Email
+      <input id="email" name="email" type="email" required>
+    </label>
+    <label for="password">Password
+      <input id="password" name="password" type="password" required>
+    </label>
+    <label for="prefix">Phone Prefix
+      <select id="prefix" name="prefix" required autocomplete="tel-country-code">
+        <option value="+41">+41 (Switzerland)</option>
+        <option value="+1">+1 (USA)</option>
+        <option value="+44">+44 (UK)</option>
+      </select>
+    </label>
+    <label for="phone">Phone Number
+      <input id="phone" name="phone" type="tel" required autocomplete="tel-national">
+    </label>
+    <label for="role">Role
+      <select id="role" name="role">
+        <option value="bar_admin">Bar Admin</option>
+        <option value="bartender">Bartender</option>
+      </select>
+    </label>
+    <p>Assigning to {{ bar.name }}</p>
+    <button class="btn btn--primary" type="submit">Create</button>
+  </form>
+</details>
 
 <h2>Current Staff</h2>
 <table class="table">

--- a/tests/test_manage_bar_users.py
+++ b/tests/test_manage_bar_users.py
@@ -59,6 +59,8 @@ def test_add_existing_and_new_user_to_bar():
             "username": "brandnew",
             "email": "fresh@example.com",
             "password": "secret",
+            "prefix": "+41",
+            "phone": "763661800",
             "role": "bartender",
         }
         resp = client.post(f"/admin/bars/{bar.id}/users", data=form)


### PR DESCRIPTION
## Summary
- hide "Add Existing User" and "Add New User" sections behind collapsible details
- extend new bar user form to request phone prefix and number
- store prefix and phone when creating bar users and update tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad655fff0c832093832371f4c80970