### PR TITLE
feat: show bar open status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@
   - Category `sort_order` defaults to `0` when missing to avoid menu sorting errors
   - Bar detail page uses bar-card metadata for rating and geolocated distance
   - Bar detail page displays the bar's description beneath the address
+  - Bar detail page shows open/closed status using `bar.is_open_now`
   - Bar detail page lists weekly opening hours beneath the description
   - Bar detail info is rendered in `.bar-detail` (no card styling)
 - Products:

--- a/templates/bar_detail.html
+++ b/templates/bar_detail.html
@@ -8,6 +8,11 @@
 {% else %}
 <img class="thumb" src="{{ fallback_img }}" alt="" loading="lazy" width="400" height="225">
 {% endif %}
+{% if bar.is_open_now %}
+<span class="status status-open">Open now</span>
+{% else %}
+<span class="status status-closed">Closed now</span>
+{% endif %}
 <div class="bar-meta">
   {% if bar.rating %}<span class="bar-rating"><i class="bi bi-star-fill" aria-hidden="true"></i> {{ '%.1f'|format(bar.rating) }}</span>{% endif %}
   <span class="bar-distance" data-has-distance="true" hidden></span>

--- a/tests/test_bar_detail_open_status.py
+++ b/tests/test_bar_detail_open_status.py
@@ -1,0 +1,69 @@
+import os
+import sys
+import json
+import pathlib
+from datetime import datetime
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, engine, SessionLocal  # noqa: E402
+from models import Bar as BarModel  # noqa: E402
+from main import app, bars, load_bars_from_db  # noqa: E402
+import main  # noqa: E402
+
+def reset_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    bars.clear()
+
+def add_bar(hours_json: str) -> int:
+    db = SessionLocal()
+    bar = BarModel(name="Bar", slug="bar", opening_hours=hours_json)
+    db.add(bar)
+    db.commit()
+    db.refresh(bar)
+    bar_id = bar.id
+    db.close()
+    return bar_id
+
+def test_bar_detail_shows_open_status(monkeypatch):
+    reset_db()
+    monkeypatch.setenv("BAR_TIMEZONE", "UTC")
+    hours = json.dumps({"0": {"open": "08:00", "close": "17:00"}})
+    bar_id = add_bar(hours)
+
+    class FakeDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2024, 1, 1, 12, 0, tzinfo=tz)
+
+    monkeypatch.setattr(main, "datetime", FakeDatetime)
+
+    load_bars_from_db()
+
+    client = TestClient(app)
+    resp = client.get(f"/bars/{bar_id}")
+    assert resp.status_code == 200
+    assert "Open now" in resp.text
+
+def test_bar_detail_shows_closed_status(monkeypatch):
+    reset_db()
+    monkeypatch.setenv("BAR_TIMEZONE", "UTC")
+    hours = json.dumps({"0": {"open": "08:00", "close": "17:00"}})
+    bar_id = add_bar(hours)
+
+    class FakeDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2024, 1, 1, 18, 0, tzinfo=tz)
+
+    monkeypatch.setattr(main, "datetime", FakeDatetime)
+
+    load_bars_from_db()
+
+    client = TestClient(app)
+    resp = client.get(f"/bars/{bar_id}")
+    assert resp.status_code == 200
+    assert "Closed now" in resp.text


### PR DESCRIPTION
## Summary
- display open/closed badge on bar detail page
- document bar detail open status
- add tests covering open and closed states

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1d3ba66288320bd029afd5007b9dd