### PR TITLE
feat: track orders and add history page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,5 +55,9 @@
   - The top-up page at `/topup` renders `templates/topup.html` and suppresses the cart popup by passing `cart_bar_id` and `cart_bar_name` as `None`.
 - Users:
   - Credit stored in `users.credit`; ensured by `ensure_credit_column()` on startup
+- Orders:
+  - `/orders` page renders `templates/order_history.html` with past `Order` entries for the current user.
+  - Checkout persists orders to the database and redirects to `/orders`.
+  - Mobile hamburger menu links to order history via `bi bi-clock-history` icon.
 - Testing:
   - Run `pytest`

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -70,6 +70,7 @@
         {% endif %}
         {% if user %}
         <a href="/wallet" role="menuitem"><i class="bi bi-wallet2" aria-hidden="true"></i><span>Wallet</span></a>
+        <a href="/orders" role="menuitem"><i class="bi bi-clock-history" aria-hidden="true"></i><span>Orders</span></a>
         <a href="/logout" role="menuitem"><i class="bi bi-box-arrow-right" aria-hidden="true"></i><span>Logout</span></a>
         {% else %}
         <a href="/login" role="menuitem" class="menu-login"><i class="bi bi-box-arrow-in-right" aria-hidden="true"></i><span>Login</span></a>

--- a/templates/order_history.html
+++ b/templates/order_history.html
@@ -1,0 +1,11 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>Order History</h1>
+<ul>
+  {% for order in orders %}
+  <li>Order #{{ order.id }} - CHF {{ "%.2f"|format(order.subtotal) }}</li>
+  {% else %}
+  <li>No orders yet.</li>
+  {% endfor %}
+</ul>
+{% endblock %}


### PR DESCRIPTION
## Summary
- persist orders on checkout and redirect to new history page
- add order history route and template
- link order history in mobile menu via Bootstrap icon
- document order tracking in AGENTS

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b57a0060ac8320b46d1f968b45c8fd