### PR TITLE
Mirror bar edit upload flow for product edits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,5 +48,6 @@
 - After creating or editing a product, `refresh_bar_from_db()` syncs the in-memory bar data with database changes.
 - Product photo uploads reuse the same file-saving approach as bar photos, storing paths in `menu_items.photo` and refreshing bar data after edits.
 - Editing a product without uploading a new photo preserves the existing `menu_items.photo` path so images survive restarts.
+- Product edit (`bar_edit_product` in `main.py`) validates the database record belongs to the requested category before applying updates and persists new photos via `save_upload()`.
 - Product card images adopt bar card markup with `srcset`/`sizes` for responsive loading.
 - `save_upload()` centralises file saving for bars and products; product forms reuse it to persist uploaded photos.


### PR DESCRIPTION
## Summary
- ensure product edit validates associated DB record and category before updating
- reuse bar edit's upload workflow via `save_upload()` and keep in-memory data refreshed
- document product edit upload flow in `AGENTS.md`

## Testing
- `pytest tests/test_product_photo_upload.py tests/test_product_photo_edit.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b17a8bdbf08320897bf0aa5a0ec303