### PR TITLE
fix: allow cart form submissions via POST

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,9 @@
 - Products:
   - Images stored in `menu_items.photo` and served via `/api/products/{id}/image`
   - `templates/bar_detail.html` shows products with carousels handled by `static/js/app.js`
+- Cart:
+  - `/bars/{bar_id}/add_to_cart` accepts POST form submissions
+  - `/cart/update` and `/cart/checkout` also expect POST form data
 - Users:
   - Credit stored in `users.credit`; ensured by `ensure_credit_column()` on startup
 - Testing:


### PR DESCRIPTION
## Summary
- handle add-to-cart as POST form submission
- update cart update and checkout routes to expect POST data
- document cart POST routes in AGENTS notes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b53c9b159083208f19b3b1d6d42954