### PR TITLE
refactor: simplify bar metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,14 +89,7 @@ Bars now support additional optional metadata:
 
 - `rating` – float 0–5 displayed with a star icon.
 - `is_open_now` – flag shown as an "OPEN NOW" badge.
-- `price_level` – integer 1–4.
 - `promo_label` – short badge text like "2×1 Happy Hour".
 - `tags` – comma separated list of chips.
-- `short_description` – 120–160 character summary.
-- `avg_prep_time_min` – average preparation time in minutes.
-- `cover_image_url` – https image shown on cards.
-- `gallery_urls` – comma separated additional images.
-
 These fields are editable in **Admin → BarEdit Info**. Image URLs must be
-absolute HTTPS links; when no cover image is provided a generic placeholder is
-used.
+absolute HTTPS links.

--- a/models.py
+++ b/models.py
@@ -60,13 +60,8 @@ class Bar(Base):
     zone = Column(String(50))
     rating = Column(Float, default=0.0)
     is_open_now = Column(Boolean, default=False)
-    price_level = Column(Integer, default=1)
     promo_label = Column(String(100))
     tags = Column(Text)
-    short_description = Column(String(160))
-    avg_prep_time_min = Column(Integer)
-    cover_image_url = Column(String(255))
-    gallery_urls = Column(Text)
 
     categories = relationship("Category", back_populates="bar")
     menu_items = relationship("MenuItem", back_populates="bar")

--- a/templates/admin_edit_bar.html
+++ b/templates/admin_edit_bar.html
@@ -20,20 +20,11 @@
   <label for="description">Description
     <textarea id="description" name="description">{{ bar.description }}</textarea>
   </label>
-  <label for="short_description">Short Description
-    <textarea id="short_description" name="short_description">{{ bar.short_description or '' }}</textarea>
-  </label>
   {% if bar.photo_url %}
   <img src="{{ bar.photo_url }}" alt="{{ bar.name }} photo" style="max-width:200px;"/>
   {% endif %}
   <label for="photo">Photo
     <input id="photo" name="photo" type="file">
-  </label>
-  <label for="cover_image_url">Cover Image URL
-    <input id="cover_image_url" name="cover_image_url" value="{{ bar.cover_image_url or '' }}">
-  </label>
-  <label for="gallery_urls">Gallery URLs (comma separated)
-    <input id="gallery_urls" name="gallery_urls" value="{{ bar.gallery_urls or '' }}">
   </label>
   <label for="rating">Rating
     <input id="rating" name="rating" type="number" min="0" max="5" step="0.1" value="{{ bar.rating or 0 }}">
@@ -41,17 +32,11 @@
   <label for="is_open_now">
     <input id="is_open_now" name="is_open_now" type="checkbox" {% if bar.is_open_now %}checked{% endif %}> Open now
   </label>
-  <label for="price_level">Price Level
-    <input id="price_level" name="price_level" type="number" min="1" max="4" value="{{ bar.price_level or '' }}">
-  </label>
   <label for="promo_label">Promo Label
     <input id="promo_label" name="promo_label" value="{{ bar.promo_label or '' }}">
   </label>
   <label for="tags">Tags
-    <input id="tags" name="tags" value="{{ bar.tags or '' }}">
-  </label>
-  <label for="avg_prep_time_min">Avg Prep Time (min)
-    <input id="avg_prep_time_min" name="avg_prep_time_min" type="number" value="{{ bar.avg_prep_time_min or '' }}">
+    <input id="tags" name="tags" value="{{ tags_csv }}">
   </label>
   <input id="latitude" name="latitude" type="hidden" value="{{ bar.latitude }}">
   <input id="longitude" name="longitude" type="hidden" value="{{ bar.longitude }}">

--- a/templates/home.html
+++ b/templates/home.html
@@ -33,9 +33,8 @@
     <li>
       <a class="bar-card" href="/bars/{{ last_bar.id }}" aria-label="Apri {{ last_bar.name }}" data-name="{{ last_bar.name|lower }}" data-address="{{ last_bar.address|lower }}" data-city="{{ last_bar.city|lower }}" data-state="{{ last_bar.state|lower }}" data-latitude="{{ last_bar.latitude }}" data-longitude="{{ last_bar.longitude }}" data-rating="{{ last_bar.rating or '' }}" data-distance_km="{{ last_bar.distance_km or '' }}" data-categories="" data-open="{{ 'true' if last_bar.is_open_now else 'false' }}" itemscope itemtype="https://schema.org/BarOrPub">
         <div class="thumb-wrapper">
-        {% set img = last_bar.cover_image_url or last_bar.photo_url %}
-        {% if img %}
-        <img class="thumb" src="{{ img }}" alt="{{ last_bar.name }} photo" itemprop="image" loading="lazy" decoding="async" width="400" height="225" srcset="{{ img }} 400w, {{ img }} 800w" sizes="(max-width: 600px) 100vw, 400px" fetchpriority="high" onerror="this.src='{{ fallback_img }}';this.onerror=null;">
+        {% if last_bar.photo_url %}
+        <img class="thumb" src="{{ last_bar.photo_url }}" alt="{{ last_bar.name }} photo" itemprop="image" loading="lazy" decoding="async" width="400" height="225" srcset="{{ last_bar.photo_url }} 400w, {{ last_bar.photo_url }} 800w" sizes="(max-width: 600px) 100vw, 400px" fetchpriority="high" onerror="this.src='{{ fallback_img }}';this.onerror=null;">
         {% else %}
         <img class="thumb" src="{{ fallback_img }}" alt="" loading="lazy" width="400" height="225">
         {% endif %}
@@ -47,7 +46,7 @@
           {% if last_bar.rating %}<span class="bar-rating"><i class="bi bi-star-fill" aria-hidden="true"></i> {{ '%.1f'|format(last_bar.rating) }}</span>{% endif %}
         </div>
         <address>{{ last_bar.address }}, {{ last_bar.city }}, {{ last_bar.state }}</address>
-        <p class="desc">{{ last_bar.short_description or last_bar.description }}</p>
+        <p class="desc">{{ last_bar.description }}</p>
       </a>
     </li>
   </ul>
@@ -62,9 +61,8 @@
     <li>
       <a class="bar-card" href="/bars/{{ bar.id }}" aria-label="Apri {{ bar.name }}" data-name="{{ bar.name|lower }}" data-address="{{ bar.address|lower }}" data-city="{{ bar.city|lower }}" data-state="{{ bar.state|lower }}" data-latitude="{{ bar.latitude }}" data-longitude="{{ bar.longitude }}" data-rating="{{ bar.rating or '' }}" data-distance_km="{{ bar.distance_km or '' }}" data-categories="" data-open="{{ 'true' if bar.is_open_now else 'false' }}" itemscope itemtype="https://schema.org/BarOrPub">
         <div class="thumb-wrapper">
-        {% set img = bar.cover_image_url or bar.photo_url %}
-        {% if img %}
-        <img class="thumb" src="{{ img }}" alt="{{ bar.name }} photo" itemprop="image" loading="lazy" decoding="async" width="400" height="225" srcset="{{ img }} 400w, {{ img }} 800w" sizes="(max-width: 600px) 100vw, 400px" {% if not last_bar and loop.first %}fetchpriority="high"{% endif %} onerror="this.src='{{ fallback_img }}';this.onerror=null;">
+        {% if bar.photo_url %}
+        <img class="thumb" src="{{ bar.photo_url }}" alt="{{ bar.name }} photo" itemprop="image" loading="lazy" decoding="async" width="400" height="225" srcset="{{ bar.photo_url }} 400w, {{ bar.photo_url }} 800w" sizes="(max-width: 600px) 100vw, 400px" {% if not last_bar and loop.first %}fetchpriority="high"{% endif %} onerror="this.src='{{ fallback_img }}';this.onerror=null;">
         {% else %}
         <img class="thumb" src="{{ fallback_img }}" alt="" loading="lazy" width="400" height="225">
         {% endif %}
@@ -76,7 +74,7 @@
           {% if bar.rating %}<span class="bar-rating"><i class="bi bi-star-fill" aria-hidden="true"></i> {{ '%.1f'|format(bar.rating) }}</span>{% endif %}
         </div>
         <address>{{ bar.address }}, {{ bar.city }}, {{ bar.state }}</address>
-        <p class="desc">{{ bar.short_description or bar.description }}</p>
+        <p class="desc">{{ bar.description }}</p>
       </a>
     </li>
     {% endfor %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -29,10 +29,9 @@
       <div class="cards scroller" aria-label="{{ title }}" tabindex="0">
         {% for bar in bars %}
         <a class="bar-card" href="/bars/{{ bar.id }}" aria-label="Apri {{ bar.name }}" data-name="{{ bar.name|lower }}" data-address="{{ bar.address|lower }}" data-city="{{ bar.city|lower }}" data-state="{{ bar.state|lower }}" data-latitude="{{ bar.latitude }}" data-longitude="{{ bar.longitude }}" data-rating="{{ bar.rating or '' }}" data-distance_km="{{ bar.distance_km or '' }}" data-categories="{{ bar.categories.values() | map(attribute='name') | map('lower') | join(',') if bar.categories else '' }}" data-open="{{ 'true' if bar.is_open_now else 'false' }}" itemscope itemtype="https://schema.org/BarOrPub">
-        {% set img = bar.cover_image_url or bar.photo_url %}
-        {% if img %}
+        {% if bar.photo_url %}
           <div class="thumb-wrapper">
-          <img src="{{ img }}" alt="{{ bar.name }} photo" class="thumb" loading="lazy" decoding="async" width="400" height="225" srcset="{{ img }} 400w, {{ img }} 800w" sizes="(max-width: 600px) 100vw, 400px" onerror="this.src='{{ fallback_img }}';this.onerror=null;">
+          <img src="{{ bar.photo_url }}" alt="{{ bar.name }} photo" class="thumb" loading="lazy" decoding="async" width="400" height="225" srcset="{{ bar.photo_url }} 400w, {{ bar.photo_url }} 800w" sizes="(max-width: 600px) 100vw, 400px" onerror="this.src='{{ fallback_img }}';this.onerror=null;">
           </div>
         {% else %}
           <div class="thumb-wrapper">


### PR DESCRIPTION
## Summary
- drop unused bar fields like short description, cover image, gallery, price level, and average prep time
- keep rating, open status, promo label, and tags with cleaner admin editing
- update templates to use bar photos and descriptions without extra URLs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad9869cd8c83209e46415fb6f647ab