### PR TITLE
fix: show canceled orders in completed history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@
   - Order status updates return the updated order; `static/js/orders.js` re-renders immediately after POST so bartenders see new states without reloading.
   - Bartenders can accept or cancel incoming orders; after acceptance, actions progress Ready → Complete.
   - Orders are grouped into four sections: Incoming (`PLACED`), Preparing (`ACCEPTED`), Ready (`READY`), and Completed (`COMPLETED`/`CANCELED`).
+  - The `/orders` route treats `CANCELED` orders as completed so they're excluded from pending.
   - Order statuses progress `PLACED → ACCEPTED → READY → COMPLETED` (with optional `CANCELED/REJECTED`).
   - Valid transitions are enforced server-side via `ALLOWED_STATUS_TRANSITIONS` in `main.py`.
   - Order listings include customer name/phone, table, and line items for both bartender and user history.

--- a/main.py
+++ b/main.py
@@ -1714,8 +1714,8 @@ async def order_history(request: Request, db: Session = Depends(get_db)):
         .order_by(Order.created_at.desc())
         .all()
     )
-    pending_orders = [o for o in orders if o.status != "COMPLETED"]
-    completed_orders = [o for o in orders if o.status == "COMPLETED"]
+    pending_orders = [o for o in orders if o.status not in ("COMPLETED", "CANCELED")]
+    completed_orders = [o for o in orders if o.status in ("COMPLETED", "CANCELED")]
     return render_template(
         "order_history.html",
         request=request,

--- a/tests/test_canceled_order_history.py
+++ b/tests/test_canceled_order_history.py
@@ -1,0 +1,63 @@
+import os
+import sys
+import pathlib
+import hashlib
+
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, engine, SessionLocal  # noqa: E402
+from models import Bar, Category, MenuItem, Table, User  # noqa: E402
+from main import (
+    app,
+    load_bars_from_db,
+    user_carts,
+    users,
+    users_by_email,
+    users_by_username,
+)  # noqa: E402
+
+
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    user_carts.clear()
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()
+
+
+def test_canceled_order_moves_to_completed_history():
+    setup_db()
+    with TestClient(app) as client:
+        db = SessionLocal()
+        bar = Bar(name="Test Bar", slug="test-bar")
+        db.add(bar); db.commit(); db.refresh(bar)
+        cat = Category(bar_id=bar.id, name="Drinks")
+        db.add(cat); db.commit(); db.refresh(cat)
+        item = MenuItem(bar_id=bar.id, category_id=cat.id, name="Water", price_chf=5)
+        db.add(item)
+        table = Table(bar_id=bar.id, name="T1")
+        db.add(table)
+        pwd = hashlib.sha256("pass".encode("utf-8")).hexdigest()
+        user = User(username="u", email="u@example.com", password_hash=pwd)
+        db.add(user); db.commit(); db.refresh(item); db.refresh(table)
+        item_id, bar_id, table_id, user_email = item.id, bar.id, table.id, user.email
+        db.close(); load_bars_from_db()
+
+        client.post('/login', data={'email': user_email, 'password': 'pass'})
+        client.post(f'/bars/{bar_id}/add_to_cart', data={'product_id': item_id})
+        client.post('/cart/checkout', data={'table_id': table_id, 'payment_method': 'card'})
+        client.post('/api/orders/1/status', json={'status': 'CANCELED'})
+        resp = client.get('/orders')
+        pending = resp.text.split('<h2>Pending Orders</h2>')[1].split('<h2>Completed Orders</h2>')[0]
+        completed = resp.text.split('<h2>Completed Orders</h2>')[1]
+        assert 'Order #1' not in pending
+        assert 'Order #1' in completed
+        assert 'Canceled' in completed
+    user_carts.clear()
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()
+


### PR DESCRIPTION
## Summary
- show canceled orders under completed in order history
- document that `/orders` treats canceled orders as completed
- add regression test for canceled orders in history

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b709ec79108320b5cf900a798668c7