### PR TITLE
Restore open/closed status colors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@
   - Bar detail page lists weekly opening hours beneath the description
   - Bar detail info is rendered in `.bar-detail` (no card styling)
   - Bar detail layout: `.bar-cover` image (16/9), `.bar-meta` row with status/rating/distance, `.clamp`ed description, and `.bar-hours-card` grid (Mon–Thu / Fri–Sun)
+  - Open status uses `.status-open` (green) and closed status uses `.status-closed` (red); badges apply the same classes for background colors
 - Products:
   - Images stored in `menu_items.photo` and served via `/api/products/{id}/image`
   - `templates/bar_detail.html` shows products with carousels handled by `static/js/app.js`

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -107,8 +107,10 @@ body.dark-mode{
 
 .badge{display:inline-flex;align-items:center;justify-content:center;border-radius:999px;background:var(--brand);color:#fff;padding:0 var(--space-1);font-size:.75rem;}
 .status{font-weight:600;}
-.status-open{color:#2563eb;}
+.status-open{color:#10B981;}
 .status-closed{color:#dc2626;}
+.badge.status-open{background:#10B981;}
+.badge.status-closed{background:#dc2626;}
 
 .card{background:var(--surface);border-radius:var(--radius);overflow:hidden;box-shadow:var(--shadow);transition:.25s;display:flex;flex-direction:column;}
 @media (max-width:768px){.card{max-height:400px;}}

--- a/templates/bar_detail.html
+++ b/templates/bar_detail.html
@@ -13,7 +13,7 @@
   <div class="bar-meta">
     <span class="bar-status">
       <i class="bi bi-circle-fill {% if bar.is_open_now %}status-open{% else %}status-closed{% endif %}" aria-hidden="true"></i>
-      <span class="badge">{% if bar.is_open_now %}Open now{% else %}Closed now{% endif %}</span>
+      <span class="badge {% if bar.is_open_now %}status-open{% else %}status-closed{% endif %}">{% if bar.is_open_now %}Open now{% else %}Closed now{% endif %}</span>
     </span>
     {% if bar.rating %}<span class="bar-rating"><i class="bi bi-star-fill" aria-hidden="true"></i> {{ '%.1f'|format(bar.rating) }}</span>{% endif %}
     <span class="bar-distance" data-has-distance="true" hidden><i class="bi bi-geo-alt" aria-hidden="true"></i> <span class="distance-value"></span></span>


### PR DESCRIPTION
## Summary
- revert "Open now" indicator to green and "Closed now" to red
- apply matching status classes to bar detail badge
- document status color conventions in AGENTS notes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1dd8ba45483208ed319e2908e4a1a