### PR TITLE
feat: toggle filter panel visibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@
 - `/bars` now includes search inputs and filter controls (name, city, max distance, min rating, open/closed, categories) wired up in `static/js/view-all.js` and styled via `.bar-filters` in `components.css`.
 - `/bars` filter toolbar uses a grid layout with icon-labeled inputs, range slider, star rating selector, and active filter chips (markup in `templates/all_bars.html`, logic in `static/js/view-all.js`, styles in `components.css`).
 - The filter controls sit inside a responsive `.bar-filters` card that uses `auto-fit` grid columns to size itself to both screen width and filter content.
-- Filters on `/bars` are hidden by default; clicking the `#showFilters` button reveals the `.bar-filters` card (markup in `templates/all_bars.html`, logic in `static/js/view-all.js`).
+- Filters on `/bars` are hidden by default; the `#showFilters` button toggles the `.bar-filters` card and swaps its label between "Mostra filtri" and "Nascondi filtri" (markup in `templates/all_bars.html`, logic in `static/js/view-all.js`).
 - `.bar-filters[hidden]{display:none;}` in `static/css/components.css` keeps the panel hidden until it's toggled.
 - Category chip group spans the full filter width via `.bar-filters .filter-group.categories` to keep chips inline until space runs out (see `templates/all_bars.html` and `static/css/components.css`).
 - Bars support a `bar_categories` field (comma-separated) with 30 predefined types (see `BAR_CATEGORIES` in `main.py`).

--- a/static/js/view-all.js
+++ b/static/js/view-all.js
@@ -314,8 +314,15 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('applyFiltersBtn')?.addEventListener('click', applyFilters);
 
   showFiltersBtn?.addEventListener('click', () => {
-    filterPanel?.removeAttribute('hidden');
-    showFiltersBtn?.setAttribute('hidden', '');
+    if (!filterPanel || !showFiltersBtn) return;
+    const isHidden = filterPanel.hasAttribute('hidden');
+    if (isHidden) {
+      filterPanel.removeAttribute('hidden');
+      showFiltersBtn.textContent = 'Nascondi filtri';
+    } else {
+      filterPanel.setAttribute('hidden', '');
+      showFiltersBtn.textContent = 'Mostra filtri';
+    }
   });
 
   applyFilters();


### PR DESCRIPTION
## Summary
- toggle the bar filter panel on the /bars page and switch button text between "Mostra filtri" and "Nascondi filtri"
- document new filter toggle behavior in AGENTS notes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b05fe0b9c48320a85a4a2926bbff21