### PR TITLE
Fix nearby bar ordering

### DIFF
--- a/main.py
+++ b/main.py
@@ -749,6 +749,8 @@ async def search_bars(
         top_bars_message = None
         if not top_bars:
             top_bars_message = "Non ci sono bar nelle tue vicinanze."
+        # Sort search results by proximity when location is provided
+        results.sort(key=lambda b: (b.distance_km is None, b.distance_km))
     else:
         rated = [b for b in results if b.rating is not None]
         rated.sort(key=lambda b: -b.rating)
@@ -758,6 +760,8 @@ async def search_bars(
             others.sort(key=lambda b: (b.name or ""))
             top_bars.extend(others[: 5 - len(top_bars)])
         top_bars_message = None
+        # Default to alphabetical order when distance is unavailable
+        results.sort(key=lambda b: (b.name or "").lower())
 
     return render_template(
         "search.html",

--- a/tests/test_nearby_bars_order.py
+++ b/tests/test_nearby_bars_order.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import pathlib
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, SessionLocal, engine  # noqa: E402
+from models import Bar  # noqa: E402
+from main import app  # noqa: E402
+
+
+def reset_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def extract_nearby_section(html: str) -> str:
+    return html.split("I più vicini a te", 1)[1].split("I più votati", 1)[0]
+
+
+def test_nearby_bars_sorted_by_distance():
+    reset_db()
+    db = SessionLocal()
+    bars = [
+        Bar(name="Far", slug="far", latitude=0.1, longitude=0.0),
+        Bar(name="Near", slug="near", latitude=0.01, longitude=0.0),
+        Bar(name="NoLoc", slug="noloc"),
+    ]
+    db.add_all(bars)
+    db.commit()
+    for b in bars:
+        db.refresh(b)
+    db.close()
+
+    with TestClient(app) as client:
+        resp = client.get("/search?lat=0&lng=0")
+        assert resp.status_code == 200
+        section = extract_nearby_section(resp.text)
+        assert "Near" in section and "Far" in section and "NoLoc" in section
+        assert section.index("Near") < section.index("Far") < section.index("NoLoc")


### PR DESCRIPTION
## Summary
- sort search results by distance when user location provided
- default to alphabetical ordering without location
- test ordering of nearby bars

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aeb1ec80c88320b893a434f887498d