### PR TITLE
feat: enhance product edit photo handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@
 - The same helper also migrates legacy `photo_url` data into `photo`, keeping existing product images after schema updates.
 - Product edit view (`bar_edit_product_form` in `main.py`) pulls item data directly from the database so uploaded photos appear when editing.
 - Product photo uploads are saved in the `menu_items.photo` column and reloaded at startup via `load_bars_from_db()` so images persist after restarts.
+- Product cards read their images from this `menu_items.photo` field, so uploaded photos render in both admin listings and bar detail pages.
 - Product edit and bar detail pages convert product `photo_url` values to absolute URLs so images render correctly.
 - `/bar/{bar_id}/categories/{category_id}/products` lists now include product photo thumbnails with a fallback placeholder.
 - File uploads retrieved via `request.form()` return Starlette `UploadFile` objects; check for a `.filename` attribute instead of using `isinstance(..., UploadFile)`.
@@ -51,3 +52,4 @@
 - Product edit (`bar_edit_product` in `main.py`) validates the database record belongs to the requested category before applying updates and persists new photos via `save_upload()`.
 - Product card images adopt bar card markup with `srcset`/`sizes` for responsive loading.
 - `save_upload()` centralises file saving for bars and products; product forms reuse it to persist uploaded photos.
+- `templates/bar_edit_product.html` previews the current product photo with a placeholder fallback and limits uploads to images with `accept="image/*"`.

--- a/templates/bar_edit_product.html
+++ b/templates/bar_edit_product.html
@@ -1,5 +1,6 @@
 {% extends "layout.html" %}
 {% block content %}
+{% set fallback_img = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCA0MDAgMjI1Jz48cmVjdCB3aWR0aD0nNDAwJyBoZWlnaHQ9JzIyNScgZmlsbD0nJTIzZjFmM2Y1Jy8+PC9zdmc+" %}
 <h1>Edit Product {{ product.name }}</h1>
 <form class="form" method="post" enctype="multipart/form-data">
   <label for="name">Name
@@ -15,10 +16,12 @@
     <input id="display_order" type="number" name="display_order" value="{{ product.display_order }}">
   </label>
   {% if product.photo_url %}
-  <img src="{{ product.photo_url }}" alt="{{ product.name }} photo" style="max-width:200px;"/>
+  <img src="{{ product.photo_url }}" alt="{{ product.name }} photo" style="max-width:200px;" loading="lazy" decoding="async" onerror="this.src='{{ fallback_img }}';this.onerror=null;" width="400" height="225" />
+  {% else %}
+  <img src="{{ fallback_img }}" alt="" style="max-width:200px;" loading="lazy" width="400" height="225" />
   {% endif %}
   <label for="photo">Photo
-    <input id="photo" type="file" name="photo">
+    <input id="photo" type="file" name="photo" accept="image/*">
   </label>
   <button class="btn btn--primary" type="submit">Update</button>
 </form>

--- a/tests/test_product_photo_upload.py
+++ b/tests/test_product_photo_upload.py
@@ -86,11 +86,11 @@ def test_upload_product_photo_updates_db_and_renders():
 
     detail = client.get(f"/bars/{bar_id}")
     assert detail.status_code == 200
-    assert "http://testserver/static/uploads/" in detail.text
 
     db = SessionLocal()
     db_item = db.get(MenuItem, item_id)
     assert db_item.photo and db_item.photo.startswith("/static/uploads/")
+    assert f"http://testserver{db_item.photo}" in detail.text
     db.close()
 
     users.clear()


### PR DESCRIPTION
## Summary
- show current product photo in edit form with fallback placeholder and image-only file uploads
- document product card usage of `menu_items.photo` column
- verify product card uses stored photo path via dedicated test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b17ff4f4c083208a7e88bc218fcc3a