### PR TITLE
Hide bar list while filter panel open

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
 - `/bars` now includes search inputs and filter controls (name, city, max distance, min rating, open/closed, categories) wired up in `static/js/view-all.js` and styled via `.bar-filters` in `components.css`.
 - `/bars` filter toolbar uses a grid layout with icon-labeled inputs, range slider, star rating selector, and active filter chips (markup in `templates/all_bars.html`, logic in `static/js/view-all.js`, styles in `components.css`).
 - Filters on `/bars` are hidden by default and revealed via the `#toggleFilters` button, which also shows the active filter count.
+- When the filter panel is shown, the bar list and category chips are temporarily hidden to free screen space; this toggle logic lives in `static/js/view-all.js`.
 - Bars support a `bar_categories` field (comma-separated) with 30 predefined types (see `BAR_CATEGORIES` in `main.py`).
 - Admin forms `templates/admin_new_bar.html` and `templates/admin_edit_bar.html` offer multiselect inputs for these categories.
 - Category filter chips on `/bars` and search overlays draw from this predefined list in `static/js/view-all.js` and `static/js/search.js`.

--- a/static/js/view-all.js
+++ b/static/js/view-all.js
@@ -320,7 +320,19 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('applyFiltersBtn')?.addEventListener('click', applyFilters);
 
   toggleBtn?.addEventListener('click', () => {
-    filterPanel?.toggleAttribute('hidden');
+    const wasHidden = filterPanel?.hasAttribute('hidden');
+    if (wasHidden) {
+      filterPanel?.removeAttribute('hidden');
+    } else {
+      filterPanel?.setAttribute('hidden', '');
+    }
+    list?.toggleAttribute('hidden', wasHidden);
+    activeChips?.toggleAttribute('hidden', wasHidden);
+    chipsContainer?.toggleAttribute('hidden', wasHidden);
+    const textNode = toggleBtn.childNodes[0];
+    if (textNode && textNode.nodeType === Node.TEXT_NODE) {
+      textNode.textContent = wasHidden ? 'Chiudi filtri ' : 'Filtri ';
+    }
   });
 
   applyFilters();


### PR DESCRIPTION
## Summary
- Hide bar list and category chips when filter panel is shown
- Update toggle button text to reflect open state
- Document filter behavior in AGENTS notes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b032f9f3cc83208dc9281f2adf920d