### PR TITLE
fix: persist completed orders for bartenders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,11 +73,14 @@
   - Mobile hamburger menu links to order history via `bi bi-clock-history` icon.
   - Bartenders manage live orders in `bartender_orders.html` using `static/js/orders.js`,
     which loads with `defer` and initializes `initBartender(bar.id)` on `DOMContentLoaded`.
+  - `templates/bartender_orders.html` groups orders into `<ul>` lists with IDs
+    `incoming-orders`, `preparing-orders`, `ready-orders`, and `completed-orders`.
   - The bartender dashboard lists assigned bars as `.bar-card` links to `/dashboard/bar/{id}/orders`.
   - WebSocket endpoints `/ws/bar/{bar_id}/orders` and `/ws/user/{user_id}/orders` push real-time status updates.
   - WebSocket support depends on `uvicorn[standard]` (or another backend that provides the `websockets` library).
   - `static/js/orders.js` selects `ws` or `wss` based on the page protocol for secure deployments.
   - API endpoints `/api/bars/{bar_id}/orders` (GET) and `/api/orders/{id}/status` (POST) list and update orders.
+  - `/api/bars/{bar_id}/orders` returns all statuses so completed orders remain visible after reloads.
   - Order status updates return the updated order; `static/js/orders.js` re-renders immediately after POST so bartenders see new states without reloading.
   - Bartenders can accept or cancel incoming orders; after acceptance, actions progress Ready → Complete.
   - Orders are grouped into four sections: Incoming (`PLACED`), Preparing (`ACCEPTED`), Ready (`READY`), and Completed (`COMPLETED`/`CANCELED`/`REJECTED`).

--- a/main.py
+++ b/main.py
@@ -1743,7 +1743,7 @@ async def get_bar_orders(
         raise HTTPException(status_code=403, detail="Not authorised")
     orders = (
         db.query(Order)
-        .filter(Order.bar_id == bar_id, Order.status != "COMPLETED")
+        .filter(Order.bar_id == bar_id)
         .order_by(Order.created_at.desc())
         .all()
     )

--- a/tests/test_bartender_completed_orders_persistence.py
+++ b/tests/test_bartender_completed_orders_persistence.py
@@ -1,0 +1,76 @@
+import os
+import sys
+import pathlib
+import hashlib
+
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, engine, SessionLocal  # noqa: E402
+from models import (  # noqa: E402
+    Bar,
+    Category,
+    MenuItem,
+    Table,
+    User,
+    UserBarRole,
+    RoleEnum,
+    Order,
+)
+from main import (  # noqa: E402
+    app,
+    load_bars_from_db,
+    user_carts,
+    users,
+    users_by_email,
+    users_by_username,
+)
+
+
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    user_carts.clear()
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()
+
+
+def test_completed_orders_visible_in_bartender_dashboard():
+    setup_db()
+    with TestClient(app) as client:
+        db = SessionLocal()
+        bar = Bar(name="Test Bar", slug="test-bar")
+        db.add(bar); db.commit(); db.refresh(bar)
+        cat = Category(bar_id=bar.id, name="Drinks")
+        db.add(cat); db.commit(); db.refresh(cat)
+        item = MenuItem(bar_id=bar.id, category_id=cat.id, name="Water", price_chf=5)
+        table = Table(bar_id=bar.id, name="T1")
+        pwd = hashlib.sha256("pass".encode("utf-8")).hexdigest()
+        customer = User(username="u", email="u@example.com", password_hash=pwd)
+        bartender = User(username="b", email="b@example.com", password_hash=pwd, role=RoleEnum.BARTENDER)
+        db.add_all([item, table, customer, bartender]); db.commit()
+        db.add(UserBarRole(user_id=bartender.id, bar_id=bar.id, role=RoleEnum.BARTENDER))
+        db.commit(); db.refresh(item); db.refresh(table); db.refresh(bar)
+        bar_id, item_id, table_id = bar.id, item.id, table.id
+        db.close(); load_bars_from_db()
+
+        client.post('/login', data={'email': 'u@example.com', 'password': 'pass'})
+        client.post(f'/bars/{bar_id}/add_to_cart', data={'product_id': item_id})
+        client.post('/cart/checkout', data={'table_id': table_id, 'payment_method': 'card'})
+        client.get('/logout')
+
+        db = SessionLocal()
+        order_id = db.query(Order).first().id
+        db.close()
+
+        client.post('/login', data={'email': 'b@example.com', 'password': 'pass'})
+        client.post(f'/api/orders/{order_id}/status', json={'status': 'ACCEPTED'})
+        client.post(f'/api/orders/{order_id}/status', json={'status': 'READY'})
+        client.post(f'/api/orders/{order_id}/status', json={'status': 'COMPLETED'})
+
+        resp = client.get(f'/api/bars/{bar_id}/orders')
+        assert resp.status_code == 200
+        data = resp.json()
+        assert any(o['id'] == order_id and o['status'] == 'COMPLETED' for o in data)

--- a/tests/test_bartender_orders_html.py
+++ b/tests/test_bartender_orders_html.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import pathlib
+import hashlib
+
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, engine, SessionLocal  # noqa: E402
+from models import Bar, User, UserBarRole, RoleEnum  # noqa: E402
+from main import app, load_bars_from_db, user_carts, users, users_by_email, users_by_username  # noqa: E402
+
+
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    user_carts.clear()
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()
+
+
+def test_bartender_orders_page_contains_completed_list():
+    setup_db()
+    with TestClient(app) as client:
+        db = SessionLocal()
+        bar = Bar(name="Test Bar", slug="test-bar")
+        pwd = hashlib.sha256("pass".encode("utf-8")).hexdigest()
+        bartender = User(username="b", email="b@example.com", password_hash=pwd, role=RoleEnum.BARTENDER)
+        db.add_all([bar, bartender])
+        db.commit()
+        db.add(UserBarRole(user_id=bartender.id, bar_id=bar.id, role=RoleEnum.BARTENDER))
+        db.commit(); db.refresh(bar); db.close()
+        load_bars_from_db()
+        client.post('/login', data={'email': 'b@example.com', 'password': 'pass'})
+        resp = client.get(f'/dashboard/bar/{bar.id}/orders')
+        assert resp.status_code == 200
+        assert '<ul id="completed-orders"' in resp.text


### PR DESCRIPTION
## Summary
- return completed orders in bartender API so past orders remain after reload
- document bartender API returning all statuses
- add regression test for completed order visibility
- document bartender order list container IDs
- add test verifying bartender orders page contains completed orders list

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7e3b9c54083208166d4e73f1d2eca