### PR TITLE
feat: instant bartender order updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@
   - WebSocket endpoints `/ws/bar/{bar_id}/orders` and `/ws/user/{user_id}/orders` push real-time status updates.
   - `static/js/orders.js` selects `ws` or `wss` based on the page protocol for secure deployments.
   - API endpoints `/api/bars/{bar_id}/orders` (GET) and `/api/orders/{id}/status` (POST) list and update orders.
+  - Order status updates return the updated order; `static/js/orders.js` re-renders immediately after POST so bartenders see new states without reloading.
   - Bartender sees a single action button per order: Accept → Ready → Complete.
   - Order listings include customer name/phone, table, and line items for both bartender and user history.
   - Orders store `payment_method`; `order.total` returns `subtotal + vat_total` and both fields are displayed in order listings.

--- a/static/js/orders.js
+++ b/static/js/orders.js
@@ -35,7 +35,7 @@ function initBartender(barId) {
       actionsHtml +
       `</div>`;
     li.querySelectorAll('button').forEach(btn => {
-      btn.addEventListener('click', () => updateStatus(order.id, btn.dataset.status));
+      btn.addEventListener('click', () => updateStatus(order.id, btn.dataset.status, render));
     });
     if (order.status === 'completed') {
       li.remove();
@@ -91,10 +91,16 @@ function initUser(userId) {
   };
 }
 
-function updateStatus(orderId, status) {
+function updateStatus(orderId, status, onUpdate) {
   fetch(`/api/orders/${orderId}/status`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ status })
-  });
+  })
+    .then(r => r.json())
+    .then(data => {
+      if (onUpdate && data.order) {
+        onUpdate(data.order);
+      }
+    });
 }


### PR DESCRIPTION
## Summary
- re-render bartender order cards immediately after status change
- return updated order payload from status endpoint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6afbc2d34832093fec2cb54d90b69