### PR TITLE
Fix top-rated bar distance filtering

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -157,7 +157,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       }
       const topBars = bars.filter(b => b.el.closest('[data-section="top"]'));
       topBars.forEach(b => {
-        if (b.distance_km != null && b.distance_km > 5) {
+        if (b.distance_km == null || b.distance_km > 5) {
           b.el.remove();
         }
       });


### PR DESCRIPTION
## Summary
- Hide "top" bars lacking distance data or beyond 5 km

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aea92f420c8320972d5aa6a7190cc2