### PR TITLE
feat: toggle filter card visibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@
 - `/bars` filter toolbar uses a grid layout with icon-labeled inputs, range slider, star rating selector, and active filter chips (markup in `templates/all_bars.html`, logic in `static/js/view-all.js`, styles in `components.css`).
 - The filter controls sit inside a responsive `.bar-filters` card that uses `auto-fit` grid columns to size itself to both screen width and filter content.
 - Filters on `/bars` are hidden by default and revealed via the `#toggleFilters` button, which also shows the active filter count.
+- The `#toggleFilters` button controls the `.bar-filters` card via `aria-controls`/`aria-expanded`, updated in `static/js/view-all.js`.
 - When the filter panel is shown, the bar list is temporarily hidden to free screen space; category chips now sit inside the `.bar-filters` card and are toggled along with it (logic in `static/js/view-all.js`).
 - Category chip group spans the full filter width via `.bar-filters .filter-group.categories` to keep chips inline until space runs out (see `templates/all_bars.html` and `static/css/components.css`).
 - Bars support a `bar_categories` field (comma-separated) with 30 predefined types (see `BAR_CATEGORIES` in `main.py`).

--- a/static/js/view-all.js
+++ b/static/js/view-all.js
@@ -328,6 +328,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     list?.toggleAttribute('hidden', wasHidden);
     activeChips?.toggleAttribute('hidden', wasHidden);
+    toggleBtn?.setAttribute('aria-expanded', wasHidden ? 'true' : 'false');
     const textNode = toggleBtn.childNodes[0];
     if (textNode && textNode.nodeType === Node.TEXT_NODE) {
       textNode.textContent = wasHidden ? 'Chiudi filtri ' : 'Filtri ';

--- a/templates/all_bars.html
+++ b/templates/all_bars.html
@@ -6,7 +6,7 @@
       <div class="section-head">
         <h2>Tutti i bar</h2>
       </div>
-      <button type="button" id="toggleFilters" class="filter-toggle">Filtri <span class="filter-count" id="filterCount" hidden>0</span></button>
+      <button type="button" id="toggleFilters" class="filter-toggle" aria-controls="barFilters" aria-expanded="false">Filtri <span class="filter-count" id="filterCount" hidden>0</span></button>
       <div class="bar-filters" id="barFilters" hidden>
         <div class="filter-grid">
           <div class="filter-group">


### PR DESCRIPTION
## Summary
- toggle filter panel with aria-expanded button
- document filter toggle setup in AGENTS notes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b057e02d6c8320b975375601afa931