### PR TITLE
Ensure recommended bars are open and nearby

### DIFF
--- a/main.py
+++ b/main.py
@@ -726,15 +726,17 @@ async def search_bars(
         or term in (bar.city or "").lower()
         or term in (bar.state or "").lower()
     ]
-    # Determine a random selection of bars within 20km for the "Consigliati" section.
+    # Determine a random selection of open bars within 20km for the "Consigliati" section.
     if lat is not None and lng is not None:
         nearby_pool = [
             b
             for b in db_bars
-            if b.distance_km is not None and b.distance_km <= 20
+            if b.is_open_now
+            and b.distance_km is not None
+            and b.distance_km <= 20
         ]
     else:
-        nearby_pool = list(db_bars)
+        nearby_pool = [b for b in db_bars if b.is_open_now]
     recommended_bars = random.sample(nearby_pool, min(5, len(nearby_pool)))
     if lat is not None and lng is not None:
         rated_within = [

--- a/tests/test_recommended_bars.py
+++ b/tests/test_recommended_bars.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import json
+import pathlib
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, SessionLocal, engine  # noqa: E402
+from models import Bar  # noqa: E402
+from main import app  # noqa: E402
+
+
+def reset_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def extract_recommended_section(html: str) -> str:
+    return html.split("Consigliati", 1)[1]
+
+
+def test_recommended_only_open_within_20km():
+    reset_db()
+    db = SessionLocal()
+    hours = json.dumps({str(i): {"open": "00:00", "close": "23:59"} for i in range(7)})
+    bars = [
+        Bar(name="NearOpenA", slug="near-open-a", latitude=0.05, longitude=0.0, opening_hours=hours),
+        Bar(name="NearOpenB", slug="near-open-b", latitude=0.02, longitude=0.0, opening_hours=hours),
+        Bar(name="FarOpen", slug="far-open", latitude=0.25, longitude=0.0, opening_hours=hours),
+        Bar(
+            name="NearClosed",
+            slug="near-closed",
+            latitude=0.01,
+            longitude=0.0,
+            opening_hours=hours,
+            manual_closed=True,
+        ),
+    ]
+    db.add_all(bars)
+    db.commit()
+    for b in bars:
+        db.refresh(b)
+    db.close()
+
+    with TestClient(app) as client:
+        resp = client.get("/search?lat=0&lng=0")
+        assert resp.status_code == 200
+        section = extract_recommended_section(resp.text)
+        assert "NearOpenA" in section
+        assert "NearOpenB" in section
+        assert "FarOpen" not in section
+        assert "NearClosed" not in section
+


### PR DESCRIPTION
## Summary
- Show only open bars within 20km in the "Consigliati" list
- Test recommended bar selection for distance and open status

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeb7bc30608320a2186bd68d192fda