### PR TITLE
Ensure bars table has bar_categories column

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,4 @@
 - Admin forms `templates/admin_new_bar.html` and `templates/admin_edit_bar.html` offer multiselect inputs for these categories.
 - Category filter chips on `/bars` and search overlays draw from this predefined list in `static/js/view-all.js` and `static/js/search.js`.
 - Admin bar category selection is limited to five choices, enforced in both the form UI and server-side handlers.
+- Startup ensures the `bars` table includes a `bar_categories` column and `load_bars_from_db()` populates each bar's categories from that comma-separated field.

--- a/main.py
+++ b/main.py
@@ -374,6 +374,7 @@ def ensure_bar_columns() -> None:
         "promo_label": "VARCHAR(100)",
         "tags": "TEXT",
         "opening_hours": "TEXT",
+        "bar_categories": "TEXT",
     }
     missing = {name: ddl for name, ddl in required.items() if name not in columns}
     if missing:
@@ -532,6 +533,7 @@ def load_bars_from_db() -> None:
                 opening_hours=hours,
                 promo_label=b.promo_label,
                 tags=json.loads(b.tags) if b.tags else [],
+                bar_categories=b.bar_categories.split(",") if b.bar_categories else [],
             )
             # Load categories for the bar
             for c in b.categories:


### PR DESCRIPTION
## Summary
- add `bar_categories` to automatic bars table migrations
- load bar categories into in-memory store
- document startup behavior in AGENTS notes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b02374f894832084eb896b1f134940