### PR TITLE
Fix bar detail handling for missing product categories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,3 +56,4 @@
 - Bar detail page no longer displays an "Edit Category" button for each category.
 - Product card body stacks description, price, and action button with a small gap; margins removed from `.description`, `.price`, and `.add-to-cart` in `static/css/components.css` (and minified) to tighten spacing.
 - Product card description now grows to fill available space while the price and `Add to Cart` button remain pinned to the bottom with roughly `12px` of card padding and an `8px` gap between them.
+- Bar detail view skips products with missing categories to prevent rendering errors when data is inconsistent.

--- a/main.py
+++ b/main.py
@@ -1154,6 +1154,8 @@ async def bar_detail(request: Request, bar_id: int):
     for prod in bar.products.values():
         prod.photo_url = make_absolute_url(prod.photo_url, request)
         category = bar.categories.get(prod.category_id)
+        if not category:
+            continue
         products_by_category.setdefault(category, []).append(prod)
     for prods in products_by_category.values():
         prods.sort(key=lambda p: p.display_order)
@@ -1186,6 +1188,8 @@ async def add_to_cart(request: Request, bar_id: int):
         products_by_category: Dict[Category, List[Product]] = {}
         for prod in bar.products.values():
             category = bar.categories.get(prod.category_id)
+            if not category:
+                continue
             products_by_category.setdefault(category, []).append(prod)
         return render_template(
             "bar_detail.html",

--- a/tests/test_bar_detail_missing_category.py
+++ b/tests/test_bar_detail_missing_category.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import pathlib
+from decimal import Decimal
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, engine, SessionLocal  # noqa: E402
+from models import Bar as BarModel, Category as CategoryModel, MenuItem  # noqa: E402
+from main import app, bars, load_bars_from_db  # noqa: E402
+
+
+def setup_module(module):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    bars.clear()
+
+
+def test_bar_detail_handles_missing_category():
+    db = SessionLocal()
+    bar = BarModel(name="Bar", slug="bar")
+    db.add(bar)
+    db.commit()
+    db.refresh(bar)
+    category = CategoryModel(bar_id=bar.id, name="Drinks")
+    db.add(category)
+    db.commit()
+    db.refresh(category)
+    item = MenuItem(
+        bar_id=bar.id,
+        category_id=category.id,
+        name="Beer",
+        description="desc",
+        price_chf=Decimal("5.00"),
+    )
+    db.add(item)
+    db.commit()
+    db.refresh(item)
+    bar_id, category_id = bar.id, category.id
+    db.close()
+
+    load_bars_from_db()
+    bars[bar_id].categories.pop(category_id)
+
+    client = TestClient(app)
+    resp = client.get(f"/bars/{bar_id}")
+    assert resp.status_code == 200
+    assert "Beer" not in resp.text


### PR DESCRIPTION
## Summary
- guard bar detail view from products whose categories are missing
- document missing-category handling
- test that bar detail renders without missing-category errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1b793093c8320a09d960c58ba5bd8