### PR TITLE
Honor timezone in bar opening-hour calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ The app will then be available at http://localhost:8000.
 
 This is a starting point for adding persistent storage and role-based features.
 
+## Timezone
+
+Opening hours are evaluated in the timezone specified by the
+`BAR_TIMEZONE` environment variable (or `TZ` if set). Ensure this variable
+matches your local timezone (e.g. `Europe/Rome`) so the "open now" status
+reflects your local time.
+
 ## API
 
 The application exposes minimal database-backed endpoints to illustrate

--- a/main.py
+++ b/main.py
@@ -36,6 +36,7 @@ import hashlib
 import json
 from typing import Dict, List, Optional
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 from fastapi import Depends, FastAPI, HTTPException, Request, status, UploadFile
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -433,8 +434,14 @@ def slugify(value: str) -> str:
 
 
 def is_open_now_from_hours(hours: Dict[str, Dict[str, str]]) -> bool:
-    """Determine if a bar should be open now based on its hours dict."""
-    now = datetime.now()
+    """Determine if a bar should be open now based on its hours dict.
+
+    The current time is evaluated in the timezone specified by the
+    ``BAR_TIMEZONE`` environment variable (falling back to ``TZ`` if set).
+    If neither variable is defined the server's local timezone is used.
+    """
+    tz_name = os.getenv("BAR_TIMEZONE") or os.getenv("TZ")
+    now = datetime.now(ZoneInfo(tz_name)) if tz_name else datetime.now()
     day = str(now.weekday())
     info = hours.get(day)
     if not info:

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -1,0 +1,37 @@
+import os
+import pathlib
+import sys
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import main
+
+
+def test_is_open_now_respects_timezone(monkeypatch):
+    hours = {"0": {"open": "14:00", "close": "15:30"}}
+    monkeypatch.setenv("BAR_TIMEZONE", "Europe/Rome")
+    tz = ZoneInfo("Europe/Rome")
+
+    class FakeDatetime(datetime):
+        tz_used = None
+
+        @classmethod
+        def now(cls, tz=None):
+            cls.tz_used = tz
+            return cls(2024, 1, 1, 14, 30, tzinfo=tz)
+
+    monkeypatch.setattr(main, "datetime", FakeDatetime)
+    assert main.is_open_now_from_hours(hours)
+    assert FakeDatetime.tz_used == tz
+
+    class FakeDatetimeClosed(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2024, 1, 1, 16, 0, tzinfo=tz)
+
+    monkeypatch.setattr(main, "datetime", FakeDatetimeClosed)
+    assert not main.is_open_now_from_hours(hours)


### PR DESCRIPTION
## Summary
- evaluate bar open/closed state using timezone from `BAR_TIMEZONE`/`TZ`
- document timezone configuration in README
- test opening-hour logic with timezone awareness

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ada49044188320b4161fa37b9b3103