### PR TITLE
fix: support secure websockets for order updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@
   - Bartenders manage live orders in `bartender_orders.html` using `static/js/orders.js`.
   - The bartender dashboard lists assigned bars as `.bar-card` links to `/dashboard/bar/{id}/orders`.
   - WebSocket endpoints `/ws/bar/{bar_id}/orders` and `/ws/user/{user_id}/orders` push real-time status updates.
+  - JavaScript selects `wss` when `https` is used, falling back to `ws` otherwise for order WebSocket connections.
   - API endpoints `/api/bars/{bar_id}/orders` (GET) and `/api/orders/{id}/status` (POST) list and update orders.
   - Bartender sees a single action button per order: Accept → Ready → Complete.
   - Order listings include customer name/phone, table, and line items for both bartender and user history.

--- a/static/js/orders.js
+++ b/static/js/orders.js
@@ -2,6 +2,8 @@ function formatPayment(method) {
   return method ? method.replace('_', ' ').replace(/\b\w/g, c => c.toUpperCase()) : '';
 }
 
+const wsScheme = location.protocol === 'https:' ? 'wss' : 'ws';
+
 function initBartender(barId) {
   const list = document.getElementById('orders');
   function render(order) {
@@ -42,7 +44,7 @@ function initBartender(barId) {
     }
   }
   fetch(`/api/bars/${barId}/orders`).then(r => r.json()).then(data => data.forEach(render));
-  const ws = new WebSocket(`ws://${location.host}/ws/bar/${barId}/orders`);
+  const ws = new WebSocket(`${wsScheme}://${location.host}/ws/bar/${barId}/orders`);
   ws.onmessage = ev => {
     const data = JSON.parse(ev.data);
     if (data.type === 'order') {
@@ -75,7 +77,7 @@ function initUser(userId) {
       `</div>`;
     return li;
   }
-  const ws = new WebSocket(`ws://${location.host}/ws/user/${userId}/orders`);
+  const ws = new WebSocket(`${wsScheme}://${location.host}/ws/user/${userId}/orders`);
   ws.onmessage = ev => {
     const data = JSON.parse(ev.data);
     if (data.type === 'order') {


### PR DESCRIPTION
## Summary
- ensure order page WebSocket connections use wss on https
- document secure websocket selection in AGENTS notes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6a60ade0c8320a32535dff27bd84e