### PR TITLE
refactor: remove category image upload and display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,3 +50,4 @@
 - `templates/bar_edit_product.html` previews the current product photo with a placeholder fallback and limits uploads to images with `accept="image/*"`.
 - Product images are stored in the `product_images` table and served through `/api/products/{product_id}/image`; uploading uses the same endpoint via `POST` with an `image` field.
 - Templates reference this endpoint directly for product photos and rely on `onerror` fallbacks when an image is missing.
+- Category creation and edit views no longer support image uploads, and `bar_detail.html` stops rendering category photos.

--- a/main.py
+++ b/main.py
@@ -2471,8 +2471,6 @@ async def bar_new_category(
     name = form.get("name")
     description = form.get("description")
     display_order = form.get("display_order") or 0
-    photo_file = form.get("photo")
-    photo_url = await save_upload(photo_file)
     if not name or not description:
         return render_template(
             "bar_new_category.html",
@@ -2488,7 +2486,6 @@ async def bar_new_category(
         bar_id=bar_id,
         name=name,
         description=description,
-        photo_url=photo_url,
         sort_order=order_val,
     )
     db.add(db_category)
@@ -2499,7 +2496,6 @@ async def bar_new_category(
         name=name,
         description=description,
         display_order=order_val,
-        photo_url=photo_url,
     )
     bar.categories[category.id] = category
     return RedirectResponse(
@@ -2851,7 +2847,6 @@ async def bar_edit_category(
     name = form.get("name")
     description = form.get("description")
     display_order = form.get("display_order") or category.display_order
-    photo_file = form.get("photo")
     db_category = db.get(CategoryModel, category_id)
     if name:
         category.name = name
@@ -2868,17 +2863,6 @@ async def bar_edit_category(
             db_category.sort_order = order_val
     except ValueError:
         pass
-    if getattr(photo_file, "filename", None):
-        uploads_dir = os.path.join("static", "uploads")
-        os.makedirs(uploads_dir, exist_ok=True)
-        _, ext = os.path.splitext(photo_file.filename)
-        filename = f"{uuid4().hex}{ext}"
-        file_path = os.path.join(uploads_dir, filename)
-        with open(file_path, "wb") as f:
-            f.write(await photo_file.read())
-        category.photo_url = f"/static/uploads/{filename}"
-        if db_category:
-            db_category.photo_url = category.photo_url
     if db_category:
         db.commit()
     return RedirectResponse(

--- a/templates/bar_detail.html
+++ b/templates/bar_detail.html
@@ -21,9 +21,6 @@
       </div>
     </div>
     <p>{{ category.description }}</p>
-    {% if category.photo_url %}
-    <img src="{{ category.photo_url }}" alt="{{ category.name }} photo" style="max-width:200px;"/>
-    {% endif %}
     {% if user and (user.is_super_admin or (user.bar_id == bar.id and (user.is_bar_admin or user.is_bartender))) %}
     <a class="btn btn--small" href="/bar/{{ bar.id }}/categories/{{ category.id }}/edit">Edit Category</a>
     {% endif %}

--- a/templates/bar_edit_category.html
+++ b/templates/bar_edit_category.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 {% block content %}
 <h1>Edit Category for {{ bar.name }}</h1>
-<form class="form" method="post" enctype="multipart/form-data">
+<form class="form" method="post">
   <label for="name">Name
     <input id="name" name="name" value="{{ category.name }}" required>
   </label>
@@ -10,12 +10,6 @@
   </label>
   <label for="display_order">Display Order
     <input id="display_order" type="number" name="display_order" value="{{ category.display_order }}">
-  </label>
-  {% if category.photo_url %}
-  <img src="{{ category.photo_url }}" alt="{{ category.name }} photo" style="max-width:200px;"/>
-  {% endif %}
-  <label for="photo">Photo
-    <input id="photo" type="file" name="photo">
   </label>
   <button class="btn btn--primary" type="submit">Save</button>
 </form>

--- a/templates/bar_new_category.html
+++ b/templates/bar_new_category.html
@@ -2,7 +2,7 @@
 {% block content %}
 <h1>Add Category for {{ bar.name }}</h1>
 {% if error %}<p class="error">{{ error }}</p>{% endif %}
-<form class="form" method="post" enctype="multipart/form-data">
+<form class="form" method="post">
   <label for="name">Name
     <input id="name" name="name" required>
   </label>
@@ -11,9 +11,6 @@
   </label>
   <label for="display_order">Display Order
     <input id="display_order" type="number" name="display_order" value="0">
-  </label>
-  <label for="photo">Photo
-    <input id="photo" type="file" name="photo">
   </label>
   <button class="btn btn--primary" type="submit">Create</button>
 </form>


### PR DESCRIPTION
## Summary
- drop photo upload handling for bar categories
- clean up category templates and detail page to omit image fields
- document removal in AGENTS notes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1940eb00c8320bbd487f9ec92bd8f