### PR TITLE
Refresh bar cache after product updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,4 @@
 - Product edit and bar detail pages convert product `photo_url` values to absolute URLs so images render correctly.
 - `/bar/{bar_id}/categories/{category_id}/products` lists now include product photo thumbnails with a fallback placeholder.
 - File uploads retrieved via `request.form()` return Starlette `UploadFile` objects; check for a `.filename` attribute instead of using `isinstance(..., UploadFile)`.
+- After creating or editing a product, `refresh_bar_from_db()` syncs the in-memory bar data with database changes.

--- a/main.py
+++ b/main.py
@@ -2518,16 +2518,7 @@ async def bar_new_product(
     db.add(db_item)
     db.commit()
     db.refresh(db_item)
-    product = Product(
-        id=db_item.id,
-        category_id=category_id,
-        name=name,
-        price=price_val,
-        description=description,
-        display_order=order_val,
-        photo_url=photo_url,
-    )
-    bar.products[product.id] = product
+    refresh_bar_from_db(bar_id, db)
     return RedirectResponse(
         url=f"/bar/{bar_id}/categories/{category_id}/products",
         status_code=status.HTTP_303_SEE_OTHER,
@@ -2674,6 +2665,7 @@ async def bar_edit_product(
         db.add(db_item)
         db.commit()
         db.refresh(db_item)
+        refresh_bar_from_db(bar_id, db)
     return RedirectResponse(
         url=f"/bar/{bar_id}/categories/{category_id}/products",
         status_code=status.HTTP_303_SEE_OTHER,


### PR DESCRIPTION
## Summary
- reload bar data from the database after creating or editing a product so photo paths persist
- document cache refresh behavior in AGENTS notes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b16b36a4988320b431f0dfc1a5dde4