### PR TITLE
Show bar city instead of street in cards

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -51,7 +51,7 @@
           {% if bar.rating %}<span class="bar-rating"><i class="bi bi-star-fill" aria-hidden="true"></i> {{ '%.1f'|format(bar.rating) }}</span>{% endif %}
           <span class="bar-distance" data-has-distance="true" hidden></span>
         </div>
-        <address>{{ bar.address }}, {{ bar.city }}, {{ bar.state }}</address>
+        <address>{{ bar.city }}{% if bar.state %}, {{ bar.state }}{% endif %}</address>
         <p class="desc">{{ bar.description }}</p>
       </a>
     </li>
@@ -85,7 +85,7 @@
           {% if bar.rating %}<span class="bar-rating"><i class="bi bi-star-fill" aria-hidden="true"></i> {{ '%.1f'|format(bar.rating) }}</span>{% endif %}
           <span class="bar-distance" data-has-distance="true" hidden></span>
         </div>
-        <address>{{ bar.address }}, {{ bar.city }}, {{ bar.state }}</address>
+        <address>{{ bar.city }}{% if bar.state %}, {{ bar.state }}{% endif %}</address>
         <p class="desc">{{ bar.description }}</p>
       </a>
     </li>

--- a/templates/search.html
+++ b/templates/search.html
@@ -55,7 +55,7 @@
               <span class="bar-rating" data-has-rating="true" hidden></span>
               <span class="bar-distance" data-has-distance="true" hidden></span>
             </div>
-            {% if bar.address_short or bar.address %}<address>{{ bar.address_short or bar.address }}</address>{% endif %}
+            {% if bar.city %}<address>{{ bar.city }}{% if bar.state %}, {{ bar.state }}{% endif %}</address>{% endif %}
             {% if bar.description_short or bar.description %}<p class="desc">{{ bar.description_short or bar.description }}</p>{% endif %}
           </a>
           {% endfor %}


### PR DESCRIPTION
## Summary
- show bar city (and optional state) on home bar cards
- display city/state instead of street on browse/search bar cards

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aebcc3bf148320a914cf7e033e6aaa