### PR TITLE
Allow bar descriptions to wrap lines

### DIFF
--- a/static/css/components.css
+++ b/static/css/components.css
@@ -294,7 +294,7 @@ body.dark-mode{
 .bar-meta .bar-distance{color:var(--muted);}
 .bar-card,.bar-card:focus,.bar-card:hover{text-decoration:none;}
 .bar-card address{font-style:normal;font-size:13px;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;margin:0;}
-.bar-card .desc{font-size:13px;color:var(--muted);margin:0;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;overflow:hidden;}
+.bar-card .desc{font-size:13px;color:var(--muted);margin:0;white-space:pre-line;}
 .bar-card:focus-visible{outline:2px solid var(--sg-focus);outline-offset:3px;}
 .status-open::before{content:"";display:inline-block;width:8px;height:8px;border-radius:50%;background:#10B981;margin-right:4px;}
 .bar-card.featured::before{content:"";position:absolute;top:0;left:0;right:0;height:3px;background:var(--sg-purple-700);border-radius:var(--sg-card-radius) var(--sg-card-radius) 0 0;}


### PR DESCRIPTION
## Summary
- Allow bar descriptions to show line breaks by preserving whitespace in bar cards

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af32f353248320b0927d0c4c8435ed