### PR TITLE
feat: allow customers to add order notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,8 @@
   - `cart.html` displays the current bar's name, lists its tables for selection, and shows a wallet link for adding funds.
   - Checkout form asks for payment method (credit card, wallet credit, or pay at bar);
     selection is handled by `/cart/checkout` and stored in `Transaction.payment_method`.
+  - Checkout form includes an optional "notes" textarea for special requests;
+    notes are saved on orders and shown on bartender and user order cards.
   - The popup offers "Remove products" (clears cart via `POST /cart/clear`) or "Go to the bar menu".
   - Wallet and top-up pages clear `cart_bar_id` to prevent the cart popup from appearing.
   - The top-up page at `/topup` renders `templates/topup.html` and suppresses the cart popup by passing `cart_bar_id` and `cart_bar_name` as `None`.

--- a/main.py
+++ b/main.py
@@ -462,6 +462,7 @@ async def send_order_update(order: Order) -> Dict[str, Any]:
         "accepted_at": order.accepted_at.isoformat() if order.accepted_at else None,
         "ready_at": order.ready_at.isoformat() if order.ready_at else None,
         "total": order.total,
+        "notes": order.notes,
         "items": [
             {
                 "id": i.id,
@@ -1308,6 +1309,7 @@ class OrderRead(BaseModel):
     accepted_at: Optional[datetime] = None
     ready_at: Optional[datetime] = None
     total: float
+    notes: Optional[str] = None
     customer_name: Optional[str] = None
     customer_prefix: Optional[str] = None
     customer_phone: Optional[str] = None
@@ -1633,6 +1635,7 @@ async def checkout(
     request: Request,
     table_id: Optional[int] = Form(None),
     payment_method: str = Form(...),
+    notes: Optional[str] = Form(None),
     db: Session = Depends(get_db),
 ):
     user = get_current_user(request)
@@ -1673,6 +1676,7 @@ async def checkout(
         payment_method=payment_method,
         paid_at=datetime.utcnow(),
         items=order_items,
+        notes=notes,
     )
     db.add(db_order)
     db.commit()

--- a/static/js/orders.js
+++ b/static/js/orders.js
@@ -40,6 +40,7 @@ function initBartender(barId) {
     const actionsHtml = actions ? `<div class="order-actions">${actions}</div>` : '';
     const placed = formatTime(order.created_at);
     const prep = order.ready_at ? `<p>Prep time: ${diffMinutes(order.created_at, order.ready_at)} min</p>` : '';
+    const notes = order.notes ? `<p>Notes: ${order.notes}</p>` : '';
     li.className = 'card card--' + order.status.toLowerCase();
     li.innerHTML =
       `<div class="card__body">` +
@@ -51,6 +52,7 @@ function initBartender(barId) {
       `<p>Total: CHF ${order.total.toFixed(2)}</p>` +
       `<p>Placed: ${placed}</p>` +
       prep +
+      notes +
       `<ul>` +
       order.items.map(i => `<li>${i.qty}× ${i.menu_item_name || ''}</li>`).join('') +
       `</ul>` +
@@ -114,6 +116,7 @@ function initUser(userId) {
     li.className = 'card card--' + order.status.toLowerCase();
     const placed = formatTime(order.created_at);
     const prep = order.ready_at ? `<p>Prep time: ${diffMinutes(order.created_at, order.ready_at)} min</p>` : '';
+    const notes = order.notes ? `<p>Notes: ${order.notes}</p>` : '';
     li.innerHTML =
       `<div class="card__body">` +
       `<h3 class="card__title">Order #${order.id} - <span class=\"status status-${order.status.toLowerCase()}\">${formatStatus(order.status)}</span></h3>` +
@@ -124,6 +127,7 @@ function initUser(userId) {
       `<p>Total: CHF ${order.total.toFixed(2)}</p>` +
       `<p>Ordered at: ${placed}</p>` +
       prep +
+      notes +
       `<ul>` +
       order.items.map(i => `<li>${i.qty}× ${i.menu_item_name || ''}</li>`).join('') +
       `</ul>` +

--- a/templates/cart.html
+++ b/templates/cart.html
@@ -50,6 +50,9 @@
     <label><input type="radio" name="payment_method" value="wallet"> Wallet Credit</label>
     <label><input type="radio" name="payment_method" value="bar"> Pay at Bar</label>
   </fieldset>
+  <label for="notes">Message to bartender
+    <textarea id="notes" name="notes" rows="3" placeholder="Add a note for the bartender"></textarea>
+  </label>
   <button class="btn btn--success" type="submit">Place Order</button>
 </form>
 {% else %}

--- a/templates/order_history.html
+++ b/templates/order_history.html
@@ -12,6 +12,7 @@
       <p>Bar: {{ order.bar_name or '' }}</p>
       <p>Table: {{ order.table_name or '' }}</p>
       <p>Payment method: {{ order.payment_method.replace('_', ' ')|title if order.payment_method else '' }}</p>
+      {% if order.notes %}<p>Notes: {{ order.notes }}</p>{% endif %}
       <p>Total: CHF {{ "%.2f"|format(order.total) }}</p>
       <p>Ordered at: {{ order.created_at|format_time }}</p>
       {% if order.ready_at %}
@@ -39,6 +40,7 @@
       <p>Bar: {{ order.bar_name or '' }}</p>
       <p>Table: {{ order.table_name or '' }}</p>
       <p>Payment method: {{ order.payment_method.replace('_', ' ')|title if order.payment_method else '' }}</p>
+      {% if order.notes %}<p>Notes: {{ order.notes }}</p>{% endif %}
       <p>Total: CHF {{ "%.2f"|format(order.total) }}</p>
       <p>Ordered at: {{ order.created_at|format_time }}</p>
       {% if order.ready_at %}

--- a/tests/test_order_notes.py
+++ b/tests/test_order_notes.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import pathlib
+import hashlib
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, engine, SessionLocal  # noqa: E402
+from models import Bar, Category, MenuItem, Table, User  # noqa: E402
+from main import app, load_bars_from_db  # noqa: E402
+
+
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def test_checkout_saves_notes():
+    setup_db()
+    with TestClient(app) as client:
+        db = SessionLocal()
+        bar = Bar(name="Test Bar", slug="test-bar")
+        db.add(bar); db.commit(); db.refresh(bar)
+        cat = Category(bar_id=bar.id, name="Drinks")
+        db.add(cat); db.commit(); db.refresh(cat)
+        item = MenuItem(bar_id=bar.id, category_id=cat.id, name="Water", price_chf=5)
+        db.add(item)
+        table = Table(bar_id=bar.id, name="T1")
+        db.add(table)
+        pwd = hashlib.sha256("pass".encode("utf-8")).hexdigest()
+        user = User(username="u", email="u@example.com", password_hash=pwd)
+        db.add(user); db.commit(); db.refresh(item); db.refresh(table)
+        item_id, bar_id, table_id, user_email = item.id, bar.id, table.id, user.email
+        db.close(); load_bars_from_db()
+
+        client.post("/login", data={"email": user_email, "password": "pass"})
+        client.post(f"/bars/{bar_id}/add_to_cart", data={"product_id": item_id})
+        resp = client.post(
+            "/cart/checkout",
+            data={"table_id": table_id, "payment_method": "card", "notes": "No sugar"},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        assert "Notes: No sugar" in resp.text
+


### PR DESCRIPTION
## Summary
- add textarea in cart for customer notes
- store and broadcast notes with orders
- show notes on bartender and user order cards

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6f34441ac83209022ffe20550159c