### PR TITLE
feat: show product images

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,3 +40,5 @@
 - Bar detail page sections (`.product-section`) wrap the category name, description, and product carousel inside a card-style box.
 - `ensure_menu_item_columns()` in `main.py` now auto-adds a `photo` column so product images persist in the `menu_items` table.
 - Product edit view (`bar_edit_product_form` in `main.py`) pulls item data directly from the database so uploaded photos appear when editing.
+- Product edit and bar detail pages convert product `photo_url` values to absolute URLs so images render correctly.
+- `/bar/{bar_id}/categories/{category_id}/products` lists now include product photo thumbnails with a fallback placeholder.

--- a/templates/bar_category_products.html
+++ b/templates/bar_category_products.html
@@ -1,5 +1,6 @@
 {% extends "layout.html" %}
 {% block content %}
+{% set fallback_img = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCA0MDAgMjI1Jz48cmVjdCB3aWR0aD0nNDAwJyBoZWlnaHQ9JzIyNScgZmlsbD0nJTIzZjFmM2Y1Jy8+PC9zdmc+" %}
 <h1>Products in {{ category.name }} for {{ bar.name }}</h1>
 
 <div class="toolbar" style="margin-bottom:1rem;">
@@ -11,6 +12,7 @@
   <thead>
     <tr>
       <th>Order</th>
+      <th>Photo</th>
       <th>Name</th>
       <th>Description</th>
       <th>Price (CHF)</th>
@@ -21,6 +23,13 @@
     {% for product in products %}
     <tr>
       <td>{{ product.display_order }}</td>
+      <td>
+        {% if product.photo_url %}
+        <img src="{{ product.photo_url }}" alt="{{ product.name }} photo" width="50" height="28" loading="lazy">
+        {% else %}
+        <img src="{{ fallback_img }}" alt="" width="50" height="28" loading="lazy">
+        {% endif %}
+      </td>
       <td>{{ product.name }}</td>
       <td>{{ product.description }}</td>
       <td>{{ "%.2f"|format(product.price) }}</td>

--- a/tests/test_product_photo_edit.py
+++ b/tests/test_product_photo_edit.py
@@ -61,7 +61,11 @@ def test_edit_product_shows_uploaded_photo():
 
     resp = client.get(f"/bar/{bar_id}/categories/{category_id}/products/{item_id}/edit")
     assert resp.status_code == 200
-    assert "/static/uploads/beer.jpg" in resp.text
+    assert "http://testserver/static/uploads/beer.jpg" in resp.text
+
+    detail = client.get(f"/bars/{bar_id}")
+    assert detail.status_code == 200
+    assert "http://testserver/static/uploads/beer.jpg" in detail.text
 
     users.clear()
     users_by_email.clear()


### PR DESCRIPTION
## Summary
- ensure product photos render on bar detail and edit pages by converting paths to absolute URLs
- display product thumbnails in bar category product lists
- cover product photo rendering with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b15be3bedc8320adb4bc638215a6b5