### PR TITLE
Fix product image upload persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,4 @@
 - Product edit view (`bar_edit_product_form` in `main.py`) pulls item data directly from the database so uploaded photos appear when editing.
 - Product edit and bar detail pages convert product `photo_url` values to absolute URLs so images render correctly.
 - `/bar/{bar_id}/categories/{category_id}/products` lists now include product photo thumbnails with a fallback placeholder.
+- File uploads retrieved via `request.form()` return Starlette `UploadFile` objects; check for a `.filename` attribute instead of using `isinstance(..., UploadFile)`.

--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ from typing import Dict, List, Optional
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
-from fastapi import Depends, FastAPI, HTTPException, Request, status, UploadFile
+from fastapi import Depends, FastAPI, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
@@ -1437,7 +1437,7 @@ async def create_bar_post(request: Request, db: Session = Depends(get_db)):
     categories_csv = ",".join(categories) if categories else None
     photo_file = form.get("photo")
     photo_url = None
-    if isinstance(photo_file, UploadFile) and photo_file.filename:
+    if getattr(photo_file, "filename", None):
         uploads_dir = os.path.join("static", "uploads")
         os.makedirs(uploads_dir, exist_ok=True)
         _, ext = os.path.splitext(photo_file.filename)
@@ -1579,7 +1579,7 @@ async def edit_bar_post(request: Request, bar_id: int, db: Session = Depends(get
     categories_csv = ",".join(categories) if categories else None
     photo_file = form.get("photo")
     photo_url = bar.photo_url
-    if isinstance(photo_file, UploadFile) and photo_file.filename:
+    if getattr(photo_file, "filename", None):
         uploads_dir = os.path.join("static", "uploads")
         os.makedirs(uploads_dir, exist_ok=True)
         _, ext = os.path.splitext(photo_file.filename)
@@ -2319,7 +2319,7 @@ async def bar_new_category(
     display_order = form.get("display_order") or 0
     photo_file = form.get("photo")
     photo_url = None
-    if isinstance(photo_file, UploadFile) and photo_file.filename:
+    if getattr(photo_file, "filename", None):
         uploads_dir = os.path.join("static", "uploads")
         os.makedirs(uploads_dir, exist_ok=True)
         _, ext = os.path.splitext(photo_file.filename)
@@ -2474,7 +2474,7 @@ async def bar_new_product(
     display_order = form.get("display_order") or 0
     photo_file = form.get("photo")
     photo_url = None
-    if isinstance(photo_file, UploadFile) and photo_file.filename:
+    if getattr(photo_file, "filename", None):
         uploads_dir = os.path.join("static", "uploads")
         os.makedirs(uploads_dir, exist_ok=True)
         _, ext = os.path.splitext(photo_file.filename)
@@ -2659,7 +2659,7 @@ async def bar_edit_product(
             db_item.sort_order = order_val
     except ValueError:
         pass
-    if isinstance(photo_file, UploadFile) and photo_file.filename:
+    if getattr(photo_file, "filename", None):
         uploads_dir = os.path.join("static", "uploads")
         os.makedirs(uploads_dir, exist_ok=True)
         _, ext = os.path.splitext(photo_file.filename)
@@ -2739,7 +2739,7 @@ async def bar_edit_category(
             db_category.sort_order = order_val
     except ValueError:
         pass
-    if isinstance(photo_file, UploadFile) and photo_file.filename:
+    if getattr(photo_file, "filename", None):
         uploads_dir = os.path.join("static", "uploads")
         os.makedirs(uploads_dir, exist_ok=True)
         _, ext = os.path.splitext(photo_file.filename)

--- a/tests/test_product_photo_upload.py
+++ b/tests/test_product_photo_upload.py
@@ -1,0 +1,91 @@
+import os
+import sys
+import pathlib
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from decimal import Decimal
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, engine, SessionLocal  # noqa: E402
+from models import Bar as BarModel, Category as CategoryModel, MenuItem  # noqa: E402
+from main import app, DemoUser, users, users_by_email, users_by_username, bars  # noqa: E402
+
+
+def setup_module(module):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()
+    bars.clear()
+
+
+def test_upload_product_photo_updates_db_and_renders():
+    db = SessionLocal()
+    bar = BarModel(name="Bar", slug="bar")
+    db.add(bar)
+    db.commit()
+    db.refresh(bar)
+    category = CategoryModel(bar_id=bar.id, name="Drinks")
+    db.add(category)
+    db.commit()
+    db.refresh(category)
+    item = MenuItem(
+        bar_id=bar.id,
+        category_id=category.id,
+        name="Beer",
+        description="desc",
+        price_chf=Decimal("5.00"),
+    )
+    db.add(item)
+    db.commit()
+    db.refresh(item)
+    bar_id, category_id, item_id = bar.id, category.id, item.id
+    db.close()
+
+    admin = DemoUser(
+        id=123,
+        username="uploader",
+        password="secret",
+        email="uploader@example.com",
+        role="super_admin",
+    )
+    users[admin.id] = admin
+    users_by_email[admin.email] = admin
+    users_by_username[admin.username] = admin
+
+    client = TestClient(app)
+    client.post("/login", data={"email": admin.email, "password": admin.password})
+
+    file_content = b"img"
+    client.post(
+        f"/bar/{bar_id}/categories/{category_id}/products/{item_id}/edit",
+        data={
+            "name": "Beer",
+            "price": "5.00",
+            "description": "desc",
+            "display_order": "0",
+        },
+        files={"photo": ("beer.jpg", file_content, "image/jpeg")},
+    )
+
+    edit = client.get(
+        f"/bar/{bar_id}/categories/{category_id}/products/{item_id}/edit"
+    )
+    assert edit.status_code == 200
+    assert "http://testserver/static/uploads/" in edit.text
+
+    detail = client.get(f"/bars/{bar_id}")
+    assert detail.status_code == 200
+    assert "http://testserver/static/uploads/" in detail.text
+
+    db = SessionLocal()
+    db_item = db.get(MenuItem, item_id)
+    assert db_item.photo and db_item.photo.startswith("/static/uploads/")
+    db.close()
+
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()
+    bars.clear()


### PR DESCRIPTION
## Summary
- handle file uploads by checking for a filename rather than relying on FastAPI's UploadFile type
- add regression test ensuring uploaded product images persist and render

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b160f73c0c832083d704aa92ea5599