### PR TITLE
fix: add startup check for users.credit column

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@
 - `.btn-filter` suppresses default link underlines with `text-decoration:none;` so "View all" renders without a line beneath the text.
 - Links displaying user credit (`.credit-pill`) also drop default underlines with `text-decoration:none;` in `components.css`.
 - User credit is persisted in the `users.credit` column; login loads the value and checkout/top-up operations commit updates back to the database.
+- Startup auto-adds the `users.credit` column via `ensure_credit_column()` to prevent deployment errors when the column is missing.
 - Browse bars sections in `templates/search.html` append a "View all" card linking to `/bars` (excluded for the "Recently visited bars" section); these cards use `.browse-bars-card` styling and are ignored by data logic in `static/js/search.js`.
 - All UI text is now in English. Category names are defined in `main.py` and mirrored in `static/js/search.js` and `static/js/view-all.js`.
 - Sorting in `static/js/search.js` and `static/js/app.js` inserts bars before browse/view-all cards so those cards always stay at the end of their lists.

--- a/main.py
+++ b/main.py
@@ -360,6 +360,17 @@ def ensure_prefix_column():
             conn.execute(text("ALTER TABLE users ADD COLUMN prefix VARCHAR(10)"))
 
 
+def ensure_credit_column() -> None:
+    """Add the `credit` column to users table if it's missing."""
+    inspector = inspect(engine)
+    columns = [col["name"] for col in inspector.get_columns("users")]
+    if "credit" not in columns:
+        with engine.begin() as conn:
+            conn.execute(
+                text("ALTER TABLE users ADD COLUMN credit NUMERIC(10, 2) DEFAULT 0")
+            )
+
+
 def ensure_bar_columns() -> None:
     """Ensure recently added columns exist on the bars table."""
     inspector = inspect(engine)
@@ -420,6 +431,7 @@ def on_startup():
     """Initialise database tables on startup."""
     Base.metadata.create_all(bind=engine)
     ensure_prefix_column()
+    ensure_credit_column()
     ensure_bar_columns()
     ensure_category_columns()
     ensure_menu_item_columns()


### PR DESCRIPTION
## Summary
- add `ensure_credit_column` to create missing `users.credit`
- document automatic credit column creation in AGENTS notes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1426a1b9c8320a90efb2739cc27b0