### PR TITLE
fix: keep view-all cards at end of bar lists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,3 +29,4 @@
 - `.btn-filter` suppresses default link underlines with `text-decoration:none;` so "View all" renders without a line beneath the text.
 - Browse bars sections in `templates/search.html` append a "View all" card linking to `/bars` (excluded for the "Recently visited bars" section); these cards use `.browse-bars-card` styling and are ignored by data logic in `static/js/search.js`.
 - All UI text is now in English. Category names are defined in `main.py` and mirrored in `static/js/search.js` and `static/js/view-all.js`.
+- Sorting in `static/js/search.js` and `static/js/app.js` inserts bars before browse/view-all cards so those cards always stay at the end of their lists.

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -154,12 +154,15 @@ document.addEventListener('DOMContentLoaded', function() {
     const list = document.getElementById('barList');
     if(!list) return;
     const items = Array.from(list.children);
-    items.sort((a,b)=>{
+    const browse = list.querySelector('.browse-bars-card')?.closest('li');
+    const sortable = browse ? items.filter(it => it !== browse) : items;
+    sortable.sort((a,b)=>{
       const da = parseFloat(a.querySelector('.bar-card').dataset.distance_km || 'Infinity');
       const db = parseFloat(b.querySelector('.bar-card').dataset.distance_km || 'Infinity');
       return da - db;
     });
-    items.forEach(it=>list.appendChild(it));
+    sortable.forEach(it=>list.appendChild(it));
+    if (browse) list.appendChild(browse);
     list.scrollLeft = 0;
   }
 

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -192,14 +192,21 @@ document.addEventListener('DOMContentLoaded', async () => {
   let userLoc = null;
   let bars = await normalizeBars(rawBars, userLoc);
 
-  function sortNearby() {
-    const container = document.querySelector('.bar-section[data-section="nearby"] .cards');
-    if (!container) return;
-    const nearbyBars = bars
-      .filter(b => b.el.closest('[data-section="nearby"]'))
-      .sort((a, b) => (a.distance_km ?? Infinity) - (b.distance_km ?? Infinity));
-    nearbyBars.forEach(b => container.appendChild(b.el));
-  }
+function sortNearby() {
+  const container = document.querySelector('.bar-section[data-section="nearby"] .cards');
+  if (!container) return;
+  const viewAll = container.querySelector('.view-all-card');
+  const nearbyBars = bars
+    .filter(b => b.el.closest('[data-section="nearby"]'))
+    .sort((a, b) => (a.distance_km ?? Infinity) - (b.distance_km ?? Infinity));
+  nearbyBars.forEach(b => {
+    if (viewAll) {
+      container.insertBefore(b.el, viewAll);
+    } else {
+      container.appendChild(b.el);
+    }
+  });
+}
 
   bars.forEach(b => renderMeta(b.el, b));
   sortNearby();


### PR DESCRIPTION
## Summary
- ensure nearby bar sorting keeps `.view-all-card` as last item
- keep home page `browse-bars-card` at end after distance sort
- document sorting behavior in AGENTS notes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b08bb473188320a9d2cb9ed146b86b