### PR TITLE
fix: handle missing menu items in order history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@
   - Bartender sees a single action button per order: Accept → Ready → Complete.
   - Order listings include customer name/phone, table, and line items for both bartender and user history.
   - `order_history.html` uses `order.customer_name`, `order.customer_prefix`, `order.customer_phone`, and `order.table_name` to avoid `None` errors when related records are missing.
+  - `order_history.html` displays line items via `item.menu_item_name` to handle missing menu items gracefully.
   - `ensure_order_columns()` in `main.py` adds missing columns to the `orders` table at startup.
 - Testing:
   - Run `pytest`

--- a/templates/order_history.html
+++ b/templates/order_history.html
@@ -11,7 +11,7 @@
     Table: {{ order.table_name or '' }}
     <ul>
       {% for item in order.items %}
-      <li>{{ item.qty }}× {{ item.menu_item.name }}</li>
+      <li>{{ item.qty }}× {{ item.menu_item_name or 'Unknown item' }}</li>
       {% endfor %}
     </ul>
   </li>
@@ -29,7 +29,7 @@
     Table: {{ order.table_name or '' }}
     <ul>
       {% for item in order.items %}
-      <li>{{ item.qty }}× {{ item.menu_item.name }}</li>
+      <li>{{ item.qty }}× {{ item.menu_item_name or 'Unknown item' }}</li>
       {% endfor %}
     </ul>
   </li>


### PR DESCRIPTION
## Summary
- avoid crashes when orders reference deleted menu items
- document menu item fallback for order history

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5914163508320b5ca9be50d26755d