### PR TITLE
Hide cart popup on top-up page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,8 @@
   - Navigating away from the active bar shows a blocking popup in `templates/layout.html` styled via `.cart-blocker` and `.cart-popup`.
   - `cart.html` displays the current bar's name, lists its tables for selection, and shows a wallet link for adding funds.
   - The popup offers "Remove products" (clears cart via `POST /cart/clear`) or "Go to the bar menu".
-  - Wallet pages clear `cart_bar_id` to prevent the cart popup from appearing.
+  - Wallet and top-up pages clear `cart_bar_id` to prevent the cart popup from appearing.
+  - The top-up page at `/topup` renders `templates/topup.html` and suppresses the cart popup by passing `cart_bar_id` and `cart_bar_name` as `None`.
 - Users:
   - Credit stored in `users.credit`; ensured by `ensure_credit_column()` on startup
 - Testing:

--- a/main.py
+++ b/main.py
@@ -1537,7 +1537,11 @@ async def topup(request: Request, db: Session = Depends(get_db)):
                 raise ValueError
         except ValueError:
             return render_template(
-                "topup.html", request=request, error="Invalid amount"
+                "topup.html",
+                request=request,
+                error="Invalid amount",
+                cart_bar_id=None,
+                cart_bar_name=None,
             )
         # In a real application, integrate with a payment gateway here
         user.credit += add_amount
@@ -1546,9 +1550,16 @@ async def topup(request: Request, db: Session = Depends(get_db)):
             db_user.credit = user.credit
             db.commit()
         return render_template(
-            "topup.html", request=request, success=True, amount=add_amount
+            "topup.html",
+            request=request,
+            success=True,
+            amount=add_amount,
+            cart_bar_id=None,
+            cart_bar_name=None,
         )
-    return render_template("topup.html", request=request)
+    return render_template(
+        "topup.html", request=request, cart_bar_id=None, cart_bar_name=None
+    )
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_topup_popup.py
+++ b/tests/test_topup_popup.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import pathlib
+import hashlib
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, SessionLocal, engine  # noqa: E402
+from models import Bar, Category, MenuItem, User  # noqa: E402
+from main import app  # noqa: E402
+
+
+def setup_module(module):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def test_topup_hides_cart_popup_when_cart_exists():
+    db = SessionLocal()
+    bar = Bar(name="Test Bar", slug="test-bar")
+    db.add(bar)
+    db.commit()
+    db.refresh(bar)
+    cat = Category(bar_id=bar.id, name="Drinks")
+    db.add(cat)
+    db.commit()
+    db.refresh(cat)
+    item = MenuItem(bar_id=bar.id, category_id=cat.id, name="Water", price_chf=5)
+    db.add(item)
+    password_hash = hashlib.sha256("pass".encode("utf-8")).hexdigest()
+    user = User(username="u", email="u@example.com", password_hash=password_hash)
+    db.add(user)
+    db.commit()
+    db.refresh(item)
+    db.refresh(user)
+    item_id = item.id
+    bar_id = bar.id
+    user_email = user.email
+    db.close()
+
+    with TestClient(app) as client:
+        client.post("/login", data={"email": user_email, "password": "pass"})
+        client.post(
+            f"/bars/{bar_id}/add_to_cart",
+            data={"product_id": item_id},
+            headers={"accept": "application/json"},
+        )
+        resp = client.get("/topup")
+        assert resp.status_code == 200
+        assert '<div id="cartBlocker" class="cart-blocker" hidden>' in resp.text


### PR DESCRIPTION
## Summary
- prevent cart popup from appearing on the top-up page by clearing cart context variables
- document top-up behaviour and popup suppression in AGENTS notes
- test that top-up page hides cart popup even when a cart exists

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b570abd74883209035f2bdab2ee495