### PR TITLE
feat: allow bar admins to manage live orders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,8 @@
   - The bartender dashboard lists assigned bars as `.bar-card` links to `/dashboard/bar/{id}/orders`.
   - The bar admin dashboard lists assigned bars as `.bar-card` items with edit and management links.
   - Each bar card includes buttons for editing the bar and managing orders via `/dashboard/bar/{id}/orders`.
+  - Bar admins view live orders in `bar_admin_orders.html`, which mirrors the bartender view and adds an
+    "Order History & Revenue" button linking to `/dashboard/bar/{id}/orders/history`.
   - WebSocket endpoints `/ws/bar/{bar_id}/orders` and `/ws/user/{user_id}/orders` push real-time status updates.
   - WebSocket support depends on `uvicorn[standard]` (or another backend that provides the `websockets` library).
   - `static/js/orders.js` selects `ws` or `wss` based on the page protocol for secure deployments.

--- a/main.py
+++ b/main.py
@@ -2045,14 +2045,32 @@ async def dashboard(request: Request):
 
 
 @app.get("/dashboard/bar/{bar_id}/orders", response_class=HTMLResponse)
-async def bartender_orders(request: Request, bar_id: int):
+async def manage_orders(request: Request, bar_id: int):
     user = get_current_user(request)
-    if not user or not user.is_bartender or bar_id not in user.bar_ids:
+    if (
+        not user
+        or bar_id not in user.bar_ids
+        or not (user.is_bartender or user.is_bar_admin)
+    ):
         return RedirectResponse(url="/dashboard", status_code=status.HTTP_303_SEE_OTHER)
     bar = bars.get(bar_id)
     if not bar:
         raise HTTPException(status_code=404)
-    return render_template("bartender_orders.html", request=request, bar=bar)
+    template = "bar_admin_orders.html" if user.is_bar_admin else "bartender_orders.html"
+    return render_template(template, request=request, bar=bar)
+
+
+@app.get(
+    "/dashboard/bar/{bar_id}/orders/history", response_class=HTMLResponse
+)
+async def bar_admin_order_history(request: Request, bar_id: int):
+    user = get_current_user(request)
+    if not user or not user.is_bar_admin or bar_id not in user.bar_ids:
+        return RedirectResponse(url="/dashboard", status_code=status.HTTP_303_SEE_OTHER)
+    bar = bars.get(bar_id)
+    if not bar:
+        raise HTTPException(status_code=404)
+    return render_template("bar_admin_order_history.html", request=request, bar=bar)
 
 
 # Admin management endpoints

--- a/templates/bar_admin_order_history.html
+++ b/templates/bar_admin_order_history.html
@@ -1,0 +1,5 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>{{ bar.name }} - Order History &amp; Revenue</h1>
+<p>Coming soon.</p>
+{% endblock %}

--- a/templates/bar_admin_orders.html
+++ b/templates/bar_admin_orders.html
@@ -1,0 +1,24 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>{{ bar.name }} Orders</h1>
+<div class="orders-controls">
+  <a class="btn" href="/dashboard/bar/{{ bar.id }}/orders/history">Order History &amp; Revenue</a>
+</div>
+<div id="orders-section">
+  <h2>Incoming Orders</h2>
+  <ul id="incoming-orders" class="order-list"></ul>
+  <h2>Preparing</h2>
+  <ul id="preparing-orders" class="order-list"></ul>
+  <h2>Ready</h2>
+  <ul id="ready-orders" class="order-list"></ul>
+  <h2>Completed</h2>
+  <ul id="completed-orders" class="order-list"></ul>
+</div>
+<script src="/static/js/orders.js" defer></script>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    // start bartender WebSocket listener for live orders
+    initBartender({{ bar.id }});
+  });
+</script>
+{% endblock %}

--- a/tests/test_bar_admin_orders_html.py
+++ b/tests/test_bar_admin_orders_html.py
@@ -1,0 +1,58 @@
+import os
+import sys
+import pathlib
+import hashlib
+
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, engine, SessionLocal  # noqa: E402
+from models import Bar, User, UserBarRole, RoleEnum  # noqa: E402
+from main import app, load_bars_from_db, user_carts, users, users_by_email, users_by_username  # noqa: E402
+
+
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    user_carts.clear()
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()
+
+
+def test_bar_admin_orders_page_has_history_link():
+    setup_db()
+    with TestClient(app) as client:
+        db = SessionLocal()
+        bar = Bar(name="Test Bar", slug="test-bar")
+        pwd = hashlib.sha256("pass".encode("utf-8")).hexdigest()
+        admin = User(username="a", email="a@example.com", password_hash=pwd, role=RoleEnum.BARADMIN)
+        db.add_all([bar, admin])
+        db.commit()
+        db.add(UserBarRole(user_id=admin.id, bar_id=bar.id, role=RoleEnum.BARADMIN))
+        db.commit(); db.refresh(bar); db.close()
+        load_bars_from_db()
+        client.post('/login', data={'email': 'a@example.com', 'password': 'pass'})
+        resp = client.get(f'/dashboard/bar/{bar.id}/orders')
+        assert resp.status_code == 200
+        assert 'Order History &amp; Revenue' in resp.text
+        assert f'href="/dashboard/bar/{bar.id}/orders/history"' in resp.text
+
+
+def test_bar_admin_orders_history_page():
+    setup_db()
+    with TestClient(app) as client:
+        db = SessionLocal()
+        bar = Bar(name="Test Bar", slug="test-bar")
+        pwd = hashlib.sha256("pass".encode("utf-8")).hexdigest()
+        admin = User(username="a", email="a@example.com", password_hash=pwd, role=RoleEnum.BARADMIN)
+        db.add_all([bar, admin])
+        db.commit()
+        db.add(UserBarRole(user_id=admin.id, bar_id=bar.id, role=RoleEnum.BARADMIN))
+        db.commit(); db.refresh(bar); db.close()
+        load_bars_from_db()
+        client.post('/login', data={'email': 'a@example.com', 'password': 'pass'})
+        resp = client.get(f'/dashboard/bar/{bar.id}/orders/history')
+        assert resp.status_code == 200
+        assert 'Coming soon.' in resp.text


### PR DESCRIPTION
## Summary
- let bar admins access live order view and link to order history & revenue
- stub order history page for bar admins
- document bar admin order screen in AGENTS notes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b82e1e5a28832096dcd7d31119ca8d