### PR TITLE
feat: show bar cards in bar admin dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@
   - `templates/bartender_orders.html` groups orders into `<ul>` lists with IDs
     `incoming-orders`, `preparing-orders`, `ready-orders`, and `completed-orders`.
   - The bartender dashboard lists assigned bars as `.bar-card` links to `/dashboard/bar/{id}/orders`.
+  - The bar admin dashboard lists assigned bars as `.bar-card` items with edit and management links.
   - WebSocket endpoints `/ws/bar/{bar_id}/orders` and `/ws/user/{user_id}/orders` push real-time status updates.
   - WebSocket support depends on `uvicorn[standard]` (or another backend that provides the `websockets` library).
   - `static/js/orders.js` selects `ws` or `wss` based on the page protocol for secure deployments.

--- a/templates/bar_admin_dashboard.html
+++ b/templates/bar_admin_dashboard.html
@@ -10,17 +10,29 @@
 </div>
 {% if bars %}
 <div class="dashboard-actions">
-  {% for bar in bars %}
-  <div class="card">
-    <h3>{{ bar.name }}</h3>
-    <a class="btn btn--primary" href="/admin/bars/edit/{{ bar.id }}">Edit Bar</a>
-    <a class="btn" href="/admin/bars/{{ bar.id }}/users">Manage Users</a>
-    <a class="btn" href="/bar/{{ bar.id }}/categories/new">Add Category</a>
-  </div>
-  {% endfor %}
+  <ul class="bars">
+    {% for bar in bars %}
+    <li>
+      <div class="bar-card">
+        <div class="thumb-wrapper">
+          {% if bar.photo_url %}
+          <img class="thumb" src="{{ bar.photo_url }}" alt="{{ bar.name }} photo" width="400" height="225">
+          {% endif %}
+        </div>
+        <h3 class="title">{{ bar.name }}</h3>
+        <address>{{ bar.city }}{% if bar.state %}, {{ bar.state }}{% endif %}</address>
+        <p class="desc">{{ bar.description }}</p>
+        <div class="bar-actions">
+          <a class="btn btn--primary" href="/admin/bars/edit/{{ bar.id }}">Edit Bar</a>
+          <a class="btn" href="/admin/bars/{{ bar.id }}/users">Manage Users</a>
+          <a class="btn" href="/bar/{{ bar.id }}/categories/new">Add Category</a>
+        </div>
+      </div>
+    </li>
+    {% endfor %}
+  </ul>
 </div>
 {% else %}
 <p>No bar assigned.</p>
 {% endif %}
 {% endblock %}
-

--- a/tests/test_bar_admin_dashboard_cards.py
+++ b/tests/test_bar_admin_dashboard_cards.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import pathlib
+import hashlib
+
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, engine, SessionLocal  # noqa: E402
+from models import Bar, User, UserBarRole, RoleEnum  # noqa: E402
+from main import app, load_bars_from_db, user_carts, users, users_by_email, users_by_username  # noqa: E402
+
+
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    user_carts.clear()
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()
+
+
+def test_bar_admin_dashboard_shows_bar_cards():
+    setup_db()
+    with TestClient(app) as client:
+        db = SessionLocal()
+        bar = Bar(name="Test Bar", slug="test-bar")
+        pwd = hashlib.sha256("pass".encode("utf-8")).hexdigest()
+        admin = User(username="a", email="a@example.com", password_hash=pwd, role=RoleEnum.BARADMIN)
+        db.add_all([bar, admin])
+        db.commit()
+        db.add(UserBarRole(user_id=admin.id, bar_id=bar.id, role=RoleEnum.BARADMIN))
+        db.commit(); db.refresh(bar); db.close()
+        load_bars_from_db()
+        client.post('/login', data={'email': 'a@example.com', 'password': 'pass'})
+        resp = client.get('/dashboard')
+        assert resp.status_code == 200
+        assert 'class="bar-card"' in resp.text


### PR DESCRIPTION
## Summary
- style bar admin dashboard with bar-card layout and action links
- document admin dashboard cards in AGENTS notes
- test bar admin dashboard displays bar-card elements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b809e6b9188320b936e3f7dedf70e7