### PR TITLE
refactor: premium header and menu

### DIFF
--- a/static/css/components.css
+++ b/static/css/components.css
@@ -25,9 +25,9 @@ body.dark-mode{
 
 .visually-hidden{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0;}
 
-.site-header{position:sticky;top:0;z-index:50;background:var(--bg);padding:12px 16px;box-shadow:0 2px 6px rgba(0,0,0,.04);}
+.site-header{position:sticky;top:0;z-index:50;background:var(--bg);padding:12px 16px;min-height:56px;box-shadow:var(--sg-shadow-md);transition:padding .2s var(--ease),box-shadow .2s var(--ease);}
 .site-header::after{content:"";position:absolute;left:0;right:0;bottom:0;height:2px;background:linear-gradient(to right,var(--sg-purple-700),transparent);}
-.site-header.is-scrolled{padding:8px 16px;box-shadow:0 4px 12px rgba(0,0,0,.08);}
+.site-header.is-scrolled{padding:8px 16px;box-shadow:0 8px 24px rgba(16,12,40,.12);} /* stronger shadow on scroll */
 .mobile-header,.navbar{display:flex;align-items:center;justify-content:space-between;}
 .mobile-header{height:56px;}
 .navbar{gap:var(--space-2);padding:0;}
@@ -37,10 +37,10 @@ body.dark-mode{
 .nav-right{gap:var(--space-3);}
 
 .theme-toggle{background:none;border:0;padding:var(--space-1);cursor:pointer;font-size:1.25rem;color:var(--text);transition:color .2s;min-width:44px;min-height:44px;}
-.nav-toggle{background:none;border:0;display:flex;align-items:center;justify-content:center;min-width:44px;min-height:44px;color:var(--text);transition:color .2s;}
-.nav-toggle:hover{color:var(--brand);}
-.hamburger{display:flex;flex-direction:column;gap:4px;background:none;border:0;padding:var(--space-1);cursor:pointer;min-width:32px;min-height:32px;}
-.hamburger span{width:24px;height:2px;background:var(--text);}
+.nav-toggle{background:none;border:0;display:flex;align-items:center;justify-content:center;min-width:44px;min-height:44px;color:var(--text);transition:color .2s;font-size:1.5rem;}
+.nav-toggle:hover{color:var(--sg-purple-700);}
+.hamburger{display:none;}
+.hamburger span{display:none;}
 
 .menu{position:absolute;top:100%;right:var(--space-3);background:var(--surface);border-radius:var(--radius);padding:var(--space-3);box-shadow:var(--shadow);display:none;flex-direction:column;gap:var(--space-2);}
 .menu a{color:var(--text);text-decoration:none;min-height:44px;display:flex;align-items:center;padding:0 var(--space-2);}
@@ -51,17 +51,17 @@ body.dark-mode{
 
   .logo{font-weight:600;color:var(--text);text-decoration:none;font-size:1.25rem;display:inline-flex;align-items:center;min-width:44px;min-height:44px;}
   .cart{display:flex;flex-direction:column;align-items:center;justify-content:center;text-decoration:none;color:var(--text);min-width:44px;min-height:44px;}
-  .cart-icon{position:relative;display:inline-flex;align-items:center;justify-content:center;min-width:44px;min-height:44px;text-decoration:none;color:var(--text);overflow:visible;transition:color .2s;}
-  .cart-icon:hover{color:var(--brand);}
-  .cart-icon svg{transform:scale(1);transform-origin:center;}
-  .cart-badge{position:absolute;top:4px;right:4px;min-width:16px;height:16px;border-radius:999px;display:flex;align-items:center;justify-content:center;font-size:11px;background:rgba(167,139,250,.2);color:var(--brand);padding:0 4px;font-weight:700;}
-  .credit-pill{padding:4px 8px;border-radius:999px;background:rgba(167,139,250,.2);font-weight:700;white-space:nowrap;font-size:clamp(12px,3vw,14px);min-height:32px;display:inline-flex;align-items:center;color:var(--brand);}
+  .cart-icon{position:relative;display:inline-flex;align-items:center;justify-content:center;min-width:44px;min-height:44px;text-decoration:none;color:var(--text);overflow:visible;transition:color .2s;font-size:1.5rem;}
+  .cart-icon:hover{color:var(--sg-purple-700);}
+  .cart-badge{position:absolute;top:4px;right:4px;min-width:16px;height:16px;border-radius:999px;display:flex;align-items:center;justify-content:center;font-size:11px;background:rgba(91,33,182,.15);color:var(--sg-ink-900);padding:0 4px;font-weight:700;}
+  .credit-pill{padding:4px 8px;border-radius:999px;background:rgba(91,33,182,.15);font-weight:700;white-space:nowrap;font-size:clamp(12px,3vw,14px);min-height:32px;display:inline-flex;align-items:center;color:var(--sg-purple-700);}
   .cart-emoji{font-size:1.25rem;}
   .cart-count{font-size:.75rem;margin-top:2px;}
 .avatar{border-radius:50%;background:var(--surface);color:var(--text);border:0;width:32px;height:32px;}
 
-.hero{position:relative;color:var(--sg-ink-900);display:flex;align-items:center;min-height:60vh;background:linear-gradient(135deg,var(--sg-gray-25),#fff);overflow:hidden;}
-.hero::before{content:"";position:absolute;top:0;left:0;right:0;bottom:0;background:radial-gradient(circle at 40% 40%,rgba(167,139,250,.3),transparent 70%);} 
+/* light purple hero */
+.hero{position:relative;color:var(--sg-ink-900);display:flex;align-items:center;min-height:60vh;background:linear-gradient(135deg,rgba(167,139,250,.04),#fff);overflow:hidden;}
+.hero::before{content:"";position:absolute;top:0;left:0;right:0;bottom:0;background:radial-gradient(circle at 40% 40%,rgba(167,139,250,.2),transparent 70%);}
 .hero__content{position:relative;z-index:1;padding-block:var(--space-4);max-width:640px;}
 .hero__content h1{font-size:clamp(32px,5vw,36px);line-height:1.15;margin-bottom:var(--space-2);}
 .hero__content p{color:var(--color-muted);}
@@ -85,8 +85,9 @@ body.dark-mode{
 .card__title{font-size:1.125rem;margin:0;}
 
 .chips{display:flex;gap:var(--space-1);flex-wrap:wrap;margin:var(--space-1) 0;padding:0;list-style:none;}
-.chip{display:inline-block;background:rgba(167,139,250,.2);color:var(--sg-ink-900);font-size:.8rem;padding:.25rem .75rem;border-radius:999px;transition:background .2s,color .2s;}
-.chip:hover{background:rgba(167,139,250,.3);}
+/* purple tinted chips */
+.chip{display:inline-block;background:rgba(91,33,182,.08);color:var(--sg-ink-900);font-size:.8rem;padding:.25rem .75rem;border-radius:999px;transition:background .2s,color .2s;}
+.chip:hover{background:rgba(91,33,182,.15);}
 .chip.active{background:var(--sg-purple-700);color:#fff;}
 .nav-right .chip{min-height:44px;display:inline-flex;align-items:center;padding:0 var(--space-2);}
 
@@ -224,14 +225,17 @@ body.dark-mode{
     .hdr-sub{display:flex;align-items:center;justify-content:space-between;padding:8px 12px;}
     .location-pill{flex:1;padding:10px 12px;border-radius:999px;border:1px solid #e5e7eb;text-align:left;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;margin-right:8px;font-size:clamp(14px,3.8vw,16px);background:transparent;}
     .btn-icon{width:32px;height:32px;display:grid;place-items:center;background:transparent;border:0;}
-    .mobile-menu{position:absolute;top:100%;left:12px;right:12px;background:var(--bg);border-radius:0 0 var(--sg-radius-xl) var(--sg-radius-xl);box-shadow:var(--sg-shadow-md);padding:8px;display:flex;flex-direction:column;gap:4px;z-index:1001;opacity:0;transform:translateY(-6px);transition:transform .2s var(--ease),opacity .2s var(--ease);}
+    /* premium mobile menu */
+    .mobile-menu{position:absolute;top:100%;right:12px;width:85%;max-width:320px;background:rgba(167,139,250,.05);backdrop-filter:blur(8px);border-radius:var(--sg-radius-xl);box-shadow:var(--sg-shadow-md);padding:12px;display:flex;flex-direction:column;gap:4px;z-index:1001;opacity:0;transform:translateY(-6px);transition:transform .22s var(--ease),opacity .22s var(--ease);}
     .mobile-menu[hidden]{display:none;}
     .mobile-menu.open{opacity:1;transform:translateY(0);}
-    .mobile-menu a{display:flex;align-items:center;gap:8px;padding:8px;border-radius:8px;text-decoration:none;color:var(--text);min-height:44px;}
-    .mobile-menu a:hover{background:rgba(167,139,250,.1);}
-    .menu-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.3);backdrop-filter:blur(2px);opacity:0;transition:opacity .2s var(--ease);}
-    .menu-backdrop.show{opacity:1;}
-    .menu-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.4);backdrop-filter:blur(2px);z-index:1000;opacity:0;transition:opacity .18s ease;}
+    .mobile-menu a{display:flex;align-items:center;gap:8px;padding:8px 12px;border-radius:8px;text-decoration:none;color:var(--text);min-height:44px;transition:background .2s var(--ease);}
+    .mobile-menu a:hover{background:rgba(91,33,182,.1);}
+    .menu-close{align-self:flex-end;background:none;border:0;color:var(--text);min-width:44px;min-height:44px;font-size:1.25rem;}
+    .menu-login:hover{text-decoration:underline;}
+    .menu-register{border:1px solid var(--sg-purple-700);border-radius:999px;margin-top:4px;text-align:center;}
+    .menu-register:hover{background:var(--sg-purple-600);color:#fff;}
+    .menu-backdrop{position:fixed;inset:0;background:rgba(167,139,250,.05);backdrop-filter:blur(8px);z-index:1000;opacity:0;transition:opacity .22s var(--ease);}
     .menu-backdrop[hidden]{display:none;}
     .menu-backdrop.show{opacity:1;}
     main{scroll-margin-top:60px;}

--- a/templates/home.html
+++ b/templates/home.html
@@ -7,6 +7,8 @@
     <p>Skip the wait. Discover nearby bars and order with one tap.</p>
     <div class="hero__cta">
       <a class="btn btn--primary" href="#bars">Browse Bars</a>
+      <!-- optional search trigger -->
+      <a class="btn" href="/search">Search</a>
       <a class="btn" href="#how">How it works</a>
     </div>
   </div>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -29,95 +29,74 @@
 </head>
 <body>
   <header class="site-header" role="banner">
-    <div class="mobile-header">
-      <button class="nav-toggle js-open-menu" aria-label="Menu" aria-controls="mobileMenu" aria-expanded="false">
-        <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
-          <path fill-rule="evenodd" d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5m0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5m0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5"/>
-        </svg>
-      </button>
-      <a class="hdr-logo" href="/">SiplyGo</a>
-      <div class="hdr-actions">
-        {% if user %}
-        <a class="credit-pill" href="/wallet" aria-label="Credits">CHF {{ "%.2f"|format(user.credit) }}</a>
-        {% endif %}
-        <a class="cart-icon" href="/cart" aria-label="Cart">
-          <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
-            <path d="M0 1.5A.5.5 0 0 1 .5 1H2a.5.5 0 0 1 .485.379L2.89 3H14.5a.5.5 0 0 1 .491.592l-1.5 8A.5.5 0 0 1 13 12H4a.5.5 0 0 1-.491-.408L2.01 3.607 1.61 2H.5a.5.5 0 0 1-.5-.5M3.102 4l1.313 7h8.17l1.313-7zM5 12a2 2 0 1 0 0 4 2 2 0 0 0 0-4m7 0a2 2 0 1 0 0 4 2 2 0 0 0 0-4m-7 1a1 1 0 1 1 0 2 1 1 0 0 1 0-2m7 0a1 1 0 1 1 0 2 1 1 0 0 1 0-2"/>
-          </svg>
-          <span class="cart-badge" aria-live="polite">{% if cart_count %}{{ cart_count }}{% else %}0{% endif %}</span>
-        </a>
-      </div>
-    </div>
-    <nav aria-label="Primary" class="navbar desktop-nav">
-      <div class="nav-left">
-        <a class="logo" href="/">SiplyGo</a>
-        {% if not user %}
-        <a class="btn" href="/login">Login</a>
-        <a class="btn" href="/register">Register</a>
-        {% endif %}
-      </div>
-      <div class="top-controls">
-        <div class="location-selector desktop-location">
-          <span class="location-icon">📍</span>
-          <input type="search" id="locationInputDesktop" class="location-display" value="Detecting location..." placeholder="Enter city or ZIP" aria-label="Current location" list="citySuggestionsDesktop" inputmode="search" autocomplete="postal-code" enterkeyhint="search">
-          <datalist id="citySuggestionsDesktop">
-            <option value="Lugano"></option>
-            <option value="Locarno"></option>
-            <option value="Zurich"></option>
-          </datalist>
+      <div class="mobile-header">
+        <!-- Premium hamburger trigger -->
+        <button class="nav-toggle js-open-menu" aria-label="Menu" aria-controls="mobileMenu" aria-expanded="false">
+          <i class="bi bi-list" aria-hidden="true"></i>
+        </button>
+        <a class="hdr-logo" href="/">SiplyGo</a>
+        <div class="hdr-actions">
+          {% if user %}
+          <a class="credit-pill" href="/wallet" aria-label="Credits">CHF {{ "%.2f"|format(user.credit) }}</a>
+          {% endif %}
+          <a class="cart-icon" href="/cart" aria-label="Cart">
+            <i class="bi bi-cart2" aria-hidden="true"></i>
+            <span class="cart-badge" aria-live="polite">{% if cart_count %}{{ cart_count }}{% else %}0{% endif %}</span>
+          </a>
         </div>
-        <input type="search" id="barSearchDesktop" class="desktop-search" placeholder="Search bars..." aria-label="Search bars" inputmode="search" autocomplete="off" enterkeyhint="search">
-        <div id="searchSuggestionsDesktop" class="search-suggestions"></div>
       </div>
+      <nav aria-label="Primary" class="navbar desktop-nav">
+        <div class="nav-left">
+          <a class="logo" href="/">SiplyGo</a>
+        </div>
+        <!-- Search and location kept for JS but visually hidden -->
+        <div class="top-controls" hidden>
+          <div class="location-selector desktop-location">
+            <span class="location-icon">📍</span>
+            <input type="search" id="locationInputDesktop" class="location-display" value="Detecting location..." placeholder="Enter city or ZIP" aria-label="Current location" list="citySuggestionsDesktop" inputmode="search" autocomplete="postal-code" enterkeyhint="search">
+            <datalist id="citySuggestionsDesktop">
+              <option value="Lugano"></option>
+              <option value="Locarno"></option>
+              <option value="Zurich"></option>
+            </datalist>
+          </div>
+          <input type="search" id="barSearchDesktop" class="desktop-search" placeholder="Search bars..." aria-label="Search bars" inputmode="search" autocomplete="off" enterkeyhint="search">
+          <div id="searchSuggestionsDesktop" class="search-suggestions"></div>
+        </div>
         <div class="nav-right">
+          {% if not user %}
+          <a class="btn" href="/login">Login</a>
+          <a class="btn" href="/register">Register</a>
+          {% endif %}
           {% if user %}
           <a class="credit-pill desktop-credit" href="/wallet" aria-label="Credits">CHF {{ "%.2f"|format(user.credit) }}</a>
           {% endif %}
           <a class="cart-icon" href="/cart" aria-label="Cart ({% if cart_count %}{{ cart_count }}{% else %}0{% endif %} items)">
-            <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
-              <path d="M0 1.5A.5.5 0 0 1 .5 1H2a.5.5 0 0 1 .485.379L2.89 3H14.5a.5.5 0 0 1 .491.592l-1.5 8A.5.5 0 0 1 13 12H4a.5.5 0 0 1-.491-.408L2.01 3.607 1.61 2H.5a.5.5 0 0 1-.5-.5M3.102 4l1.313 7h8.17l1.313-7zM5 12a2 2 0 1 0 0 4 2 2 0 0 0 0-4m7 0a2 2 0 1 0 0 4 2 2 0 0 0 0-4m-7 1a1 1 0 1 1 0 2 1 1 0 0 1 0-2m7 0a1 1 0 1 1 0 2 1 1 0 0 1 0-2"/>
-            </svg>
+            <i class="bi bi-cart2" aria-hidden="true"></i>
             <span class="cart-badge" aria-live="polite">{% if cart_count %}{{ cart_count }}{% else %}0{% endif %}</span>
           </a>
           <button id="themeToggle" class="theme-toggle js-theme-toggle" aria-label="Toggle theme">🌙</button>
-          <button class="hamburger js-open-menu" aria-label="Menu" aria-expanded="false" aria-controls="mobileMenu">
-            <span></span><span></span><span></span>
+          <!-- Desktop hamburger mirrors mobile trigger -->
+          <button class="nav-toggle js-open-menu" aria-label="Menu" aria-controls="mobileMenu" aria-expanded="false">
+            <i class="bi bi-list" aria-hidden="true"></i>
           </button>
         </div>
-    </nav>
-    <nav id="mobileMenu" class="mobile-menu" aria-label="Mobile menu" hidden role="menu">
-      <a href="/search" role="menuitem">
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
-          <path d="M12.166 8.94c-.524 1.062-1.234 2.12-1.96 3.07A32 32 0 0 1 8 14.58a32 32 0 0 1-2.206-2.57c-.726-.95-1.436-2.008-1.96-3.07C3.304 7.867 3 6.862 3 6a5 5 0 0 1 10 0c0 .862-.305 1.867-.834 2.94M8 16s6-5.686 6-10A6 6 0 0 0 2 6c0 4.314 6 10 6 10"/>
-          <path d="M8 8a2 2 0 1 1 0-4 2 2 0 0 1 0 4m0 1a3 3 0 1 0 0-6 3 3 0 0 0 0 6"/>
-        </svg>
-        <span>Browse Bars</span>
-      </a>
-      {% if user and (user.is_super_admin or user.is_bar_admin or user.is_bartender) %}
-      <a href="/dashboard" role="menuitem">
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
-          <path d="M8 4a.5.5 0 0 1 .5.5V6a.5.5 0 0 1-1 0V4.5A.5.5 0 0 1 8 4M3.732 5.732a.5.5 0 0 1 .707 0l.915.914a.5.5 0 1 1-.708.708l-.914-.915a.5.5 0 0 1 0-.707M2 10a.5.5 0 0 1 .5-.5h1.586a.5.5 0 0 1 0 1H2.5A.5.5 0 0 1 2 10m9.5 0a.5.5 0 0 1 .5-.5h1.5a.5.5 0 0 1 0 1H12a.5.5 0 0 1-.5-.5m.754-4.246a.39.39 0 0 0-.527-.02L7.547 9.31a.91.91 0 1 0 1.302 1.258l3.434-4.297a.39.39 0 0 0-.029-.518z"/>
-          <path fill-rule="evenodd" d="M0 10a8 8 0 1 1 15.547 2.661c-.442 1.253-1.845 1.602-2.932 1.25C11.309 13.488 9.475 13 8 13c-1.474 0-3.31.488-4.615.911-1.087.352-2.49.003-2.932-1.25A8 8 0 0 1 0 10m8-7a7 7 0 0 0-6.603 9.329c.203.575.923.876 1.68.63C4.397 12.533 6.358 12 8 12s3.604.532 4.923.96c.757.245 1.477-.056 1.68-.631A7 7 0 0 0 8 3"/>
-        </svg>
-        <span>Dashboard</span>
-      </a>
-      {% endif %}
-      {% if user %}
-      <a href="/wallet" role="menuitem">
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
-          <path d="M12.136.326A1.5 1.5 0 0 1 14 1.78V3h.5A1.5 1.5 0 0 1 16 4.5v9a1.5 1.5 0 0 1-1.5 1.5h-13A1.5 1.5 0 0 1 0 13.5v-9A1.5 1.5 0 0 1 1.432 2.5zM5.562 3H13V1.78a.5.5 0 0 0-.621-.484zM1.5 4a.5.5 0 0 0-.5.5v9a.5.5 0 0 0 .5.5h13a.5.5 0 0 0 .5-.5v-9a.5.5 0 0 0-.5-.5z"/>
-        </svg>
-        <span>Wallet</span>
-      </a>
-      <a href="/logout" role="menuitem">
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
-          <path fill-rule="evenodd" d="M10 12.5a.5.5 0 0 1-.5.5h-8a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5h8a.5.5 0 0 1 .5.5v2a.5.5 0 0 0 1 0v-2A1.5 1.5 0 0 0 9.5 2h-8A1.5 1.5 0 0 0 0 3.5v9A1.5 1.5 0 0 0 1.5 14h8a1.5 1.5 0 0 0 1.5-1.5v-2a.5.5 0 0 0-1 0z"/>
-          <path fill-rule="evenodd" d="M15.854 8.354a.5.5 0 0 0 0-.708l-3-3a.5.5 0 0 0-.708.708L14.293 7.5H5.5a.5.5 0 0 0 0 1h8.793l-2.147 2.146a.5.5 0 0 0 .708.708z"/>
-        </svg>
-        <span>Logout</span>
-      </a>
-      {% endif %}
-    </nav>
+      </nav>
+      <nav id="mobileMenu" class="mobile-menu" aria-label="Mobile menu" hidden role="menu">
+        <button class="menu-close js-close-menu" aria-label="Close menu"><i class="bi bi-x" aria-hidden="true"></i></button>
+        <a href="/search" role="menuitem"><i class="bi bi-geo-alt" aria-hidden="true"></i><span>Browse Bars</span></a>
+        <a href="#how" role="menuitem"><i class="bi bi-stars" aria-hidden="true"></i><span>How it works</span></a>
+        {% if user and (user.is_super_admin or user.is_bar_admin or user.is_bartender) %}
+        <a href="/dashboard" role="menuitem"><i class="bi bi-speedometer2" aria-hidden="true"></i><span>Dashboard</span></a>
+        {% endif %}
+        {% if user %}
+        <a href="/wallet" role="menuitem"><i class="bi bi-wallet2" aria-hidden="true"></i><span>Wallet</span></a>
+        <a href="/logout" role="menuitem"><i class="bi bi-box-arrow-right" aria-hidden="true"></i><span>Logout</span></a>
+        {% else %}
+        <a href="/login" role="menuitem" class="menu-login"><i class="bi bi-box-arrow-in-right" aria-hidden="true"></i><span>Login</span></a>
+        <a href="/register" role="menuitem" class="menu-register"><i class="bi bi-person-plus" aria-hidden="true"></i><span>Register</span></a>
+        {% endif %}
+      </nav>
     <div class="menu-backdrop" hidden></div>
   </header>
   <div class="hdr-sub">


### PR DESCRIPTION
## Summary
- modernize header with purple theming and hidden desktop search
- add login/register items and polished premium mobile menu
- tint hero and chips, add optional search CTA on homepage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aed2181f3083209f19ec4e25981315