### PR TITLE
feat: remove manual day closing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,13 +80,11 @@
   - Each bar card includes buttons for editing the bar and managing orders via `/dashboard/bar/{id}/orders`.
   - Bar admins view live orders in `bar_admin_orders.html`, which mirrors the bartender view and adds an
     "Order History & Revenue" button linking to `/dashboard/bar/{id}/orders/history`.
-  - Bar admins can close the day via `/dashboard/bar/{id}/orders/close` which moves all completed orders
-    into a `bar_closings` record (see `BarClosing` model). Each closing is listed on
+  - Bars close automatically at their scheduled closing time based on `opening_hours`, moving completed
+    orders into a `bar_closings` record (see `BarClosing` model). Each closing is listed on
     `/dashboard/bar/{id}/orders/history` with its total revenue and a "View" link to
-    `/dashboard/bar/{id}/orders/history/{closing_id}` showing the day's orders.
-  - A background task also checks each minute and automatically closes bars at their scheduled
-    closing time based on `opening_hours`, moving completed orders into `bar_closings`. Editing a bar's
-    hours immediately updates the automatic schedule.
+    `/dashboard/bar/{id}/orders/history/{closing_id}` showing the day's orders. Editing a bar's hours
+    immediately updates the automatic schedule.
   - WebSocket endpoints `/ws/bar/{bar_id}/orders` and `/ws/user/{user_id}/orders` push real-time status updates.
   - WebSocket support depends on `uvicorn[standard]` (or another backend that provides the `websockets` library).
   - `static/js/orders.js` selects `ws` or `wss` based on the page protocol for secure deployments.

--- a/templates/bar_admin_orders.html
+++ b/templates/bar_admin_orders.html
@@ -3,9 +3,6 @@
 <h1>{{ bar.name }} Orders</h1>
 <div class="orders-controls">
   <a class="btn" href="/dashboard/bar/{{ bar.id }}/orders/history">Order History &amp; Revenue</a>
-  <form method="post" action="/dashboard/bar/{{ bar.id }}/orders/close" style="display:inline">
-    <button type="submit" class="btn">Close Day</button>
-  </form>
 </div>
 <div id="orders-section">
   <h2>Incoming Orders</h2>

--- a/tests/test_bar_admin_orders_html.py
+++ b/tests/test_bar_admin_orders_html.py
@@ -2,6 +2,8 @@ import os
 import sys
 import pathlib
 import hashlib
+import json
+from datetime import datetime
 
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
@@ -9,7 +11,15 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 from fastapi.testclient import TestClient  # noqa: E402
 from database import Base, engine, SessionLocal  # noqa: E402
 from models import Bar, User, UserBarRole, RoleEnum, Order, BarClosing  # noqa: E402
-from main import app, load_bars_from_db, user_carts, users, users_by_email, users_by_username  # noqa: E402
+from main import (
+    app,
+    load_bars_from_db,
+    user_carts,
+    users,
+    users_by_email,
+    users_by_username,
+    auto_close_bars_once,
+)  # noqa: E402
 
 
 def setup_db():
@@ -38,6 +48,7 @@ def test_bar_admin_orders_page_has_history_link():
         assert resp.status_code == 200
         assert 'Order History &amp; Revenue' in resp.text
         assert f'href="/dashboard/bar/{bar.id}/orders/history"' in resp.text
+        assert 'Close Day' not in resp.text
 
 
 def test_bar_admin_orders_history_page():
@@ -58,11 +69,12 @@ def test_bar_admin_orders_history_page():
         assert 'No order history yet.' in resp.text
 
 
-def test_close_day_moves_orders_to_history():
+def test_auto_close_moves_orders_to_history():
     setup_db()
     with TestClient(app) as client:
         db = SessionLocal()
-        bar = Bar(name="Test Bar", slug="test-bar")
+        hours = {"0": {"open": "10:00", "close": "20:00"}}
+        bar = Bar(name="Test Bar", slug="test-bar", opening_hours=json.dumps(hours))
         pwd = hashlib.sha256("pass".encode("utf-8")).hexdigest()
         admin = User(username="a", email="a@example.com", password_hash=pwd, role=RoleEnum.BARADMIN)
         order = Order(bar=bar, status="COMPLETED", subtotal=10, vat_total=2)
@@ -71,15 +83,15 @@ def test_close_day_moves_orders_to_history():
         db.add(UserBarRole(user_id=admin.id, bar_id=bar.id, role=RoleEnum.BARADMIN))
         db.commit(); db.refresh(bar); db.close()
         load_bars_from_db()
+        # simulate time after closing
+        now = datetime(2024, 1, 1, 21, 0, 0)
+        with SessionLocal() as db2:
+            auto_close_bars_once(db2, now)
+            closings = db2.query(BarClosing).filter_by(bar_id=bar.id).all()
+            assert len(closings) == 1
+            assert float(closings[0].total_revenue) == 12.0
+            order = db2.query(Order).first()
+            assert order.closing_id == closings[0].id
         client.post('/login', data={'email': 'a@example.com', 'password': 'pass'})
-        resp = client.post(f'/dashboard/bar/{bar.id}/orders/close', follow_redirects=False)
-        assert resp.status_code == 303
-        db = SessionLocal()
-        closings = db.query(BarClosing).filter_by(bar_id=bar.id).all()
-        assert len(closings) == 1
-        assert float(closings[0].total_revenue) == 12.0
-        order = db.query(Order).first()
-        assert order.closing_id == closings[0].id
-        db.close()
         resp = client.get(f'/dashboard/bar/{bar.id}/orders/history')
         assert 'CHF 12.00' in resp.text


### PR DESCRIPTION
## Summary
- remove Close Day button from bar admin orders page
- drop manual closing endpoint; rely on automatic schedule
- update documentation and tests for auto-closing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b83bf9ada88320bf568d175e8d1917