### PR TITLE
feat: allow super admins to manage live bar orders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,7 @@
 - Customers may cancel their own `PLACED` orders from the order history page using the cancel button; this posts `CANCELED` via `/api/orders/{id}/status`.
 - Admin dashboard includes a testing-only "Delete all orders" button at `/admin/orders/clear` to remove every order record.
 - Super admins can review bar revenue and orders via `/admin/payments`, listing all bars with "View" links to `/dashboard/bar/{id}/orders`.
+- Super admins can view and update live orders for any bar using the same dashboards and APIs as bar admins and bartenders.
 - `/admin/payments` offers testing helpers:
   - "Add Test Closing" creates a zero-revenue `BarClosing` dated to the first day of the previous month for the selected bar.
   - "Delete Test Closing" removes that test `BarClosing`.

--- a/main.py
+++ b/main.py
@@ -1834,8 +1834,8 @@ async def get_bar_orders(
     user = get_current_user(request)
     if (
         not user
-        or bar_id not in user.bar_ids
-        or not (user.is_bartender or user.is_bar_admin)
+        or (bar_id not in user.bar_ids and not user.is_super_admin)
+        or not (user.is_bartender or user.is_bar_admin or user.is_super_admin)
     ):
         raise HTTPException(status_code=403, detail="Not authorised")
     orders = (
@@ -1864,8 +1864,13 @@ async def update_order_status(
 
     is_staff = bool(
         user
-        and order.bar_id in user.bar_ids
-        and (user.is_bartender or user.is_bar_admin)
+        and (
+            user.is_super_admin
+            or (
+                order.bar_id in user.bar_ids
+                and (user.is_bartender or user.is_bar_admin)
+            )
+        )
     )
     is_customer_cancel = (
         user

--- a/tests/test_super_admin_orders.py
+++ b/tests/test_super_admin_orders.py
@@ -1,0 +1,96 @@
+import sys
+import pathlib
+import hashlib
+import os
+
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, engine, SessionLocal  # noqa: E402
+from models import (  # noqa: E402
+    Bar,
+    Category,
+    MenuItem,
+    Table,
+    User,
+    RoleEnum,
+    Order,
+)
+from main import (  # noqa: E402
+    app,
+    load_bars_from_db,
+    user_carts,
+    users,
+    users_by_email,
+    users_by_username,
+)
+
+
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    user_carts.clear()
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()
+
+
+def test_super_admin_can_view_and_update_orders():
+    setup_db()
+    with TestClient(app) as client:
+        db = SessionLocal()
+        bar = Bar(name="Test Bar", slug="test-bar")
+        db.add(bar)
+        db.commit()
+        db.refresh(bar)
+        cat = Category(bar_id=bar.id, name="Drinks")
+        db.add(cat)
+        db.commit()
+        db.refresh(cat)
+        item = MenuItem(bar_id=bar.id, category_id=cat.id, name="Water", price_chf=5)
+        table = Table(bar_id=bar.id, name="T1")
+        pwd = hashlib.sha256("pass".encode("utf-8")).hexdigest()
+        customer = User(username="u", email="u@example.com", password_hash=pwd)
+        super_admin = User(
+            username="s",
+            email="s@example.com",
+            password_hash=pwd,
+            role=RoleEnum.SUPERADMIN,
+        )
+        db.add_all([item, table, customer, super_admin])
+        db.commit()
+        db.refresh(item)
+        db.refresh(table)
+        db.refresh(bar)
+        bar_id, item_id, table_id = bar.id, item.id, table.id
+        db.close()
+        load_bars_from_db()
+
+        client.post('/login', data={'email': 'u@example.com', 'password': 'pass'})
+        client.post(f'/bars/{bar_id}/add_to_cart', data={'product_id': item_id})
+        client.post('/cart/checkout', data={'table_id': table_id, 'payment_method': 'card'})
+        client.get('/logout')
+
+        db = SessionLocal()
+        order_id = db.query(Order).first().id
+        db.close()
+
+        client.post('/login', data={'email': 's@example.com', 'password': 'pass'})
+
+        resp = client.get(f'/api/bars/{bar_id}/orders')
+        assert resp.status_code == 200
+        data = resp.json()
+        assert any(o['id'] == order_id for o in data)
+
+        resp = client.post(
+            f'/api/orders/{order_id}/status', json={'status': 'ACCEPTED'}
+        )
+        assert resp.status_code == 200
+
+        resp = client.get(f'/api/bars/{bar_id}/orders')
+        statuses = {o['id']: o['status'] for o in resp.json()}
+        assert statuses[order_id] == 'ACCEPTED'
+
+    setup_db()
+


### PR DESCRIPTION
## Summary
- permit super admins to fetch and update live bar orders just like bar admins and bartenders
- cover super admin order access with dedicated tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b977f1be508320b8e4679d0a8358fc