### PR TITLE
feat: allow bar admins to manage orders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,10 +94,10 @@
   - WebSocket endpoints `/ws/bar/{bar_id}/orders` and `/ws/user/{user_id}/orders` push real-time status updates.
   - WebSocket support depends on `uvicorn[standard]` (or another backend that provides the `websockets` library).
   - `static/js/orders.js` selects `ws` or `wss` based on the page protocol for secure deployments.
-  - API endpoints `/api/bars/{bar_id}/orders` (GET) and `/api/orders/{id}/status` (POST) list and update orders.
+  - API endpoints `/api/bars/{bar_id}/orders` (GET) and `/api/orders/{id}/status` (POST) list and update orders for bartenders and bar admins.
   - `/api/bars/{bar_id}/orders` returns all statuses so completed orders remain visible after reloads.
-  - Order status updates return the updated order; `static/js/orders.js` re-renders immediately after POST so bartenders see new states without reloading.
-  - Bartenders can accept or cancel incoming orders; after acceptance, actions progress Ready → Complete.
+  - Order status updates return the updated order; `static/js/orders.js` re-renders immediately after POST so staff see new states without reloading.
+  - Bartenders and bar admins can accept or cancel incoming orders; after acceptance, actions progress Ready → Complete.
   - Orders are grouped into four sections: Incoming (`PLACED`), Preparing (`ACCEPTED`), Ready (`READY`), and Completed (`COMPLETED`/`CANCELED`/`REJECTED`).
   - The `/orders` route treats `CANCELED` and `REJECTED` orders as completed so they're excluded from pending.
   - Order statuses progress `PLACED → ACCEPTED → READY → COMPLETED` (with optional `CANCELED/REJECTED`).

--- a/tests/test_bar_admin_manage_orders.py
+++ b/tests/test_bar_admin_manage_orders.py
@@ -1,0 +1,80 @@
+import os
+import sys
+import pathlib
+import hashlib
+
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, engine, SessionLocal  # noqa: E402
+from models import (  # noqa: E402
+    Bar,
+    Category,
+    MenuItem,
+    Table,
+    User,
+    UserBarRole,
+    RoleEnum,
+    Order,
+)
+from main import (  # noqa: E402
+    app,
+    load_bars_from_db,
+    user_carts,
+    users,
+    users_by_email,
+    users_by_username,
+)
+
+
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    user_carts.clear()
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()
+
+
+def test_bar_admin_can_view_and_update_orders():
+    setup_db()
+    with TestClient(app) as client:
+        db = SessionLocal()
+        bar = Bar(name="Test Bar", slug="test-bar")
+        db.add(bar); db.commit(); db.refresh(bar)
+        cat = Category(bar_id=bar.id, name="Drinks")
+        db.add(cat); db.commit(); db.refresh(cat)
+        item = MenuItem(bar_id=bar.id, category_id=cat.id, name="Water", price_chf=5)
+        table = Table(bar_id=bar.id, name="T1")
+        pwd = hashlib.sha256("pass".encode("utf-8")).hexdigest()
+        customer = User(username="u", email="u@example.com", password_hash=pwd)
+        bar_admin = User(username="a", email="a@example.com", password_hash=pwd, role=RoleEnum.BARADMIN)
+        db.add_all([item, table, customer, bar_admin]); db.commit()
+        db.add(UserBarRole(user_id=bar_admin.id, bar_id=bar.id, role=RoleEnum.BARADMIN))
+        db.commit(); db.refresh(item); db.refresh(table); db.refresh(bar)
+        bar_id, item_id, table_id = bar.id, item.id, table.id
+        db.close(); load_bars_from_db()
+
+        client.post('/login', data={'email': 'u@example.com', 'password': 'pass'})
+        client.post(f'/bars/{bar_id}/add_to_cart', data={'product_id': item_id})
+        client.post('/cart/checkout', data={'table_id': table_id, 'payment_method': 'card'})
+        client.get('/logout')
+
+        db = SessionLocal()
+        order_id = db.query(Order).first().id
+        db.close()
+
+        client.post('/login', data={'email': 'a@example.com', 'password': 'pass'})
+
+        resp = client.get(f'/api/bars/{bar_id}/orders')
+        assert resp.status_code == 200
+        data = resp.json()
+        assert any(o['id'] == order_id for o in data)
+
+        resp = client.post(f'/api/orders/{order_id}/status', json={'status': 'ACCEPTED'})
+        assert resp.status_code == 200
+
+        resp = client.get(f'/api/bars/{bar_id}/orders')
+        statuses = {o['id']: o['status'] for o in resp.json()}
+        assert statuses[order_id] == 'ACCEPTED'


### PR DESCRIPTION
## Summary
- allow bar admins to fetch and update bar orders
- document bar admin order management in AGENTS.md
- test bar admin order management flow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b94a86fdc883209e31c67d4f6b41c8