### PR TITLE
feat: manage bar tables with edit support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@
   - Bar detail layout: `.bar-cover` image (16/9), `.bar-meta` row with status/rating/distance, `.clamp`ed description, and `.bar-hours-card` grid (Mon–Thu / Fri–Sun)
   - `.bar-detail` has `margin-bottom: var(--space-4)` to add space before product categories
   - Open status uses `.status-open` (green) and closed status uses `.status-closed` (red)
-  - Bar edit options page now links to table management (`templates/admin_bar_tables.html`) where staff can add tables with descriptions stored in the `tables` DB table; descriptions are only for staff use
+  - Bar edit options page links to table management (`templates/admin_bar_tables.html`) where staff can add, edit, and delete tables. Add and edit forms live in `templates/admin_bar_new_table.html` and `templates/admin_bar_edit_table.html`; table descriptions are for staff only
 - Products:
   - Images stored in `menu_items.photo` and served via `/api/products/{id}/image`
   - `templates/bar_detail.html` shows products with carousels handled by `static/js/app.js`

--- a/templates/admin_bar_edit_table.html
+++ b/templates/admin_bar_edit_table.html
@@ -1,0 +1,13 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>Edit Table for {{ bar.name }}</h1>
+<form class="form" method="post">
+  <label for="name">Name
+    <input id="name" name="name" value="{{ table.name }}" required>
+  </label>
+  <label for="description">Description
+    <input id="description" name="description" value="{{ table.description }}">
+  </label>
+  <button class="btn btn--primary" type="submit">Save</button>
+</form>
+{% endblock %}

--- a/templates/admin_bar_new_table.html
+++ b/templates/admin_bar_new_table.html
@@ -1,0 +1,13 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>Add Table for {{ bar.name }}</h1>
+<form class="form" method="post">
+  <label for="name">Name
+    <input id="name" name="name" required>
+  </label>
+  <label for="description">Description
+    <input id="description" name="description">
+  </label>
+  <button class="btn btn--primary" type="submit">Create</button>
+</form>
+{% endblock %}

--- a/templates/admin_bar_tables.html
+++ b/templates/admin_bar_tables.html
@@ -1,15 +1,11 @@
 {% extends "layout.html" %}
 {% block content %}
 <h1>Manage Tables for {{ bar.name }}</h1>
-<form class="form" method="post" action="/admin/bars/{{ bar.id }}/tables/new">
-  <label for="name">Table Name
-    <input id="name" name="name" required>
-  </label>
-  <label for="description">Description
-    <input id="description" name="description">
-  </label>
-  <button class="btn btn--primary" type="submit">Add Table</button>
-</form>
+
+<div class="toolbar" style="margin-bottom:1rem;">
+  <a class="btn btn--primary" href="/admin/bars/{{ bar.id }}/tables/new">Add Table</a>
+</div>
+
 {% if tables %}
 <table class="table">
   <thead>
@@ -22,6 +18,7 @@
       <td>{{ t.name }}</td>
       <td>{{ t.description }}</td>
       <td>
+        <a class="btn" href="/admin/bars/{{ bar.id }}/tables/{{ t.id }}/edit">Edit</a>
         <form method="post" action="/admin/bars/{{ bar.id }}/tables/{{ t.id }}/delete" style="display:inline" onsubmit="return confirm('Delete table?');">
           <button class="btn" type="submit">Delete</button>
         </form>

--- a/tests/test_manage_tables.py
+++ b/tests/test_manage_tables.py
@@ -37,13 +37,56 @@ def test_add_table():
     with TestClient(app) as client:
         _login_super_admin(client)
         form = {"name": "Table 1", "description": "Near window"}
-        resp = client.post(f"/admin/bars/{bar.id}/tables/new", data=form, follow_redirects=False)
+        resp = client.post(
+            f"/admin/bars/{bar.id}/tables/new", data=form, follow_redirects=False
+        )
         assert resp.status_code in (200, 303)
         resp = client.get(f"/admin/bars/{bar.id}/tables")
+        assert "Add Table" in resp.text
+        assert f"/admin/bars/{bar.id}/tables/new" in resp.text
         assert "Table 1" in resp.text
         assert "Near window" in resp.text
+        assert "Edit" in resp.text
 
     db = SessionLocal()
     table = db.query(Table).filter_by(bar_id=bar.id, name="Table 1").first()
     assert table is not None and table.description == "Near window"
+    db.close()
+
+
+def test_edit_table():
+    db = SessionLocal()
+    bar = Bar(name="Second Bar", slug="second-bar")
+    db.add(bar)
+    db.commit()
+    db.refresh(bar)
+    db.close()
+
+    with TestClient(app) as client:
+        _login_super_admin(client)
+        # create table
+        form = {"name": "T1", "description": "Desc"}
+        client.post(
+            f"/admin/bars/{bar.id}/tables/new", data=form, follow_redirects=False
+        )
+        db = SessionLocal()
+        table_obj = db.query(Table).filter_by(bar_id=bar.id, name="T1").first()
+        table_id = table_obj.id
+        db.close()
+        # edit table
+        form = {"name": "Table A", "description": "Updated"}
+        resp = client.post(
+            f"/admin/bars/{bar.id}/tables/{table_id}/edit",
+            data=form,
+            follow_redirects=False,
+        )
+        assert resp.status_code in (200, 303)
+        resp = client.get(f"/admin/bars/{bar.id}/tables")
+        assert "Table A" in resp.text
+        assert "Updated" in resp.text
+
+    db = SessionLocal()
+    table = db.query(Table).filter_by(id=table_id).first()
+    assert table.name == "Table A"
+    assert table.description == "Updated"
     db.close()


### PR DESCRIPTION
## Summary
- show bar tables in a list with edit/delete actions
- add separate forms to add and edit tables
- cover table editing with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b55c96eca483208d6448aee521466c