### PR TITLE
Fix carousel navigation on search page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - Mobile card styles remain at `width:300px` and `height:400px` via media queries.
 - Bar card markup resides in `templates/home.html` and `templates/search.html`, while related behavior lives in `static/js/app.js` and `static/js/search.js`.
 - Carousel arrow controls compute width from the first *visible* card; hiding the first item can break navigation if not accounted for.
+- Search page carousels now mirror home page behavior, computing width from the first visible `.bar-card` so arrow navigation works regardless of markup.
 - A "View All" list of bars is available at `/bars`, rendered with `templates/all_bars.html` and enhanced by `static/js/view-all.js`.
 - On the `/bars` page, card widths are reduced by `50px` (to `350px` desktop and `250px` mobile) via `.bars.all-bars .bar-card` overrides in `components.css`.
 - Cards on the `/bars` page are centered within their grid cells via `.bars.all-bars{justify-items:center;}`.

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -598,6 +598,30 @@ document.addEventListener('DOMContentLoaded', async () => {
     applyState(appliedState);
   });
 
+  function setupCarousels() {
+    document.querySelectorAll('.bar-section').forEach(section => {
+      const scroller = section.querySelector('.scroller');
+      const prev = section.querySelector('.scroll-btn.prev');
+      const next = section.querySelector('.scroll-btn.next');
+      if (!scroller) return;
+      const getWidth = () => {
+        const card = scroller.querySelector('.bar-card:not([hidden]):not([style*="display: none"])');
+        if (!card) return 0;
+        const style = getComputedStyle(card);
+        return card.offsetWidth + parseFloat(style.marginRight) + parseFloat(style.marginLeft);
+      };
+      let w = getWidth();
+      const scrollBy = dir => scroller.scrollBy({ left: dir * w, behavior: 'smooth' });
+      prev?.addEventListener('click', () => scrollBy(-1));
+      next?.addEventListener('click', () => scrollBy(1));
+      window.addEventListener('resize', () => { w = getWidth(); });
+      scroller.addEventListener('keydown', e => {
+        if (e.key === 'ArrowRight') { e.preventDefault(); scrollBy(1); }
+        if (e.key === 'ArrowLeft') { e.preventDefault(); scrollBy(-1); }
+      });
+    });
+  }
+
   // Initial state
   state = readFromURL();
   const hasParams = Array.from(new URLSearchParams(location.search).keys()).length > 0;
@@ -607,5 +631,6 @@ document.addEventListener('DOMContentLoaded', async () => {
   appliedState = JSON.parse(JSON.stringify(state));
   updateControls();
   applyState(appliedState);
+  setupCarousels();
 });
 


### PR DESCRIPTION
## Summary
- enable carousel arrow navigation on search page
- document new search carousel behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0873afd448320b9b7a5796632a37b