### PR TITLE
fix: ensure table_id column on orders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,6 @@
   - Order listings include customer name/phone, table, and line items for both bartender and user history.
   - `order_history.html` uses `order.customer_name`, `order.customer_prefix`, `order.customer_phone`, and `order.table_name` to avoid `None` errors when related records are missing.
   - `order_history.html` displays line items via `item.menu_item_name` to handle missing menu items gracefully.
-  - `ensure_order_columns()` in `main.py` adds missing columns to the `orders` table at startup.
+  - `ensure_order_columns()` in `main.py` adds missing columns (e.g., `table_id`, `status`) to the `orders` table at startup.
 - Testing:
   - Run `pytest`

--- a/main.py
+++ b/main.py
@@ -568,6 +568,7 @@ def ensure_order_columns() -> None:
     inspector = inspect(engine)
     columns = {col["name"] for col in inspector.get_columns("orders")}
     required = {
+        "table_id": "INTEGER",
         "vat_total": "NUMERIC(10, 2) DEFAULT 0",
         "fee_platform_5pct": "NUMERIC(10, 2) DEFAULT 0",
         "payout_due_to_bar": "NUMERIC(10, 2) DEFAULT 0",

--- a/tests/test_checkout_with_outdated_orders_table.py
+++ b/tests/test_checkout_with_outdated_orders_table.py
@@ -23,7 +23,6 @@ def reset_db_with_legacy_orders():
                     id INTEGER PRIMARY KEY,
                     bar_id INTEGER NOT NULL,
                     customer_id INTEGER,
-                    table_id INTEGER,
                     subtotal NUMERIC(10,2) DEFAULT 0
                 )
                 """
@@ -38,6 +37,7 @@ def test_checkout_succeeds_when_order_columns_missing():
         insp = inspect(engine)
         cols = {c["name"] for c in insp.get_columns("orders")}
         assert "status" in cols  # added by ensure_order_columns()
+        assert "table_id" in cols  # added by ensure_order_columns()
 
         db = SessionLocal()
         bar = Bar(name="Test Bar", slug="test-bar")


### PR DESCRIPTION
## Summary
- ensure `table_id` is added to legacy `orders` tables at startup
- cover missing `table_id` case in checkout regression test
- document `ensure_order_columns` behavior in AGENTS notes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b593f4d0608320ae6f9c921f01da9e