### PR TITLE
feat: centralize product photo uploads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,3 +49,4 @@
 - Product photo uploads reuse the same file-saving approach as bar photos, storing paths in `menu_items.photo` and refreshing bar data after edits.
 - Editing a product without uploading a new photo preserves the existing `menu_items.photo` path so images survive restarts.
 - Product card images adopt bar card markup with `srcset`/`sizes` for responsive loading.
+- `save_upload()` centralises file saving for bars and products; product forms reuse it to persist uploaded photos.


### PR DESCRIPTION
## Summary
- add async `save_upload` helper for saving uploaded files
- reuse `save_upload` in product create/edit flows for consistent photo handling
- document upload helper in `AGENTS.md`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1786f1bb483208573000cb075ba2e