### PR TITLE
Add view-all bars page and remove search filters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,4 @@
 - Mobile card styles remain at `width:300px` and `height:400px` via media queries.
 - Bar card markup resides in `templates/home.html` and `templates/search.html`, while related behavior lives in `static/js/app.js` and `static/js/search.js`.
 - Carousel arrow controls compute width from the first *visible* card; hiding the first item can break navigation if not accounted for.
+- A "View All" list of bars is available at `/bars`, rendered with `templates/all_bars.html` and enhanced by `static/js/view-all.js`.

--- a/static/js/view-all.js
+++ b/static/js/view-all.js
@@ -1,0 +1,75 @@
+function toNumber(v) {
+  if (v == null) return null;
+  if (typeof v === 'number') return Number.isFinite(v) ? v : null;
+  const m = String(v).replace(',', '.').match(/-?\d+(\.\d+)?/);
+  return m ? parseFloat(m[0]) : null;
+}
+
+function renderMeta(el, data) {
+  const rating = toNumber(data.rating);
+  const km = toNumber(data.distance_km);
+  const rEl = el.querySelector('.bar-rating');
+  const dEl = el.querySelector('.bar-distance');
+  if (rEl) {
+    if (rating != null) {
+      rEl.innerHTML = '<i class="bi bi-star-fill" aria-hidden="true"></i> <span class="rating-value">' + rating.toFixed(1) + '</span>';
+      rEl.hidden = false;
+      rEl.dataset.hasRating = 'true';
+    } else {
+      rEl.hidden = true;
+      rEl.dataset.hasRating = 'false';
+    }
+  }
+  if (dEl) {
+    if (km != null) {
+      dEl.innerHTML = '<i class="bi bi-geo-alt-fill" aria-hidden="true"></i> <span class="distance-value">' + km.toFixed(1) + ' km</span>';
+      dEl.hidden = false;
+      dEl.dataset.hasDistance = 'true';
+    } else {
+      dEl.hidden = true;
+      dEl.dataset.hasDistance = 'false';
+    }
+  }
+}
+
+function haversineKm(lat1, lon1, lat2, lon2) {
+  const R = 6371;
+  const toRad = d => d * Math.PI / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a = Math.sin(dLat / 2) ** 2 + Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const list = document.getElementById('allBarList');
+  if (!list) return;
+  const cards = Array.from(list.querySelectorAll('.bar-card'));
+  function sortByDistance(lat, lng) {
+    cards.forEach(card => {
+      const bLat = toNumber(card.dataset.latitude);
+      const bLng = toNumber(card.dataset.longitude);
+      if (bLat != null && bLng != null) {
+        const dist = haversineKm(lat, lng, bLat, bLng);
+        card.dataset.distance_km = dist;
+        renderMeta(card, { rating: card.dataset.rating, distance_km: dist });
+      } else {
+        renderMeta(card, { rating: card.dataset.rating, distance_km: null });
+      }
+    });
+    const items = cards.map(c => c.closest('li'));
+    items.sort((a, b) => {
+      const da = toNumber(a.querySelector('.bar-card').dataset.distance_km);
+      const db = toNumber(b.querySelector('.bar-card').dataset.distance_km);
+      return (da == null ? Infinity : da) - (db == null ? Infinity : db);
+    });
+    items.forEach(li => list.appendChild(li));
+  }
+  if (navigator.geolocation) {
+    navigator.geolocation.getCurrentPosition(pos => {
+      sortByDistance(pos.coords.latitude, pos.coords.longitude);
+    });
+  } else {
+    cards.forEach(card => renderMeta(card, card.dataset));
+  }
+});

--- a/templates/all_bars.html
+++ b/templates/all_bars.html
@@ -1,0 +1,43 @@
+{% extends "layout.html" %}
+{% block content %}
+{% set fallback_img = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCA0MDAgMjIxJz48cmVjdCB3aWR0aD0nNDAwJyBoZWlnaHQ9JzIyNScgZmlsbD0nJTIzZjFmM2Y1Jy8+PC9zdmc+" %}
+<section class="bar-section">
+  <div class="section-track">
+    <div class="section-head">
+      <h2>Tutti i bar</h2>
+    </div>
+    <ul class="bars" id="allBarList">
+      {% for bar in bars %}
+      <li>
+        <a class="bar-card{% if bar.promo_label %} featured{% endif %}{% if bar.is_open_now %} is-open{% endif %}" href="/bars/{{ bar.id }}" aria-label="Apri {{ bar.name }}" data-name="{{ bar.name|lower }}" data-address="{{ bar.address|lower }}" data-city="{{ bar.city|lower }}" data-state="{{ bar.state|lower }}" data-latitude="{{ bar.latitude }}" data-longitude="{{ bar.longitude }}" data-rating="{{ bar.rating or '' }}" data-distance_km="{{ bar.distance_km or '' }}" data-open="{{ 'true' if bar.is_open_now else 'false' }}" itemscope itemtype="https://schema.org/BarOrPub">
+          <div class="thumb-wrapper">
+            {% if bar.photo_url %}
+            <img class="thumb" src="{{ bar.photo_url }}" alt="{{ bar.name }} photo" itemprop="image" loading="lazy" decoding="async" width="400" height="225" srcset="{{ bar.photo_url }} 400w, {{ bar.photo_url }} 800w" sizes="(max-width: 600px) 100vw, 400px" onerror="this.src='{{ fallback_img }}';this.onerror=null;">
+            {% else %}
+            <img class="thumb" src="{{ fallback_img }}" alt="" loading="lazy" width="400" height="225">
+            {% endif %}
+          </div>
+          {% if bar.is_open_now %}
+          <span class="status status-open">Open now</span>
+          {% else %}
+          <span class="status status-closed">Closed now</span>
+          {% endif %}
+          {% if bar.promo_label %}<span class="badge badge-promo">{{ bar.promo_label }}</span>{% endif %}
+          <h3 class="title" itemprop="name">{{ bar.name }}</h3>
+          <div class="bar-meta">
+            {% if bar.rating %}<span class="bar-rating"><i class="bi bi-star-fill" aria-hidden="true"></i> {{ '%.1f'|format(bar.rating) }}</span>{% endif %}
+            <span class="bar-distance" data-has-distance="true" hidden></span>
+          </div>
+          <address>{{ bar.city }}{% if bar.state %}, {{ bar.state }}{% endif %}</address>
+          <p class="desc">{{ bar.description }}</p>
+        </a>
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+</section>
+{% endblock %}
+
+{% block scripts %}
+<script src="/static/js/view-all.js" defer></script>
+{% endblock %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -3,12 +3,7 @@
 {% set fallback_img = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCA0MDAgMjI1Jz48cmVjdCB3aWR0aD0nNDAwJyBoZWlnaHQ9JzIyNScgZmlsbD0nJTIzZjFmM2Y1Jy8+PC9zdmc+" %}
 <div class="search-page">
   <div class="search-stick">
-    <label class="visually-hidden" for="barSearch">Cerca bar o città</label>
-    <input id="barSearch" type="search" placeholder="Cerca un bar o una città…" aria-label="Cerca bar o città" inputmode="search" autocomplete="off">
-    <button id="filterBtn" class="filter-btn" aria-label="Filtri">
-      <i class="bi bi-sliders"></i>
-      <span id="filterCount" class="cart-badge" hidden></span>
-    </button>
+    <a class="btn btn--primary" href="/bars">View All</a>
   </div>
   {% if bars or recent_bars %}
     {% set sections = [
@@ -75,74 +70,8 @@
   {% else %}
   <div class="empty-state">
     <p>Nessun bar trovato.</p>
-    <button type="button" id="clearFilters" class="btn btn--secondary">Clear filters</button>
   </div>
   {% endif %}
-</div>
-  <div id="filterOverlay" class="filter-overlay" hidden>
-  <div class="filter-sheet" role="dialog" aria-modal="true" aria-labelledby="filterTitle">
-    <div class="grabber" aria-hidden="true"></div>
-    <h2 id="filterTitle">Filtri</h2>
-    <form id="filterForm">
-      <div class="group" data-key="max_km" data-active="false">
-        <div class="group-head">
-          <label for="filterDistance">Max distance</label>
-          <div class="group-toggle">
-            <input type="checkbox" id="filterDistanceToggle">
-            <span id="filterDistanceVal" class="chip value-chip" hidden></span>
-          </div>
-        </div>
-        <input type="range" id="filterDistance" name="distance" min="1" max="50" step="1" value="50" aria-label="Max distance in kilometers" aria-valuenow="50">
-        <span id="filterDistanceAnnounce" class="visually-hidden" aria-live="polite"></span>
-        <p class="help inactive-hint">Attiva per filtrare</p>
-      </div>
-      <div class="group" data-key="min_rating" data-active="false">
-        <div class="group-head">
-          <label for="filterRating">Min rating</label>
-          <div class="group-toggle">
-            <input type="checkbox" id="filterRatingToggle">
-            <span id="filterRatingVal" class="chip value-chip" hidden></span>
-          </div>
-        </div>
-        <input type="range" id="filterRating" name="rating" min="0" max="5" step="0.1" value="0" aria-label="Minimum rating" aria-valuenow="0">
-        <span id="filterRatingAnnounce" class="visually-hidden" aria-live="polite"></span>
-        <p class="help inactive-hint">Attiva per filtrare</p>
-      </div>
-      <div class="group" data-key="categories" data-active="false">
-        <div class="group-head">
-          <p>Category</p>
-          <span id="filterCategoryVal" class="chip value-chip" hidden></span>
-        </div>
-        {% set cats = namespace(names=[]) %}
-        {% for bar in bars %}
-          {% for c in bar.categories %}
-            {% if c.name not in cats.names %}
-              {% set cats.names = cats.names + [c.name] %}
-            {% endif %}
-          {% endfor %}
-        {% endfor %}
-        <div id="filterCategoryChips" class="chips">
-          <button type="button" class="chip" data-value="">All</button>
-          {% for name in cats.names %}
-          <button type="button" class="chip" data-value="{{ name|lower }}">{{ name }}</button>
-          {% endfor %}
-        </div>
-        <p class="help inactive-hint">Seleziona per attivare</p>
-      </div>
-      <div class="group" data-key="open_now" data-active="false">
-        <div class="group-head">
-          <label for="filterOpen">Open now</label>
-          <span id="filterOpenVal" class="chip value-chip" hidden></span>
-        </div>
-        <input type="checkbox" id="filterOpen" name="open">
-        <p class="help inactive-hint">Attiva per filtrare</p>
-      </div>
-      <div class="sheet-footer">
-        <button type="button" class="btn reset">Reset</button>
-        <button type="submit" class="btn btn--primary apply" disabled>Apply</button>
-      </div>
-    </form>
-  </div>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Replace search/filter controls on Browse Bars with a simple **View All** button
- Introduce `/bars` page listing all bars from nearest to farthest, including closed ones
- Provide client-side script to sort bars by distance

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0113e88788320805722d5d233aa4b