### PR TITLE
feat: geolocate bar detail distance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
   - Categories stored in `bars.bar_categories`
   - Opening hours data is sanitized; invalid or non-dict values are treated as closed
   - Category `sort_order` defaults to `0` when missing to avoid menu sorting errors
-  - Bar detail page no longer shows distance or opening hours
+  - Bar detail page uses bar-card metadata for rating and geolocated distance; opening hours remain hidden
   - Bar detail page displays the bar's description beneath the address
 - Products:
   - Images stored in `menu_items.photo` and served via `/api/products/{id}/image`

--- a/main.py
+++ b/main.py
@@ -1161,6 +1161,7 @@ async def bar_detail(request: Request, bar_id: int):
     if not bar:
         raise HTTPException(status_code=404, detail="Bar not found")
     bar.photo_url = make_absolute_url(bar.photo_url, request)
+    bar.distance_km = None
     recent = request.session.get("recent_bar_ids", [])
     if bar.id in recent:
         recent.remove(bar.id)

--- a/templates/bar_detail.html
+++ b/templates/bar_detail.html
@@ -1,14 +1,20 @@
 {% extends "layout.html" %}
 {% block content %}
 {% set fallback_img = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCA0MDAgMjI1Jz48cmVjdCB3aWR0aD0nNDAwJyBoZWlnaHQ9JzIyNScgZmlsbD0nJTIzZjFmM2Y1Jy8+PC9zdmc+" %}
-<h1>{{ bar.name }}</h1>
+<article class="bar-card bar-detail" data-latitude="{{ bar.latitude }}" data-longitude="{{ bar.longitude }}" data-rating="{{ bar.rating or '' }}" data-distance_km="{{ bar.distance_km or '' }}" itemscope itemtype="https://schema.org/BarOrPub">
+<h1 class="title" itemprop="name">{{ bar.name }}</h1>
 {% if bar.photo_url %}
 <img class="thumb" src="{{ bar.photo_url }}" alt="{{ bar.name }} photo" itemprop="image" loading="lazy" decoding="async" width="400" height="225" srcset="{{ bar.photo_url }} 400w, {{ bar.photo_url }} 800w" sizes="(max-width: 600px) 100vw, 400px" onerror="this.src='{{ fallback_img }}';this.onerror=null;">
 {% else %}
 <img class="thumb" src="{{ fallback_img }}" alt="" loading="lazy" width="400" height="225">
 {% endif %}
-<p>{{ bar.address }}, {{ bar.city }}, {{ bar.state }}</p>
+<div class="bar-meta">
+  {% if bar.rating %}<span class="bar-rating"><i class="bi bi-star-fill" aria-hidden="true"></i> {{ '%.1f'|format(bar.rating) }}</span>{% endif %}
+  <span class="bar-distance" data-has-distance="true" hidden></span>
+</div>
+<address>{{ bar.address }}, {{ bar.city }}{% if bar.state %}, {{ bar.state }}{% endif %}</address>
 <p class="desc">{{ bar.description }}</p>
+</article>
 {% if error %}
 <p class="error">{{ error }}</p>
 {% endif %}

--- a/tests/test_bar_detail_rating_distance.py
+++ b/tests/test_bar_detail_rating_distance.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import pathlib
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, engine, SessionLocal  # noqa: E402
+from models import Bar as BarModel  # noqa: E402
+from main import app, bars, load_bars_from_db  # noqa: E402
+
+
+def setup_module(module):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    bars.clear()
+
+def test_bar_detail_has_rating_and_distance_placeholders():
+    db = SessionLocal()
+    bar = BarModel(
+        name="Bar",
+        slug="bar",
+        rating=4.5,
+        latitude=0.0,
+        longitude=0.0,
+    )
+    db.add(bar)
+    db.commit()
+    db.refresh(bar)
+    bar_id = bar.id
+    db.close()
+
+    load_bars_from_db()
+
+    client = TestClient(app)
+    resp = client.get(f"/bars/{bar_id}")
+    assert resp.status_code == 200
+    assert 'data-latitude="0.0"' in resp.text
+    assert 'data-longitude="0.0"' in resp.text
+    assert '<span class="bar-rating"><i class="bi bi-star-fill" aria-hidden="true"></i> 4.5</span>' in resp.text
+    assert '<span class="bar-distance" data-has-distance="true" hidden></span>' in resp.text
+


### PR DESCRIPTION
## Summary
- reuse bar-card metadata on bar detail for rating and geolocated distance
- remove server-side distance calculation
- document geolocation behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1c850786483209ec100ee224b8f75