### PR TITLE
feat: show preparation time to customers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,7 @@
   - Order listings include customer name/phone, table, and line items for both bartender and user history.
   - Bartender dashboards prepend newly received orders to each status list so the latest orders appear first.
   - Orders record `accepted_at` and `ready_at` timestamps; bartender cards show placement time and preparation duration via `orders.js`.
+  - User order cards show placement time and preparation duration using `order_history.html` and `orders.js`.
   - `orders.js` sends a keep-alive ping every 30s so bartender WebSocket connections stay open and receive new orders instantly.
   - Bartender WebSocket connections automatically reconnect if the socket closes.
   - Orders store `payment_method`; `order.total` returns `subtotal + vat_total` and both fields are displayed in order listings.

--- a/static/js/orders.js
+++ b/static/js/orders.js
@@ -110,6 +110,8 @@ function initUser(userId) {
       li.id = 'user-order-' + order.id;
       li.className = 'card';
     }
+    const placed = formatTime(order.created_at);
+    const prep = order.ready_at ? `<p>Prep time: ${diffMinutes(order.created_at, order.ready_at)} min</p>` : '';
     li.innerHTML =
       `<div class="card__body">` +
       `<h3 class="card__title">Order #${order.id} - <span class=\"status status-${order.status.toLowerCase()}\">${formatStatus(order.status)}</span></h3>` +
@@ -118,6 +120,8 @@ function initUser(userId) {
       `<p>Table: ${order.table_name || ''}</p>` +
       `<p>Payment: ${formatPayment(order.payment_method)}</p>` +
       `<p>Total: CHF ${order.total.toFixed(2)}</p>` +
+      `<p>Ordered at: ${placed}</p>` +
+      prep +
       `<ul>` +
       order.items.map(i => `<li>${i.qty}× ${i.menu_item_name || ''}</li>`).join('') +
       `</ul>` +

--- a/templates/order_history.html
+++ b/templates/order_history.html
@@ -14,6 +14,9 @@
       <p>Payment method: {{ order.payment_method.replace('_', ' ')|title if order.payment_method else '' }}</p>
       <p>Total: CHF {{ "%.2f"|format(order.total) }}</p>
       <p>Ordered at: {{ order.created_at|format_time }}</p>
+      {% if order.ready_at %}
+      <p>Prep time: {{ ((order.ready_at - order.created_at).total_seconds() // 60)|int }} min</p>
+      {% endif %}
       <ul>
         {% for item in order.items %}
         <li>{{ item.qty }}× {{ item.menu_item_name or 'Unknown item' }}</li>
@@ -38,6 +41,9 @@
       <p>Payment method: {{ order.payment_method.replace('_', ' ')|title if order.payment_method else '' }}</p>
       <p>Total: CHF {{ "%.2f"|format(order.total) }}</p>
       <p>Ordered at: {{ order.created_at|format_time }}</p>
+      {% if order.ready_at %}
+      <p>Prep time: {{ ((order.ready_at - order.created_at).total_seconds() // 60)|int }} min</p>
+      {% endif %}
       <ul>
         {% for item in order.items %}
         <li>{{ item.qty }}× {{ item.menu_item_name or 'Unknown item' }}</li>


### PR DESCRIPTION
## Summary
- display order preparation time in customer order history
- render placement and prep times in user order websocket updates
- document user-facing prep time in AGENTS notes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6e70843ac8320811b4a89e215f1e6