### PR TITLE
Group bar order history into monthly summaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,12 +87,12 @@
     "Order History & Revenue" button linking to `/dashboard/bar/{id}/orders/history`.
   - Bars close automatically at their scheduled closing time based on `opening_hours`, moving completed
     orders into a `bar_closings` record (see `BarClosing` model). Canceled or rejected orders are also
-    attached to the closing but do not count toward `total_revenue`. Each closing is listed on
-    `/dashboard/bar/{id}/orders/history` with its total revenue and a "View" link to
-    `/dashboard/bar/{id}/orders/history/{closing_id}` showing the day's orders. Editing a bar's hours
-    immediately updates the automatic schedule.
-  - The Order History & Revenue page shows total collected, total earned, and Siplygo commission
-    (5% of total) for each closing.
+    attached to the closing but do not count toward `total_revenue`. Editing a bar's hours immediately
+    updates the automatic schedule.
+  - The Order History & Revenue page groups closings by month, showing total collected, total earned,
+    and Siplygo commission (5% of total) for each month. Monthly "View" links point to
+    `/dashboard/bar/{id}/orders/history/{year}/{month}` with the list of that month's closings, and
+    individual daily summaries still link to `/dashboard/bar/{id}/orders/history/{closing_id}`.
   - WebSocket endpoints `/ws/bar/{bar_id}/orders` and `/ws/user/{user_id}/orders` push real-time status updates.
   - WebSocket support depends on `uvicorn[standard]` (or another backend that provides the `websockets` library).
   - `static/js/orders.js` selects `ws` or `wss` based on the page protocol for secure deployments.

--- a/templates/bar_admin_month_history.html
+++ b/templates/bar_admin_month_history.html
@@ -1,0 +1,21 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>{{ bar.name }} - {{ month_label }}</h1>
+{% if closings %}
+<ul class="closing-list">
+  {% for closing in closings %}
+  <li class="card">
+    <div class="card__body">
+      <h2>{{ closing.closed_at|format_time }}</h2>
+      <p>Total collected: CHF {{ "%.2f"|format(closing.total_revenue) }}</p>
+      <p>Total earned: CHF {{ "%.2f"|format(closing.total_earned) }}</p>
+      <p>Siplygo commission (5%): CHF {{ "%.2f"|format(closing.siplygo_commission) }}</p>
+      <a class="btn" href="/dashboard/bar/{{ bar.id }}/orders/history/{{ closing.id }}">View</a>
+    </div>
+  </li>
+  {% endfor %}
+</ul>
+{% else %}
+<p>No order history yet.</p>
+{% endif %}
+{% endblock %}

--- a/templates/bar_admin_order_history.html
+++ b/templates/bar_admin_order_history.html
@@ -1,16 +1,16 @@
 {% extends "layout.html" %}
 {% block content %}
 <h1>{{ bar.name }} - Order History &amp; Revenue</h1>
-{% if closings %}
+{% if monthly %}
 <ul class="closing-list">
-  {% for closing in closings %}
+  {% for m in monthly %}
   <li class="card">
     <div class="card__body">
-      <h2>{{ closing.closed_at|format_time }}</h2>
-      <p>Total collected: CHF {{ "%.2f"|format(closing.total_revenue) }}</p>
-      <p>Total earned: CHF {{ "%.2f"|format(closing.total_earned) }}</p>
-      <p>Siplygo commission (5%): CHF {{ "%.2f"|format(closing.siplygo_commission) }}</p>
-      <a class="btn" href="/dashboard/bar/{{ bar.id }}/orders/history/{{ closing.id }}">View</a>
+      <h2>{{ m.label }}</h2>
+      <p>Total collected: CHF {{ "%.2f"|format(m.total_revenue) }}</p>
+      <p>Total earned: CHF {{ "%.2f"|format(m.total_earned) }}</p>
+      <p>Siplygo commission (5%): CHF {{ "%.2f"|format(m.siplygo_commission) }}</p>
+      <a class="btn" href="/dashboard/bar/{{ bar.id }}/orders/history/{{ m.year }}/{{ m.month }}">View</a>
     </div>
   </li>
   {% endfor %}

--- a/tests/test_bar_admin_orders_html.py
+++ b/tests/test_bar_admin_orders_html.py
@@ -96,6 +96,11 @@ def test_auto_close_moves_orders_to_history():
             closing_id = closings[0].id
         client.post('/login', data={'email': 'a@example.com', 'password': 'pass'})
         resp = client.get(f'/dashboard/bar/{bar.id}/orders/history')
+        assert 'January 2024' in resp.text
+        assert 'Total collected: CHF 12.00' in resp.text
+        assert 'Total earned: CHF 11.40' in resp.text
+        assert 'Siplygo commission (5%): CHF 0.60' in resp.text
+        resp = client.get(f'/dashboard/bar/{bar.id}/orders/history/2024/1')
         assert 'Total collected: CHF 12.00' in resp.text
         assert 'Total earned: CHF 11.40' in resp.text
         assert 'Siplygo commission (5%): CHF 0.60' in resp.text


### PR DESCRIPTION
## Summary
- Aggregate bar closings by month for Order History & Revenue
- Add monthly history view listing daily closings
- Document monthly grouping and update tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9516f61448320a5b70de33522373b