### PR TITLE
Ensure bartender dashboard loads orders without WebSocket

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@
   - The bartender dashboard lists assigned bars as `.bar-card` links to `/dashboard/bar/{id}/orders`.
   - WebSocket endpoints `/ws/bar/{bar_id}/orders` and `/ws/user/{user_id}/orders` push real-time status updates.
   - `static/js/orders.js` selects `ws` or `wss` based on the page protocol for secure deployments.
+  - Bartender dashboards fetch existing orders via `/api/bars/{bar_id}/orders` before connecting to WebSockets so orders display even if the real-time connection fails.
   - API endpoints `/api/bars/{bar_id}/orders` (GET) and `/api/orders/{id}/status` (POST) list and update orders.
   - Order status updates return the updated order; `static/js/orders.js` re-renders immediately after POST so bartenders see new states without reloading.
   - Bartender sees a single action button per order: Accept → Ready → Complete.

--- a/static/js/orders.js
+++ b/static/js/orders.js
@@ -74,6 +74,8 @@ function initBartender(barId) {
     };
     ws.onerror = () => ws.close();
   }
+  // load existing orders even if the WebSocket can't connect
+  load();
   connect();
 }
 


### PR DESCRIPTION
## Summary
- Fetch existing orders before connecting to the bar's WebSocket so orders render even if the socket fails
- Document the initial order fetch behavior in AGENTS notes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6d52c2eb08320a1a4021058410d48