### PR TITLE
feat: show pause popup when cart bar paused

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@
   - Cart items are limited to one bar at a time.
   - Navigating away from the active bar shows a blocking popup in `templates/layout.html` styled via `.cart-blocker` and `.cart-popup`.
   - Bartenders can pause ordering from the orders dashboard; paused bars return 409 on `/bars/{id}/add_to_cart` and `app.js` shows a "service paused" popup.
-  - The cart page sets `window.orderingPaused` when a bar is paused so the service pause popup appears on load.
+  - The layout sets `window.orderingPaused` when the cart's bar is paused so the service pause popup appears on load and links back to the bar menu.
   - `cart.html` displays the current bar's name, lists its tables for selection, and shows a wallet link for adding funds.
   - Checkout form asks for payment method (credit card, wallet credit, or pay at bar);
     selection is handled by `/cart/checkout` and stored in `Transaction.payment_method`.

--- a/main.py
+++ b/main.py
@@ -1082,6 +1082,7 @@ def render_template(template_name: str, **context) -> HTMLResponse:
                 if bar:
                     context.setdefault("cart_bar_id", bar.id)
                     context.setdefault("cart_bar_name", bar.name)
+                    context.setdefault("cart_bar_paused", bar.ordering_paused)
         bar_obj = context.get("bar")
         if bar_obj and hasattr(bar_obj, "id"):
             context.setdefault("current_bar_id", bar_obj.id)

--- a/templates/cart.html
+++ b/templates/cart.html
@@ -60,6 +60,4 @@
 {% endif %}
 {% endblock %}
 
-{% block scripts %}
-<script>window.orderingPaused = {{ 'true' if bar and bar.ordering_paused else 'false' }};</script>
-{% endblock %}
+{% block scripts %}{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -104,7 +104,7 @@
       <p>SiplyGo © 2025 · <a href="#">About</a> · <a href="#">Help Center</a> · <a href="#">For Bars</a> · <a href="#">Legal</a></p>
     </div>
   </footer>
-  <div id="cartBlocker" class="cart-blocker" {% if cart_bar_id and current_bar_id != cart_bar_id %}{% else %}hidden{% endif %}>
+  <div id="cartBlocker" class="cart-blocker" {% if cart_bar_id and current_bar_id != cart_bar_id and not cart_bar_paused %}{% else %}hidden{% endif %}>
     <div class="cart-popup">
       <p>You still have products in your cart at <strong>{{ cart_bar_name }}</strong>.</p>
       <div class="cart-popup-actions">
@@ -115,14 +115,15 @@
   </div>
   <div id="servicePaused" class="cart-blocker" hidden>
     <div class="cart-popup">
-      <p>Ordering is temporarily paused. Please ask a staff member for more information.</p>
+      <p>Ordering is temporarily paused for <strong>{{ cart_bar_name }}</strong>.</p>
       <div class="cart-popup-actions">
-        <button type="button" class="btn btn--primary js-close-service-paused">Close</button>
+        <a class="btn btn--primary" href="/bars/{{ cart_bar_id }}">Go to the bar menu</a>
       </div>
     </div>
   </div>
-    <script src="/static/js/app.min.js" defer></script>
-    {% block scripts %}{% endblock %}
+  <script>window.orderingPaused = {{ 'true' if cart_bar_paused else 'false' }};</script>
+  <script src="/static/js/app.min.js" defer></script>
+  {% block scripts %}{% endblock %}
 </body>
 </html>
 

--- a/tests/test_cart_paused_popup.py
+++ b/tests/test_cart_paused_popup.py
@@ -55,3 +55,6 @@ def test_cart_shows_pause_popup_when_bar_paused():
         resp = client.get("/cart")
         assert resp.status_code == 200
         assert "window.orderingPaused = true" in resp.text
+        home = client.get("/")
+        assert home.status_code == 200
+        assert "window.orderingPaused = true" in home.text


### PR DESCRIPTION
## Summary
- show service pause popup site-wide when cart's bar is paused
- link pause popup to the bar menu
- document new behavior in AGENTS notes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b84b5cec708320abf9f9226f7e2b99