### PR TITLE
fix: migrate legacy product photo data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@
 - Product categories on the bar detail page use horizontal carousels with arrow controls. Markup is in `templates/bar_detail.html` and behavior lives in `static/js/app.js` (minified in `static/js/app.min.js`), computing widths from the first visible `.product-card` just like for bars.
 - Bar detail page sections (`.product-section`) wrap the category name, description, and product carousel inside a card-style box.
 - `ensure_menu_item_columns()` in `main.py` now auto-adds a `photo` column so product images persist in the `menu_items` table.
+- The same helper also migrates legacy `photo_url` data into `photo`, keeping existing product images after schema updates.
 - Product edit view (`bar_edit_product_form` in `main.py`) pulls item data directly from the database so uploaded photos appear when editing.
 - Product photo uploads are saved in the `menu_items.photo` column and reloaded at startup via `load_bars_from_db()` so images persist after restarts.
 - Product edit and bar detail pages convert product `photo_url` values to absolute URLs so images render correctly.

--- a/main.py
+++ b/main.py
@@ -427,6 +427,15 @@ def ensure_menu_item_columns() -> None:
                         f"ALTER TABLE menu_items ADD COLUMN IF NOT EXISTS {name} {ddl}"
                     )
                 )
+    # Migrate legacy `photo_url` data to the new `photo` column if present.
+    if ("photo" in columns or "photo" in missing) and "photo_url" in columns:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "UPDATE menu_items SET photo = photo_url "
+                    "WHERE photo IS NULL AND photo_url IS NOT NULL"
+                )
+            )
 
 
 @app.on_event("startup")


### PR DESCRIPTION
## Summary
- migrate existing `photo_url` values into the new `menu_items.photo` column
- document product photo column migration in AGENTS

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b170e5492c8320a88ebeaa27b60e2c