### PR TITLE
Ensure menu items table supports product images

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,3 +38,4 @@
 - Product cards mirror bar card styling (400px×450px desktop, 300px×400px mobile) with images; markup lives in `templates/bar_detail.html` and styles are in `static/css/components.css` (minified in `static/css/components.min.css`).
 - Product categories on the bar detail page use horizontal carousels with arrow controls. Markup is in `templates/bar_detail.html` and behavior lives in `static/js/app.js` (minified in `static/js/app.min.js`), computing widths from the first visible `.product-card` just like for bars.
 - Bar detail page sections (`.product-section`) wrap the category name, description, and product carousel inside a card-style box.
+- `ensure_menu_item_columns()` in `main.py` now auto-adds a `photo` column so product images persist in the `menu_items` table.

--- a/main.py
+++ b/main.py
@@ -414,7 +414,10 @@ def ensure_menu_item_columns() -> None:
     """Ensure expected columns exist on the menu_items table."""
     inspector = inspect(engine)
     columns = {col["name"] for col in inspector.get_columns("menu_items")}
-    required = {"sort_order": "INTEGER"}
+    required = {
+        "sort_order": "INTEGER",
+        "photo": "VARCHAR(255)",
+    }
     missing = {name: ddl for name, ddl in required.items() if name not in columns}
     if missing:
         with engine.begin() as conn:


### PR DESCRIPTION
## Summary
- auto-add `photo` column to `menu_items` so product images persist
- document product image column in `AGENTS.md`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b155b9e9248320960943804ff117fb