### PR TITLE
feat: manage bar tables with staff notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@
   - Bar detail layout: `.bar-cover` image (16/9), `.bar-meta` row with status/rating/distance, `.clamp`ed description, and `.bar-hours-card` grid (Mon–Thu / Fri–Sun)
   - `.bar-detail` has `margin-bottom: var(--space-4)` to add space before product categories
   - Open status uses `.status-open` (green) and closed status uses `.status-closed` (red)
+  - Bar edit options page now links to table management (`templates/admin_bar_tables.html`) where staff can add tables with descriptions stored in the `tables` DB table; descriptions are only for staff use
 - Products:
   - Images stored in `menu_items.photo` and served via `/api/products/{id}/image`
   - `templates/bar_detail.html` shows products with carousels handled by `static/js/app.js`

--- a/models.py
+++ b/models.py
@@ -71,6 +71,7 @@ class Bar(Base):
 
     categories = relationship("Category", back_populates="bar")
     menu_items = relationship("MenuItem", back_populates="bar")
+    tables = relationship("Table", back_populates="bar")
 
 
 class UserBarRole(Base):
@@ -119,6 +120,17 @@ class MenuItem(Base):
     bar = relationship("Bar", back_populates="menu_items")
     category = relationship("Category", back_populates="items")
     variants = relationship("MenuVariant", back_populates="item")
+
+
+class Table(Base):
+    __tablename__ = "tables"
+
+    id = Column(Integer, primary_key=True)
+    bar_id = Column(Integer, ForeignKey("bars.id"), nullable=False)
+    name = Column(String(100), nullable=False)
+    description = Column(Text)
+
+    bar = relationship("Bar", back_populates="tables")
 
 
 class MenuVariant(Base):

--- a/templates/admin_bar_tables.html
+++ b/templates/admin_bar_tables.html
@@ -1,0 +1,36 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>Manage Tables for {{ bar.name }}</h1>
+<form class="form" method="post" action="/admin/bars/{{ bar.id }}/tables/new">
+  <label for="name">Table Name
+    <input id="name" name="name" required>
+  </label>
+  <label for="description">Description
+    <input id="description" name="description">
+  </label>
+  <button class="btn btn--primary" type="submit">Add Table</button>
+</form>
+{% if tables %}
+<table class="table">
+  <thead>
+    <tr><th>#</th><th>Name</th><th>Description</th><th>Actions</th></tr>
+  </thead>
+  <tbody>
+    {% for t in tables %}
+    <tr>
+      <td>{{ loop.index }}</td>
+      <td>{{ t.name }}</td>
+      <td>{{ t.description }}</td>
+      <td>
+        <form method="post" action="/admin/bars/{{ bar.id }}/tables/{{ t.id }}/delete" style="display:inline" onsubmit="return confirm('Delete table?');">
+          <button class="btn" type="submit">Delete</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p>No tables yet.</p>
+{% endif %}
+{% endblock %}

--- a/templates/admin_edit_bar_options.html
+++ b/templates/admin_edit_bar_options.html
@@ -5,5 +5,6 @@
   <li><a href="/admin/bars/edit/{{ bar.id }}/info">Edit Basic Info</a></li>
   <li><a href="/bar/{{ bar.id }}/categories">Manage Menu & Categories</a></li>
   <li><a href="/admin/bars/{{ bar.id }}/users">Manage Users</a></li>
+  <li><a href="/admin/bars/{{ bar.id }}/tables">Manage Tables</a></li>
 </ul>
 {% endblock %}

--- a/tests/test_manage_tables.py
+++ b/tests/test_manage_tables.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import pathlib
+
+# Use shared in-memory SQLite database
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, SessionLocal, engine  # noqa: E402
+from models import Bar, Table  # noqa: E402
+from main import app  # noqa: E402
+
+
+def setup_module(module):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def _login_super_admin(client: TestClient) -> None:
+    resp = client.post(
+        "/login",
+        data={"email": "admin@example.com", "password": "ChangeMe!123"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+def test_add_table():
+    db = SessionLocal()
+    bar = Bar(name="My Bar", slug="my-bar")
+    db.add(bar)
+    db.commit()
+    db.refresh(bar)
+    db.close()
+
+    with TestClient(app) as client:
+        _login_super_admin(client)
+        form = {"name": "Table 1", "description": "Near window"}
+        resp = client.post(f"/admin/bars/{bar.id}/tables/new", data=form, follow_redirects=False)
+        assert resp.status_code in (200, 303)
+        resp = client.get(f"/admin/bars/{bar.id}/tables")
+        assert "Table 1" in resp.text
+        assert "Near window" in resp.text
+
+    db = SessionLocal()
+    table = db.query(Table).filter_by(bar_id=bar.id, name="Table 1").first()
+    assert table is not None and table.description == "Near window"
+    db.close()


### PR DESCRIPTION
## Summary
- add `Table` model and in-memory support
- allow staff to add or delete tables with internal descriptions
- link table management from bar edit options and cover with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b559b97fc48320bc2c90068041ac88