### PR TITLE
feat: track bar closings and revenue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,10 @@
   - Each bar card includes buttons for editing the bar and managing orders via `/dashboard/bar/{id}/orders`.
   - Bar admins view live orders in `bar_admin_orders.html`, which mirrors the bartender view and adds an
     "Order History & Revenue" button linking to `/dashboard/bar/{id}/orders/history`.
+  - Bar admins can close the day via `/dashboard/bar/{id}/orders/close` which moves all completed orders
+    into a `bar_closings` record (see `BarClosing` model). Each closing is listed on
+    `/dashboard/bar/{id}/orders/history` with its total revenue and a "View" link to
+    `/dashboard/bar/{id}/orders/history/{closing_id}` showing the day's orders.
   - WebSocket endpoints `/ws/bar/{bar_id}/orders` and `/ws/user/{user_id}/orders` push real-time status updates.
   - WebSocket support depends on `uvicorn[standard]` (or another backend that provides the `websockets` library).
   - `static/js/orders.js` selects `ws` or `wss` based on the page protocol for secure deployments.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,9 @@
     into a `bar_closings` record (see `BarClosing` model). Each closing is listed on
     `/dashboard/bar/{id}/orders/history` with its total revenue and a "View" link to
     `/dashboard/bar/{id}/orders/history/{closing_id}` showing the day's orders.
+  - A background task also checks each minute and automatically closes bars at their scheduled
+    closing time based on `opening_hours`, moving completed orders into `bar_closings`. Editing a bar's
+    hours immediately updates the automatic schedule.
   - WebSocket endpoints `/ws/bar/{bar_id}/orders` and `/ws/user/{user_id}/orders` push real-time status updates.
   - WebSocket support depends on `uvicorn[standard]` (or another backend that provides the `websockets` library).
   - `static/js/orders.js` selects `ws` or `wss` based on the page protocol for secure deployments.

--- a/models.py
+++ b/models.py
@@ -169,6 +169,18 @@ class ProductImage(Base):
     created_at = Column(DateTime, default=datetime.utcnow)
 
 
+class BarClosing(Base):
+    __tablename__ = "bar_closings"
+
+    id = Column(Integer, primary_key=True)
+    bar_id = Column(Integer, ForeignKey("bars.id"), nullable=False)
+    closed_at = Column(DateTime, default=datetime.utcnow)
+    total_revenue = Column(Numeric(10, 2), default=0)
+
+    bar = relationship("Bar")
+    orders = relationship("Order", back_populates="closing")
+
+
 class Order(Base):
     __tablename__ = "orders"
 
@@ -190,11 +202,13 @@ class Order(Base):
     refund_amount = Column(Numeric(10, 2), default=0)
     notes = Column(Text)
     source_channel = Column(String(30))
+    closing_id = Column(Integer, ForeignKey("bar_closings.id"))
 
     items = relationship("OrderItem", back_populates="order")
     customer = relationship("User")
     table = relationship("Table")
     bar = relationship("Bar")
+    closing = relationship("BarClosing", back_populates="orders")
 
     @property
     def customer_name(self):

--- a/templates/bar_admin_order_history.html
+++ b/templates/bar_admin_order_history.html
@@ -1,5 +1,19 @@
 {% extends "layout.html" %}
 {% block content %}
 <h1>{{ bar.name }} - Order History &amp; Revenue</h1>
-<p>Coming soon.</p>
+{% if closings %}
+<ul class="closing-list">
+  {% for closing in closings %}
+  <li class="card">
+    <div class="card__body">
+      <h2>{{ closing.closed_at|format_time }}</h2>
+      <p>Total revenue: CHF {{ "%.2f"|format(closing.total_revenue) }}</p>
+      <a class="btn" href="/dashboard/bar/{{ bar.id }}/orders/history/{{ closing.id }}">View</a>
+    </div>
+  </li>
+  {% endfor %}
+</ul>
+{% else %}
+<p>No order history yet.</p>
+{% endif %}
 {% endblock %}

--- a/templates/bar_admin_order_history_view.html
+++ b/templates/bar_admin_order_history_view.html
@@ -1,0 +1,25 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>{{ bar.name }} - Orders for {{ closing.closed_at|format_time }}</h1>
+<p>Total revenue: CHF {{ "%.2f"|format(closing.total_revenue) }}</p>
+<ul class="order-list">
+  {% for order in orders %}
+  <li class="card card--{{ order.status|lower }}" data-status="{{ order.status }}">
+    <div class="card__body">
+      <h3 class="card__title">Order #{{ order.id }}</h3>
+      <p>Customer: {{ order.customer_name or 'Unknown' }} ({{ order.customer_prefix or '' }} {{ order.customer_phone or '' }})</p>
+      <p>Table: {{ order.table_name or '' }}</p>
+      <p>Total: CHF {{ "%.2f"|format(order.total) }}</p>
+      <p>Ordered at: {{ order.created_at|format_time }}</p>
+      <ul>
+        {% for item in order.items %}
+        <li>{{ item.qty }}× {{ item.menu_item_name or 'Unknown item' }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+  </li>
+  {% else %}
+  <li class="card"><div class="card__body">No orders.</div></li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/templates/bar_admin_orders.html
+++ b/templates/bar_admin_orders.html
@@ -3,6 +3,9 @@
 <h1>{{ bar.name }} Orders</h1>
 <div class="orders-controls">
   <a class="btn" href="/dashboard/bar/{{ bar.id }}/orders/history">Order History &amp; Revenue</a>
+  <form method="post" action="/dashboard/bar/{{ bar.id }}/orders/close" style="display:inline">
+    <button type="submit" class="btn">Close Day</button>
+  </form>
 </div>
 <div id="orders-section">
   <h2>Incoming Orders</h2>

--- a/tests/test_auto_closing.py
+++ b/tests/test_auto_closing.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import pathlib
+import json
+from datetime import datetime
+
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from database import Base, engine, SessionLocal  # noqa: E402
+from models import Bar, Order, BarClosing  # noqa: E402
+from main import auto_close_bars_once  # noqa: E402
+
+
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def test_auto_close_bars_once():
+    setup_db()
+    db = SessionLocal()
+    now = datetime.utcnow().replace(hour=0, minute=2, second=0, microsecond=0)
+    hours = {str(now.weekday()): {"open": "00:00", "close": "00:01"}}
+    bar = Bar(name="Test Bar", slug="test-bar", opening_hours=json.dumps(hours))
+    order = Order(bar=bar, status="COMPLETED", subtotal=10, vat_total=2)
+    db.add_all([bar, order])
+    db.commit()
+    auto_close_bars_once(db, now)
+    closings = db.query(BarClosing).filter_by(bar_id=bar.id).all()
+    assert len(closings) == 1
+    assert float(closings[0].total_revenue) == 12.0
+    order = db.query(Order).first()
+    assert order.closing_id == closings[0].id
+    db.close()


### PR DESCRIPTION
## Summary
- record daily bar closings and total revenue in new `bar_closings` table
- allow bar admins to close the day and view historic orders with totals
- document closing process and add coverage for closing workflow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b83331664c8320aeaad880d3f29926