### PR TITLE
fix: persist user credit and bar assignment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@
 - Users:
   - Credit stored in `users.credit`; ensured by `ensure_credit_column()` on startup
   - Admin user edits clear old bar roles before saving new assignments
+  - Admin user edits persist credit and current bar assignment; `_load_demo_user` hydrates both from the database
 - Orders:
   - `/orders` page renders `templates/order_history.html` with past `Order` entries for the current user.
   - Checkout persists orders to the database and redirects to `/orders`.

--- a/main.py
+++ b/main.py
@@ -2872,6 +2872,8 @@ def _load_demo_user(user_id: int, db: Session) -> DemoUser:
         phone=db_user.phone or "",
         prefix=db_user.prefix or "",
         role=role_map.get(db_user.role, "customer"),
+        bar_id=(db_user.bar_roles[0].bar_id if db_user.bar_roles else None),
+        credit=float(db_user.credit or 0),
     )
     users[user.id] = user
     users_by_username[user.username] = user
@@ -2998,7 +3000,7 @@ async def update_user(request: Request, user_id: int, db: Session = Depends(get_
     }
     role_enum = role_enum_map.get(role, RoleEnum.CUSTOMER)
     db_user.role = role_enum
-    db_user.credit = user.credit
+    db_user.credit = Decimal(str(user.credit))
     # Update user-bar role association: remove previous roles then add new assignment
     db.query(UserBarRole).filter(UserBarRole.user_id == user_id).delete()
     if user.bar_id:

--- a/tests/test_update_user.py
+++ b/tests/test_update_user.py
@@ -77,8 +77,8 @@ def test_update_user_details_without_password():
 def test_update_user_reassign_bar():
     db = SessionLocal()
     password_hash = hashlib.sha256("pass".encode("utf-8")).hexdigest()
-    bar1 = Bar(name="Bar1", slug="bar1")
-    bar2 = Bar(name="Bar2", slug="bar2")
+    bar1 = Bar(name="Bar3", slug="bar3")
+    bar2 = Bar(name="Bar4", slug="bar4")
     db.add_all([bar1, bar2])
     db.commit()
     bar1_id = bar1.id
@@ -119,6 +119,60 @@ def test_update_user_reassign_bar():
         assert resp.status_code == 303
 
     db = SessionLocal()
+    roles = db.query(UserBarRole).filter(UserBarRole.user_id == user_id).all()
+    assert len(roles) == 1
+    assert roles[0].bar_id == bar2_id
+    db.close()
+
+
+def test_update_user_credit_and_bar_assignment():
+    db = SessionLocal()
+    password_hash = hashlib.sha256("pass".encode("utf-8")).hexdigest()
+    bar1 = Bar(name="Bar1", slug="bar1")
+    bar2 = Bar(name="Bar2", slug="bar2")
+    db.add_all([bar1, bar2])
+    db.commit()
+    bar1_id = bar1.id
+    bar2_id = bar2.id
+    user = User(
+        username="user2",
+        email="user2@example.com",
+        password_hash=password_hash,
+        role=RoleEnum.BARADMIN,
+        credit=0,
+    )
+    db.add(user)
+    db.commit()
+    user_id = user.id
+    db.add(UserBarRole(user_id=user_id, bar_id=bar1_id, role=RoleEnum.BARADMIN))
+    db.commit()
+    db.close()
+
+    db = SessionLocal()
+    refresh_bar_from_db(bar1_id, db)
+    refresh_bar_from_db(bar2_id, db)
+    db.close()
+
+    with TestClient(app) as client:
+        _login_super_admin(client)
+        form = {
+            "username": "user2",
+            "password": "",
+            "email": "user2@example.com",
+            "prefix": "",
+            "phone": "",
+            "role": "bar_admin",
+            "bar_id": str(bar2_id),
+            "credit": "15.5",
+        }
+        resp = client.post(
+            f"/admin/users/edit/{user_id}", data=form, follow_redirects=False
+        )
+        assert resp.status_code == 303
+
+    db = SessionLocal()
+    updated = db.query(User).filter(User.id == user_id).first()
+    assert float(updated.credit) == 15.5
     roles = db.query(UserBarRole).filter(UserBarRole.user_id == user_id).all()
     assert len(roles) == 1
     assert roles[0].bar_id == bar2_id


### PR DESCRIPTION
## Summary
- hydrate demo users with credit and bar assignment from the database
- store user credit using Decimal and ensure bar assignments are saved
- test editing a user updates credit and bar mapping

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5a50d66bc8320ad18242164fa9ef9