### PR TITLE
feat: toggle bar sections in bar admin dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,8 @@
   - `templates/bartender_orders.html` groups orders into `<ul>` lists with IDs
     `incoming-orders`, `preparing-orders`, `ready-orders`, and `completed-orders`.
   - The bartender dashboard lists assigned bars as `.bar-card` links to `/dashboard/bar/{id}/orders`.
-  - The bar admin dashboard lists assigned bars as `.bar-card` items with edit and management links.
+  - The bar admin dashboard lists assigned bars as collapsible items: clicking a bar's name toggles a table of management links.
+  - Interactivity for the bar admin dashboard lives in `static/js/bar_admin_dashboard.js`.
   - WebSocket endpoints `/ws/bar/{bar_id}/orders` and `/ws/user/{user_id}/orders` push real-time status updates.
   - WebSocket support depends on `uvicorn[standard]` (or another backend that provides the `websockets` library).
   - `static/js/orders.js` selects `ws` or `wss` based on the page protocol for secure deployments.

--- a/static/js/bar_admin_dashboard.js
+++ b/static/js/bar_admin_dashboard.js
@@ -1,0 +1,12 @@
+function initBarAdminDashboard() {
+  document.querySelectorAll('.bar-toggle').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const table = btn.nextElementSibling;
+      if (table) {
+        table.hidden = !table.hidden;
+      }
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initBarAdminDashboard);

--- a/templates/bar_admin_dashboard.html
+++ b/templates/bar_admin_dashboard.html
@@ -9,30 +9,28 @@
   </div>
 </div>
 {% if bars %}
-<div class="dashboard-actions">
-  <ul class="bars">
-    {% for bar in bars %}
-    <li>
-      <div class="bar-card">
-        <div class="thumb-wrapper">
-          {% if bar.photo_url %}
-          <img class="thumb" src="{{ bar.photo_url }}" alt="{{ bar.name }} photo" width="400" height="225">
-          {% endif %}
-        </div>
-        <h3 class="title">{{ bar.name }}</h3>
-        <address>{{ bar.city }}{% if bar.state %}, {{ bar.state }}{% endif %}</address>
-        <p class="desc">{{ bar.description }}</p>
-        <div class="bar-actions">
-          <a class="btn btn--primary" href="/admin/bars/edit/{{ bar.id }}">Edit Bar</a>
-          <a class="btn" href="/admin/bars/{{ bar.id }}/users">Manage Users</a>
-          <a class="btn" href="/bar/{{ bar.id }}/categories/new">Add Category</a>
-        </div>
-      </div>
-    </li>
-    {% endfor %}
-  </ul>
-</div>
+<ul class="bars">
+  {% for bar in bars %}
+  <li>
+    <button class="bar-toggle" type="button">{{ bar.name }}</button>
+    <table class="bar-sections" hidden>
+      <tbody>
+        <tr>
+          <td><a href="/admin/bars/edit/{{ bar.id }}">Edit Bar</a></td>
+        </tr>
+        <tr>
+          <td><a href="/admin/bars/{{ bar.id }}/users">Manage Users</a></td>
+        </tr>
+        <tr>
+          <td><a href="/bar/{{ bar.id }}/categories/new">Add Category</a></td>
+        </tr>
+      </tbody>
+    </table>
+  </li>
+  {% endfor %}
+</ul>
 {% else %}
 <p>No bar assigned.</p>
 {% endif %}
+<script src="/static/js/bar_admin_dashboard.js" defer></script>
 {% endblock %}

--- a/tests/test_bar_admin_dashboard_cards.py
+++ b/tests/test_bar_admin_dashboard_cards.py
@@ -21,7 +21,7 @@ def setup_db():
     users_by_username.clear()
 
 
-def test_bar_admin_dashboard_shows_bar_cards():
+def test_bar_admin_dashboard_shows_bar_sections():
     setup_db()
     with TestClient(app) as client:
         db = SessionLocal()
@@ -36,4 +36,5 @@ def test_bar_admin_dashboard_shows_bar_cards():
         client.post('/login', data={'email': 'a@example.com', 'password': 'pass'})
         resp = client.get('/dashboard')
         assert resp.status_code == 200
-        assert 'class="bar-card"' in resp.text
+        assert 'class="bar-toggle"' in resp.text
+        assert 'class="bar-sections"' in resp.text


### PR DESCRIPTION
## Summary
- replace bar cards with collapsible list items in bar admin dashboard
- add JS to toggle table of bar management links
- document change in AGENTS and update tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b813ab98e08320b2e91f8eef34f85e