### PR TITLE
Add testing controls for super admin revenue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,9 @@
 - Customers may cancel their own `PLACED` orders from the order history page using the cancel button; this posts `CANCELED` via `/api/orders/{id}/status`.
 - Admin dashboard includes a testing-only "Delete all orders" button at `/admin/orders/clear` to remove every order record.
 - Super admins can review bar revenue and orders via `/admin/payments`, listing all bars with "View" links to `/dashboard/bar/{id}/orders`.
+- `/admin/payments` offers testing helpers:
+  - "Add Test Closing" creates a zero-revenue `BarClosing` dated to the first day of the previous month for the selected bar.
+  - "Delete Test Closing" removes that test `BarClosing`.
 - Testing:
   - Run `pytest`
 - Meta:

--- a/templates/admin_payments.html
+++ b/templates/admin_payments.html
@@ -16,7 +16,25 @@
     {% for bar in bars %}
     <tr>
       <td>{{ bar.name }}</td>
-      <td><a class="btn" href="/dashboard/bar/{{ bar.id }}/orders">View</a></td>
+      <td>
+        <a class="btn" href="/dashboard/bar/{{ bar.id }}/orders">View</a>
+        <form
+          method="post"
+          action="/admin/payments/{{ bar.id }}/test_closing"
+          style="display:inline"
+        >
+          <button class="btn btn--small" type="submit">Add Test Closing</button>
+        </form>
+        <form
+          method="post"
+          action="/admin/payments/{{ bar.id }}/test_closing/delete"
+          style="display:inline"
+        >
+          <button class="btn btn--danger btn--small" type="submit">
+            Delete Test Closing
+          </button>
+        </form>
+      </td>
     </tr>
     {% endfor %}
   </tbody>

--- a/tests/test_admin_test_closing.py
+++ b/tests/test_admin_test_closing.py
@@ -1,0 +1,61 @@
+import os
+import sys
+import pathlib
+import hashlib
+from datetime import datetime
+
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, engine, SessionLocal  # noqa: E402
+from models import Bar, User, RoleEnum, BarClosing  # noqa: E402
+from main import (
+    app,
+    load_bars_from_db,
+    user_carts,
+    users,
+    users_by_email,
+    users_by_username,
+)  # noqa: E402
+
+
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    user_carts.clear()
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()
+
+
+def test_super_admin_can_create_and_delete_test_closing():
+    setup_db()
+    with TestClient(app) as client:
+        db = SessionLocal()
+        bar = Bar(name="Test Bar", slug="test-bar")
+        pwd = hashlib.sha256("pass".encode("utf-8")).hexdigest()
+        admin = User(username="s", email="s@example.com", password_hash=pwd, role=RoleEnum.SUPERADMIN)
+        db.add_all([bar, admin])
+        db.commit(); db.refresh(bar); db.close()
+        load_bars_from_db()
+        client.post('/login', data={'email': 's@example.com', 'password': 'pass'})
+        resp = client.post(f'/admin/payments/{bar.id}/test_closing', follow_redirects=False)
+        assert resp.status_code == 303
+        resp = client.get(f'/dashboard/bar/{bar.id}/orders/history')
+        now = datetime.now()
+        if now.month == 1:
+            year = now.year - 1
+            month = 12
+        else:
+            year = now.year
+            month = now.month - 1
+        label = datetime(year, month, 1).strftime("%B %Y")
+        assert label in resp.text
+        resp = client.post(f'/admin/payments/{bar.id}/test_closing/delete', follow_redirects=False)
+        assert resp.status_code == 303
+        resp = client.get(f'/dashboard/bar/{bar.id}/orders/history')
+        assert label not in resp.text
+        with SessionLocal() as db2:
+            closing = db2.query(BarClosing).first()
+            assert closing is None


### PR DESCRIPTION
## Summary
- Allow super admins to add or remove a dummy BarClosing for the previous month via new dashboard actions
- Document testing helpers in `AGENTS.md`
- Cover test closing flow with integration test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b975d9583c832083cd98758345ecc4