### PR TITLE
feat: display full timestamp on orders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,8 @@
     - Order list cards match bar card width (400px desktop, 300px mobile) while allowing their height to expand with content.
     - Order card backgrounds reflect status via `card--placed` (blue), `card--accepted` (orange), `card--ready` (green), `card--completed` (default surface), and `card--canceled` (red).
     - `.order-list .card__body` uses `gap: var(--space-1)` and removes default margins on child `p` and `ul` elements to tighten spacing.
-  - `order_history.html` displays placement times via the `format_time` filter so displayed hours honor `BAR_TIMEZONE`.
+  - `order_history.html` displays placement date and time via the `format_time` filter so displayed values honor `BAR_TIMEZONE`.
+  - `orders.js` uses `formatTime` to show `YYYY-MM-DD HH:MM` strings on bartender and user order cards for clearer chronology.
   - Status labels are title-cased for display with `status status-<status>` classes (`formatStatus` in `orders.js`; `order.status|replace('_', ' ')|title` in templates).
   - `ensure_order_columns()` in `main.py` adds missing columns (e.g., `table_id`, `status`) to the `orders` table at startup.
 - Cancelling an order refunds the total to the customer's wallet when paid by card or wallet; pay-at-bar orders are removed without refund.

--- a/main.py
+++ b/main.py
@@ -766,7 +766,7 @@ def weekly_hours_list(
 
 
 def format_time(dt: Optional[datetime]) -> str:
-    """Format a UTC datetime to local HH:MM string using BAR_TIMEZONE/TZ."""
+    """Format a UTC datetime to local YYYY-MM-DD HH:MM string using BAR_TIMEZONE/TZ."""
     if not dt:
         return ""
     tz_name = os.getenv("BAR_TIMEZONE") or os.getenv("TZ")
@@ -774,7 +774,7 @@ def format_time(dt: Optional[datetime]) -> str:
     dt = dt.replace(tzinfo=ZoneInfo("UTC"))
     if tz:
         dt = dt.astimezone(tz)
-    return dt.strftime("%H:%M")
+    return dt.strftime("%Y-%m-%d %H:%M")
 
 templates_env.filters["format_time"] = format_time
 

--- a/static/js/orders.js
+++ b/static/js/orders.js
@@ -9,7 +9,9 @@ function formatStatus(status) {
 function formatTime(dt) {
   if (!dt) return '';
   const d = new Date(dt + 'Z');
-  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  const date = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  const time = d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  return `${date} ${time}`;
 }
 
 function diffMinutes(start, end) {


### PR DESCRIPTION
## Summary
- show placement date alongside time on bartender and user order cards
- format `format_time` filter and `orders.js` helper to output `YYYY-MM-DD HH:MM`
- document new timestamp behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7ef20f73483208d6f56d5a5d068f8