### PR TITLE
feat: display bar image on detail page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,4 @@
 - All UI text is now in English. Category names are defined in `main.py` and mirrored in `static/js/search.js` and `static/js/view-all.js`.
 - Sorting in `static/js/search.js` and `static/js/app.js` inserts bars before browse/view-all cards so those cards always stay at the end of their lists.
 - Logged-in greeting on the home page uses the `.info-section` layout with a waving hand emoji and a separate paragraph.
+- Bar detail page (`templates/bar_detail.html`) shows the bar's uploaded photo with a fallback placeholder.

--- a/templates/bar_detail.html
+++ b/templates/bar_detail.html
@@ -1,6 +1,12 @@
 {% extends "layout.html" %}
 {% block content %}
+{% set fallback_img = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCA0MDAgMjI1Jz48cmVjdCB3aWR0aD0nNDAwJyBoZWlnaHQ9JzIyNScgZmlsbD0nJTIzZjFmM2Y1Jy8+PC9zdmc+" %}
 <h1>{{ bar.name }}</h1>
+{% if bar.photo_url %}
+<img class="thumb" src="{{ bar.photo_url }}" alt="{{ bar.name }} photo" itemprop="image" loading="lazy" decoding="async" width="400" height="225" srcset="{{ bar.photo_url }} 400w, {{ bar.photo_url }} 800w" sizes="(max-width: 600px) 100vw, 400px" onerror="this.src='{{ fallback_img }}';this.onerror=null;">
+{% else %}
+<img class="thumb" src="{{ fallback_img }}" alt="" loading="lazy" width="400" height="225">
+{% endif %}
 <p>{{ bar.address }}, {{ bar.city }}, {{ bar.state }}</p>
 {% if error %}
 <p class="error">{{ error }}</p>


### PR DESCRIPTION
## Summary
- show bar image on detail page with fallback placeholder
- document new behavior in AGENTS guide

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b148f1089483208833cd4925b705b9