### PR TITLE
feat: add manage orders button for bar admins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,7 @@
     `incoming-orders`, `preparing-orders`, `ready-orders`, and `completed-orders`.
   - The bartender dashboard lists assigned bars as `.bar-card` links to `/dashboard/bar/{id}/orders`.
   - The bar admin dashboard lists assigned bars as `.bar-card` items with edit and management links.
+  - Each bar card includes buttons for editing the bar, managing users, managing orders via `/dashboard/bar/{id}/orders`, and adding categories.
   - WebSocket endpoints `/ws/bar/{bar_id}/orders` and `/ws/user/{user_id}/orders` push real-time status updates.
   - WebSocket support depends on `uvicorn[standard]` (or another backend that provides the `websockets` library).
   - `static/js/orders.js` selects `ws` or `wss` based on the page protocol for secure deployments.

--- a/templates/bar_admin_dashboard.html
+++ b/templates/bar_admin_dashboard.html
@@ -25,6 +25,7 @@
         <div class="bar-actions">
           <a class="btn btn--primary" href="/admin/bars/edit/{{ bar.id }}">Edit Bar</a>
           <a class="btn" href="/admin/bars/{{ bar.id }}/users">Manage Users</a>
+          <a class="btn" href="/dashboard/bar/{{ bar.id }}/orders">Manage Orders</a>
           <a class="btn" href="/bar/{{ bar.id }}/categories/new">Add Category</a>
         </div>
       </div>

--- a/tests/test_bar_admin_dashboard_cards.py
+++ b/tests/test_bar_admin_dashboard_cards.py
@@ -37,3 +37,5 @@ def test_bar_admin_dashboard_shows_bar_cards():
         resp = client.get('/dashboard')
         assert resp.status_code == 200
         assert 'class="bar-card"' in resp.text
+        assert f'href="/dashboard/bar/{bar.id}/orders"' in resp.text
+        assert 'Manage Orders' in resp.text


### PR DESCRIPTION
## Summary
- add manage orders button to bar admin dashboard cards
- document new bar admin dashboard actions
- test manage orders link renders

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8252f9e348320af20457cad55b8a3