### PR TITLE
Ensure product photos persist after restart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@
 - Bar detail page sections (`.product-section`) wrap the category name, description, and product carousel inside a card-style box.
 - `ensure_menu_item_columns()` in `main.py` now auto-adds a `photo` column so product images persist in the `menu_items` table.
 - Product edit view (`bar_edit_product_form` in `main.py`) pulls item data directly from the database so uploaded photos appear when editing.
+- Product photo uploads are saved in the `menu_items.photo` column and reloaded at startup via `load_bars_from_db()` so images persist after restarts.
 - Product edit and bar detail pages convert product `photo_url` values to absolute URLs so images render correctly.
 - `/bar/{bar_id}/categories/{category_id}/products` lists now include product photo thumbnails with a fallback placeholder.
 - File uploads retrieved via `request.form()` return Starlette `UploadFile` objects; check for a `.filename` attribute instead of using `isinstance(..., UploadFile)`.

--- a/main.py
+++ b/main.py
@@ -2673,6 +2673,7 @@ async def bar_edit_product(
     if db_item:
         db.add(db_item)
         db.commit()
+        db.refresh(db_item)
     return RedirectResponse(
         url=f"/bar/{bar_id}/categories/{category_id}/products",
         status_code=status.HTTP_303_SEE_OTHER,

--- a/tests/test_product_photo_upload.py
+++ b/tests/test_product_photo_upload.py
@@ -9,7 +9,15 @@ from decimal import Decimal
 from fastapi.testclient import TestClient  # noqa: E402
 from database import Base, engine, SessionLocal  # noqa: E402
 from models import Bar as BarModel, Category as CategoryModel, MenuItem  # noqa: E402
-from main import app, DemoUser, users, users_by_email, users_by_username, bars  # noqa: E402
+from main import (
+    app,
+    DemoUser,
+    users,
+    users_by_email,
+    users_by_username,
+    bars,
+    load_bars_from_db,
+)  # noqa: E402
 
 
 def setup_module(module):
@@ -84,6 +92,66 @@ def test_upload_product_photo_updates_db_and_renders():
     db_item = db.get(MenuItem, item_id)
     assert db_item.photo and db_item.photo.startswith("/static/uploads/")
     db.close()
+
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()
+    bars.clear()
+
+
+def test_product_photo_persists_after_restart():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    bar = BarModel(name="Bar", slug="bar")
+    db.add(bar)
+    db.commit()
+    db.refresh(bar)
+    category = CategoryModel(bar_id=bar.id, name="Drinks")
+    db.add(category)
+    db.commit()
+    db.refresh(category)
+    item = MenuItem(
+        bar_id=bar.id,
+        category_id=category.id,
+        name="Beer",
+        description="desc",
+        price_chf=Decimal("5.00"),
+    )
+    db.add(item)
+    db.commit()
+    db.refresh(item)
+    bar_id, category_id, item_id = bar.id, category.id, item.id
+    db.close()
+
+    admin = DemoUser(
+        id=456,
+        username="restarter",
+        password="secret",
+        email="restart@example.com",
+        role="super_admin",
+    )
+    users[admin.id] = admin
+    users_by_email[admin.email] = admin
+    users_by_username[admin.username] = admin
+
+    client = TestClient(app)
+    client.post("/login", data={"email": admin.email, "password": admin.password})
+
+    file_content = b"img"
+    client.post(
+        f"/bar/{bar_id}/categories/{category_id}/products/{item_id}/edit",
+        data={
+            "name": "Beer",
+            "price": "5.00",
+            "description": "desc",
+            "display_order": "0",
+        },
+        files={"photo": ("beer.jpg", file_content, "image/jpeg")},
+    )
+
+    load_bars_from_db()
+    assert bars[bar_id].products[item_id].photo_url.startswith("/static/uploads/")
 
     users.clear()
     users_by_email.clear()


### PR DESCRIPTION
## Summary
- refresh menu item after committing photo updates so image path is stored
- test product photo survives a restart of in-memory cache
- document photo persistence in AGENTS notes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1668c208883209bf3fd3d661cbf34