### PR TITLE
fix: show cart popup for paused bar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@
   - Cart contents persist in the database via the `user_carts` table so they survive server restarts.
   - Cart items are limited to one bar at a time.
   - Navigating away from the active bar shows a blocking popup in `templates/layout.html` styled via `.cart-blocker` and `.cart-popup`.
+  - The cart-blocker displays whenever the cart contains items from another bar, even if that bar's ordering is paused.
   - Bartenders can pause ordering from the orders dashboard; paused bars return 409 on `/bars/{id}/add_to_cart` and `app.js` shows a "service paused" popup.
   - The layout sets `window.orderingPaused` when the cart's bar is paused; `window.showServicePausedOnLoad` controls whether the popup opens automatically.
   - Menu pages pass `pause_popup_close` so the popup can be dismissed, while the cart page sets `pause_popup_back` and shows the popup on load with a "Back to the menu" button. The message advises contacting a staff member for more info.

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -104,7 +104,7 @@
       <p>SiplyGo © 2025 · <a href="#">About</a> · <a href="#">Help Center</a> · <a href="#">For Bars</a> · <a href="#">Legal</a></p>
     </div>
   </footer>
-  <div id="cartBlocker" class="cart-blocker" {% if cart_bar_id and current_bar_id != cart_bar_id and not cart_bar_paused %}{% else %}hidden{% endif %}>
+  <div id="cartBlocker" class="cart-blocker" {% if cart_bar_id and current_bar_id != cart_bar_id %}{% else %}hidden{% endif %}>
     <div class="cart-popup">
       <p>You still have products in your cart at <strong>{{ cart_bar_name }}</strong>.</p>
       <div class="cart-popup-actions">


### PR DESCRIPTION
## Summary
- ensure cart popup appears even when cart bar is paused
- document cart-blocker behavior in AGENTS notes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b85466f59c83208d83d975fb701a98