### PR TITLE
Fix sorting for nearby bars on browse page

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -141,44 +141,55 @@ document.addEventListener('DOMContentLoaded', async () => {
     is_recent: el.closest('[data-section="recent"]') !== null
   }));
   validateBars(rawBars);
-    let userLoc = null;
-    let bars = await normalizeBars(rawBars, userLoc);
+  let userLoc = null;
+  let bars = await normalizeBars(rawBars, userLoc);
 
-    bars.forEach(b => renderMeta(b.el, b));
+  function sortNearby() {
+    const container = document.querySelector('.bar-section[data-section="nearby"] .cards');
+    if (!container) return;
+    const nearbyBars = bars
+      .filter(b => b.el.closest('[data-section="nearby"]'))
+      .sort((a, b) => (a.distance_km ?? Infinity) - (b.distance_km ?? Infinity));
+    nearbyBars.forEach(b => container.appendChild(b.el));
+  }
 
-    const topSection = document.querySelector('.bar-section[data-section="top"]');
+  bars.forEach(b => renderMeta(b.el, b));
+  sortNearby();
 
-    async function filterTopByDistance(pos) {
-      if (!topSection) return;
-      if (pos) {
-        userLoc = { lat: pos.coords.latitude, lng: pos.coords.longitude };
-        bars = await normalizeBars(rawBars, userLoc);
-        bars.forEach(b => renderMeta(b.el, b));
-      }
-      const topBars = bars.filter(b => b.el.closest('[data-section="top"]'));
-      topBars.forEach(b => {
-        if (b.distance_km == null || b.distance_km > 5) {
-          b.el.remove();
-        }
-      });
-      if (!topSection.querySelector('.bar-card')) {
-        const msg = document.createElement('p');
-        msg.textContent = 'Non ci sono bar nelle tue vicinanze.';
-        topSection.appendChild(msg);
-      }
-      bars = bars.filter(b => document.body.contains(b.el));
+  const topSection = document.querySelector('.bar-section[data-section="top"]');
+
+  async function filterTopByDistance(pos) {
+    if (!topSection) return;
+    if (pos) {
+      userLoc = { lat: pos.coords.latitude, lng: pos.coords.longitude };
+      bars = await normalizeBars(rawBars, userLoc);
+      bars.forEach(b => renderMeta(b.el, b));
+      sortNearby();
     }
-
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(filterTopByDistance, () => filterTopByDistance());
-    } else {
-      filterTopByDistance();
-    }
-
-    if (distanceInput && bars.every(b => b.distance_km == null)) {
-      distanceInput.disabled = true;
+    const topBars = bars.filter(b => b.el.closest('[data-section="top"]'));
+    topBars.forEach(b => {
+      if (b.distance_km == null || b.distance_km > 5) {
+        b.el.remove();
+      }
+    });
+    if (!topSection.querySelector('.bar-card')) {
       const msg = document.createElement('p');
-      msg.className = 'help';
+      msg.textContent = 'Non ci sono bar nelle tue vicinanze.';
+      topSection.appendChild(msg);
+    }
+    bars = bars.filter(b => document.body.contains(b.el));
+  }
+
+  if (navigator.geolocation) {
+    navigator.geolocation.getCurrentPosition(filterTopByDistance, () => filterTopByDistance());
+  } else {
+    filterTopByDistance();
+  }
+
+  if (distanceInput && bars.every(b => b.distance_km == null)) {
+    distanceInput.disabled = true;
+    const msg = document.createElement('p');
+    msg.className = 'help';
     msg.textContent = 'Nessuna distanza disponibile per questi risultati.';
     distanceInput.closest('.group')?.appendChild(msg);
   }


### PR DESCRIPTION
## Summary
- ensure Browse Bars page orders nearby bars by distance
- update JS to recompute and sort when geolocation is available

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeb50b8c8c832090ee22492f52010f