### PR TITLE
fix: cast ordering_paused default to boolean

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@
   - Bar detail layout: `.bar-cover` image (16/9), `.bar-meta` row with status/rating/distance, `.clamp`ed description, and `.bar-hours-card` grid (Mon–Thu / Fri–Sun)
   - `.bar-detail` has `margin-bottom: var(--space-4)` to add space before product categories
   - Open status uses `.status-open` (green) and closed status uses `.status-closed` (red)
+  - Bar ordering pause state stored in `bars.ordering_paused` (BOOLEAN, defaults to FALSE)
   - Bar edit options page links to table management (`templates/admin_bar_tables.html`) where staff can add, edit, and delete tables. Add and edit forms live in `templates/admin_bar_new_table.html` and `templates/admin_bar_edit_table.html`; table descriptions are for staff only
 - Products:
   - Images stored in `menu_items.photo` and served via `/api/products/{id}/image`

--- a/main.py
+++ b/main.py
@@ -535,7 +535,7 @@ def ensure_bar_columns() -> None:
         "rating": "FLOAT",
         "is_open_now": "BOOLEAN",
         "manual_closed": "BOOLEAN",
-        "ordering_paused": "BOOLEAN DEFAULT 0",
+        "ordering_paused": "BOOLEAN DEFAULT FALSE",
         "promo_label": "VARCHAR(100)",
         "tags": "TEXT",
         "opening_hours": "TEXT",


### PR DESCRIPTION
## Summary
- fix SQL default for ordering_paused to boolean
- document ordering_paused column in agent notes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8418f79dc8320a8ff0f27b503fae0