### PR TITLE
feat: prepend new bartender orders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,7 @@
   - Order status updates return the updated order; `static/js/orders.js` re-renders immediately after POST so bartenders see new states without reloading.
   - Bartender sees a single action button per order: Accept → Ready → Complete.
   - Order listings include customer name/phone, table, and line items for both bartender and user history.
+  - Bartender dashboards prepend newly received orders to the list so the latest orders appear at the top.
   - Orders store `payment_method`; `order.total` returns `subtotal + vat_total` and both fields are displayed in order listings.
   - `order_history.html` uses `order.customer_name`, `order.customer_prefix`, `order.customer_phone`, and `order.table_name` to avoid `None` errors when related records are missing.
   - `order_history.html` displays line items via `item.menu_item_name` to handle missing menu items gracefully.

--- a/static/js/orders.js
+++ b/static/js/orders.js
@@ -10,7 +10,7 @@ function initBartender(barId) {
       li = document.createElement('li');
       li.id = 'order-' + order.id;
       li.className = 'card';
-      list.appendChild(li);
+      list.prepend(li);
     }
     let actions = '';
     if (order.status === 'pending') {


### PR DESCRIPTION
## Summary
- show new bartender orders at the top of the live list
- document live order behaviour for bartenders

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6b36b1f1c832092e3b01bd819d37b