### PR TITLE
style: align bar detail status with bar card

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,10 +21,11 @@
   - Bar detail page uses bar-card metadata for rating and geolocated distance
   - Bar detail page displays the bar's description beneath the address
   - Bar detail page shows open/closed status using `bar.is_open_now`
+  - Bar detail page uses the same `.status` classes as bar cards for open/closed labels
   - Bar detail page lists weekly opening hours beneath the description
   - Bar detail info is rendered in `.bar-detail` (no card styling)
   - Bar detail layout: `.bar-cover` image (16/9), `.bar-meta` row with status/rating/distance, `.clamp`ed description, and `.bar-hours-card` grid (Mon–Thu / Fri–Sun)
-  - Open status uses `.status-open` (green) and closed status uses `.status-closed` (red); badges apply the same classes for background colors
+  - Open status uses `.status-open` (green) and closed status uses `.status-closed` (red)
 - Products:
   - Images stored in `menu_items.photo` and served via `/api/products/{id}/image`
   - `templates/bar_detail.html` shows products with carousels handled by `static/js/app.js`

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -521,11 +521,6 @@ body.dark-mode{
   align-items:center;
   gap:4px;
 }
-.bar-detail .bar-status .badge{
-  font-size:.75rem;
-  font-weight:600;
-  padding:2px 6px;
-}
 .bar-address,
 .bar-desc{
   color:var(--muted);

--- a/templates/bar_detail.html
+++ b/templates/bar_detail.html
@@ -12,8 +12,7 @@
   <h1 class="bar-title" itemprop="name">{{ bar.name }}</h1>
   <div class="bar-meta">
     <span class="bar-status">
-      <i class="bi bi-circle-fill {% if bar.is_open_now %}status-open{% else %}status-closed{% endif %}" aria-hidden="true"></i>
-      <span class="badge {% if bar.is_open_now %}status-open{% else %}status-closed{% endif %}">{% if bar.is_open_now %}Open now{% else %}Closed now{% endif %}</span>
+      <span class="status {% if bar.is_open_now %}status-open{% else %}status-closed{% endif %}">{% if bar.is_open_now %}Open now{% else %}Closed now{% endif %}</span>
     </span>
     {% if bar.rating %}<span class="bar-rating"><i class="bi bi-star-fill" aria-hidden="true"></i> {{ '%.1f'|format(bar.rating) }}</span>{% endif %}
     <span class="bar-distance" data-has-distance="true" hidden><i class="bi bi-geo-alt" aria-hidden="true"></i> <span class="distance-value"></span></span>


### PR DESCRIPTION
## Summary
- reuse bar-card status styling for bar detail open/closed label
- remove badge-specific CSS and document status styling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1e3dff59c83209707a8903d52d864