### PR TITLE
fix: move rejected orders to completed history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,8 +80,8 @@
   - API endpoints `/api/bars/{bar_id}/orders` (GET) and `/api/orders/{id}/status` (POST) list and update orders.
   - Order status updates return the updated order; `static/js/orders.js` re-renders immediately after POST so bartenders see new states without reloading.
   - Bartenders can accept or cancel incoming orders; after acceptance, actions progress Ready → Complete.
-  - Orders are grouped into four sections: Incoming (`PLACED`), Preparing (`ACCEPTED`), Ready (`READY`), and Completed (`COMPLETED`/`CANCELED`).
-  - The `/orders` route treats `CANCELED` orders as completed so they're excluded from pending.
+  - Orders are grouped into four sections: Incoming (`PLACED`), Preparing (`ACCEPTED`), Ready (`READY`), and Completed (`COMPLETED`/`CANCELED`/`REJECTED`).
+  - The `/orders` route treats `CANCELED` and `REJECTED` orders as completed so they're excluded from pending.
   - Order statuses progress `PLACED → ACCEPTED → READY → COMPLETED` (with optional `CANCELED/REJECTED`).
   - Valid transitions are enforced server-side via `ALLOWED_STATUS_TRANSITIONS` in `main.py`.
   - Order listings include customer name/phone, table, and line items for both bartender and user history.
@@ -95,6 +95,7 @@
   - `order_history.html` displays line items via `item.menu_item_name` to handle missing menu items gracefully.
   - Order cards display the bar's name via `order.bar_name`.
     - Order views render each order inside a `.card` and group them in `.order-list` containers for consistent styling.
+    - Each order card `<li>` exposes `data-status` with the raw status for client-side updates.
     - `.order-list` is a flex container that wraps so order cards can flow horizontally.
     - Order list cards match bar card width (400px desktop, 300px mobile) while allowing their height to expand with content.
     - Order card backgrounds reflect status via `card--placed` (blue), `card--accepted` (orange), `card--ready` (green), `card--completed` (default surface), and `card--canceled` (red).

--- a/main.py
+++ b/main.py
@@ -1714,8 +1714,12 @@ async def order_history(request: Request, db: Session = Depends(get_db)):
         .order_by(Order.created_at.desc())
         .all()
     )
-    pending_orders = [o for o in orders if o.status not in ("COMPLETED", "CANCELED")]
-    completed_orders = [o for o in orders if o.status in ("COMPLETED", "CANCELED")]
+    pending_orders = [
+        o for o in orders if o.status not in ("COMPLETED", "CANCELED", "REJECTED")
+    ]
+    completed_orders = [
+        o for o in orders if o.status in ("COMPLETED", "CANCELED", "REJECTED")
+    ]
     return render_template(
         "order_history.html",
         request=request,

--- a/static/js/orders.js
+++ b/static/js/orders.js
@@ -43,6 +43,7 @@ function initBartender(barId) {
     const notes = order.notes ? `<p>Notes: ${order.notes}</p>` : '';
     const refund = order.status === 'CANCELED' && order.refund_amount ? `<p>Refund: CHF ${order.refund_amount.toFixed(2)}</p>` : '';
     li.className = 'card card--' + order.status.toLowerCase();
+    li.dataset.status = order.status;
     li.innerHTML =
       `<div class="card__body">` +
       `<h3 class="card__title">Order #${order.id} - <span class=\"status status-${order.status.toLowerCase()}\">${formatStatus(order.status)}</span></h3>` +
@@ -69,7 +70,11 @@ function initBartender(barId) {
       preparing.prepend(li);
     } else if (order.status === 'READY') {
       ready.prepend(li);
-    } else if (order.status === 'COMPLETED' || order.status === 'CANCELED') {
+    } else if (
+      order.status === 'COMPLETED' ||
+      order.status === 'CANCELED' ||
+      order.status === 'REJECTED'
+    ) {
       completed.prepend(li);
     }
   }
@@ -116,6 +121,7 @@ function initUser(userId) {
       li.className = 'card';
     }
     li.className = 'card card--' + order.status.toLowerCase();
+    li.dataset.status = order.status;
     const placed = formatTime(order.created_at);
     const prep = order.ready_at ? `<p>Prep time: ${diffMinutes(order.created_at, order.ready_at)} min</p>` : '';
     const notes = order.notes ? `<p>Notes: ${order.notes}</p>` : '';
@@ -148,7 +154,9 @@ function initUser(userId) {
     const data = JSON.parse(ev.data);
     if (data.type === 'order') {
       const li = render(data.order);
-      if (data.order.status === 'COMPLETED' || data.order.status === 'CANCELED') {
+      if (
+        ['COMPLETED', 'CANCELED', 'REJECTED'].includes(data.order.status)
+      ) {
         completed.appendChild(li);
       } else {
         pending.appendChild(li);

--- a/templates/order_history.html
+++ b/templates/order_history.html
@@ -5,7 +5,7 @@
 <h2>Pending Orders</h2>
 <ul id="pending-orders" class="order-list">
   {% for order in pending_orders %}
-  <li id="user-order-{{ order.id }}" class="card card--{{ order.status|lower }}">
+  <li id="user-order-{{ order.id }}" class="card card--{{ order.status|lower }}" data-status="{{ order.status }}">
     <div class="card__body">
       <h3 class="card__title">Order #{{ order.id }} - <span class="status status-{{ order.status|lower }}">{{ order.status|replace('_', ' ')|title }}</span></h3>
       <p>Customer: {{ order.customer_name or 'Unknown' }} ({{ order.customer_prefix or '' }} {{ order.customer_phone or '' }})</p>
@@ -39,7 +39,7 @@
 <h2>Completed Orders</h2>
 <ul id="completed-orders" class="order-list">
   {% for order in completed_orders %}
-  <li id="user-order-{{ order.id }}" class="card card--{{ order.status|lower }}">
+  <li id="user-order-{{ order.id }}" class="card card--{{ order.status|lower }}" data-status="{{ order.status }}">
     <div class="card__body">
       <h3 class="card__title">Order #{{ order.id }} - <span class="status status-{{ order.status|lower }}">{{ order.status|replace('_', ' ')|title }}</span></h3>
       <p>Customer: {{ order.customer_name or 'Unknown' }} ({{ order.customer_prefix or '' }} {{ order.customer_phone or '' }})</p>

--- a/tests/test_rejected_order_history.py
+++ b/tests/test_rejected_order_history.py
@@ -1,0 +1,74 @@
+import os
+import sys
+import pathlib
+import hashlib
+
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, engine, SessionLocal  # noqa: E402
+from models import Bar, Category, MenuItem, Table, User, RoleEnum, UserBarRole  # noqa: E402
+from main import (
+    app,
+    load_bars_from_db,
+    user_carts,
+    users,
+    users_by_email,
+    users_by_username,
+)  # noqa: E402
+
+
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    user_carts.clear()
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()
+
+
+def test_rejected_order_moves_to_completed_history():
+    setup_db()
+    with TestClient(app) as client:
+        db = SessionLocal()
+        bar = Bar(name="Test Bar", slug="test-bar")
+        db.add(bar); db.commit(); db.refresh(bar)
+        cat = Category(bar_id=bar.id, name="Drinks")
+        db.add(cat); db.commit(); db.refresh(cat)
+        item = MenuItem(bar_id=bar.id, category_id=cat.id, name="Water", price_chf=5)
+        db.add(item)
+        table = Table(bar_id=bar.id, name="T1")
+        db.add(table)
+        pwd = hashlib.sha256("pass".encode("utf-8")).hexdigest()
+        user = User(username="u", email="u@example.com", password_hash=pwd)
+        bartender = User(username="b", email="b@example.com", password_hash=pwd, role=RoleEnum.BARTENDER)
+        db.add_all([user, bartender]); db.commit(); db.refresh(item); db.refresh(table); db.refresh(bartender)
+        db.add(UserBarRole(user_id=bartender.id, bar_id=bar.id, role=RoleEnum.BARTENDER))
+        db.commit()
+        item_id, bar_id, table_id, user_email, bartender_email = (
+            item.id,
+            bar.id,
+            table.id,
+            user.email,
+            bartender.email,
+        )
+        db.close(); load_bars_from_db()
+
+        client.post('/login', data={'email': user_email, 'password': 'pass'})
+        client.post(f'/bars/{bar_id}/add_to_cart', data={'product_id': item_id})
+        client.post('/cart/checkout', data={'table_id': table_id, 'payment_method': 'card'})
+        client.post('/login', data={'email': bartender_email, 'password': 'pass'})
+        client.post('/api/orders/1/status', json={'status': 'REJECTED'})
+        client.post('/login', data={'email': user_email, 'password': 'pass'})
+        resp = client.get('/orders')
+        pending = resp.text.split('<h2>Pending Orders</h2>')[1].split('<h2>Completed Orders</h2>')[0]
+        completed = resp.text.split('<h2>Completed Orders</h2>')[1]
+        assert 'Order #1' not in pending
+        assert 'Order #1' in completed
+        assert 'Rejected' in completed
+    user_carts.clear()
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()
+


### PR DESCRIPTION
## Summary
- treat rejected orders as completed in `/orders` view
- update realtime UI to relocate rejected orders out of pending lists
- document behavior and add regression test
- expose `data-status` on order cards so client JS tracks status changes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b70dac19588320b667c359eaa0e731