### PR TITLE
feat: show bar opening hours

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,9 @@
   - Categories stored in `bars.bar_categories`
   - Opening hours data is sanitized; invalid or non-dict values are treated as closed
   - Category `sort_order` defaults to `0` when missing to avoid menu sorting errors
-  - Bar detail page uses bar-card metadata for rating and geolocated distance; opening hours remain hidden
+  - Bar detail page uses bar-card metadata for rating and geolocated distance
   - Bar detail page displays the bar's description beneath the address
+  - Bar detail page lists weekly opening hours beneath the description
   - Bar detail info is rendered in `.bar-detail` (no card styling)
 - Products:
   - Images stored in `menu_items.photo` and served via `/api/products/{id}/image`

--- a/main.py
+++ b/main.py
@@ -529,6 +529,34 @@ def is_open_now_from_hours(hours: Dict[str, Dict[str, str]]) -> bool:
     return start <= now_t < end
 
 
+def weekly_hours_list(hours: Optional[Dict[str, Dict[str, str]]]) -> List[Dict[str, Optional[str]]]:
+    """Return a list of weekly opening hours for display purposes.
+
+    The input ``hours`` mapping uses string keys ``0``-``6`` for Monday-Sunday.
+    Any missing or malformed entries are treated as closed for that day.
+    """
+    days = [
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday",
+    ]
+    if not isinstance(hours, dict):
+        hours = {}
+    result: List[Dict[str, Optional[str]]] = []
+    for idx, day in enumerate(days):
+        info = hours.get(str(idx)) if hours else None
+        open_time = close_time = None
+        if isinstance(info, dict):
+            open_time = info.get("open")
+            close_time = info.get("close")
+        result.append({"day": day, "open": open_time, "close": close_time})
+    return result
+
+
 def is_bar_open_now(bar: BarModel) -> bool:
     """Determine if a bar is currently open considering manual closures."""
     if getattr(bar, "manual_closed", False):
@@ -1187,6 +1215,9 @@ async def bar_detail(request: Request, bar_id: int):
         request=request,
         bar=bar,
         products_by_category=sorted_products,
+        opening_hours=weekly_hours_list(bar.opening_hours)
+        if bar.opening_hours
+        else [],
     )
 
 

--- a/templates/bar_detail.html
+++ b/templates/bar_detail.html
@@ -14,6 +14,15 @@
 </div>
 <address>{{ bar.address }}, {{ bar.city }}{% if bar.state %}, {{ bar.state }}{% endif %}</address>
 <p class="desc">{{ bar.description }}</p>
+{% if opening_hours %}
+<ul class="opening-hours">
+  {% for h in opening_hours %}
+  <li>{{ h.day }}:
+    {% if h.open and h.close %}{{ h.open }} - {{ h.close }}{% else %}Closed{% endif %}
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}
 </section>
 {% if error %}
 <p class="error">{{ error }}</p>

--- a/tests/test_bar_detail_hours_display.py
+++ b/tests/test_bar_detail_hours_display.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import json
+import pathlib
+from decimal import Decimal
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, engine, SessionLocal  # noqa: E402
+from models import Bar as BarModel, Category as CategoryModel, MenuItem  # noqa: E402
+from main import app, bars, load_bars_from_db  # noqa: E402
+
+
+def setup_module(module):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    bars.clear()
+
+
+def test_bar_detail_shows_opening_hours():
+    db = SessionLocal()
+    hours = json.dumps({"0": {"open": "08:00", "close": "17:00"}})
+    bar = BarModel(name="Bar", slug="bar", opening_hours=hours)
+    db.add(bar)
+    db.commit()
+    db.refresh(bar)
+    category = CategoryModel(bar_id=bar.id, name="Drinks")
+    db.add(category)
+    db.commit()
+    db.refresh(category)
+    item = MenuItem(
+        bar_id=bar.id,
+        category_id=category.id,
+        name="Beer",
+        description="desc",
+        price_chf=Decimal("5.00"),
+    )
+    db.add(item)
+    db.commit()
+    db.refresh(item)
+    bar_id = bar.id
+    db.close()
+
+    load_bars_from_db()
+
+    client = TestClient(app)
+    resp = client.get(f"/bars/{bar_id}")
+    assert resp.status_code == 200
+    assert "Monday" in resp.text
+    assert "08:00" in resp.text
+    assert "17:00" in resp.text


### PR DESCRIPTION
## Summary
- display weekly opening hours on bar detail page
- note the new behaviour in AGENTS guidance
- cover opening hours rendering with a dedicated test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1d16b2d7c832081d477513a51240d