### PR TITLE
feat: show payout to bar on revenue summaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@
     individual daily summaries still link to `/dashboard/bar/{id}/orders/history/{closing_id}`.
   - Daily closing views list a payment breakdown (credit card, wallet, etc.) for completed orders.
   - Monthly and daily summary cards now also show payment breakdowns on their revenue cards.
+  - Monthly and daily revenue cards display "Amount to pay to bar" calculated as credit card plus wallet totals minus the Siplygo commission.
 - Order History & Revenue monthly cards use `card--placed` (blue) for the current month and `card--accepted` (orange) for past months; text color remains default.
 - Past months show a "Confirm Payment" button to super admins; confirmed months switch to `card--ready` (green).
   - WebSocket endpoints `/ws/bar/{bar_id}/orders` and `/ws/user/{user_id}/orders` push real-time status updates.

--- a/main.py
+++ b/main.py
@@ -2226,6 +2226,11 @@ async def bar_admin_order_history(request: Request, bar_id: int, db: Session = D
             )
             for pm, amount in payment_rows
         }
+        card_total = Decimal(str(payment_totals.get("Credit Card", 0)))
+        wallet_total = Decimal(str(payment_totals.get("Wallet", 0)))
+        bar_payout = float(
+            (card_total + wallet_total - commission).quantize(Decimal("0.01"))
+        )
         year, month = key.split("-")
         label = datetime(int(year), int(month), 1).strftime("%B %Y")
         is_past = int(year) < current_year or (
@@ -2242,6 +2247,7 @@ async def bar_admin_order_history(request: Request, bar_id: int, db: Session = D
             "is_past": is_past,
             "confirmed": confirmed,
             "payment_totals": payment_totals,
+            "bar_payout": bar_payout,
         })
 
     monthly.sort(key=lambda m: (m["year"], m["month"]), reverse=True)
@@ -2306,6 +2312,11 @@ async def bar_admin_order_history_month(
             )
             for pm, amount in payment_rows
         }
+        card_total = Decimal(str(c.payment_totals.get("Credit Card", 0)))
+        wallet_total = Decimal(str(c.payment_totals.get("Wallet", 0)))
+        c.bar_payout = float(
+            (card_total + wallet_total - commission).quantize(Decimal("0.01"))
+        )
     month_label = start.strftime("%B %Y")
     return render_template(
         "bar_admin_month_history.html",
@@ -2390,6 +2401,11 @@ async def bar_admin_order_history_view(
     payment_totals = {
         k: float(v.quantize(Decimal("0.01"))) for k, v in payment_totals.items()
     }
+    card_total = Decimal(str(payment_totals.get("Credit Card", 0)))
+    wallet_total = Decimal(str(payment_totals.get("Wallet", 0)))
+    bar_payout = float(
+        (card_total + wallet_total - commission).quantize(Decimal("0.01"))
+    )
     return render_template(
         "bar_admin_order_history_view.html",
         request=request,
@@ -2397,6 +2413,7 @@ async def bar_admin_order_history_view(
         closing=closing,
         orders=orders,
         payment_totals=payment_totals,
+        bar_payout=bar_payout,
     )
 
 

--- a/templates/bar_admin_month_history.html
+++ b/templates/bar_admin_month_history.html
@@ -10,6 +10,7 @@
       <p>Total collected: CHF {{ "%.2f"|format(closing.total_revenue) }}</p>
       <p>Total earned: CHF {{ "%.2f"|format(closing.total_earned) }}</p>
       <p>Siplygo commission (5%): CHF {{ "%.2f"|format(closing.siplygo_commission) }}</p>
+      <p>Amount to pay to bar: CHF {{ "%.2f"|format(closing.bar_payout) }}</p>
       {% if closing.payment_totals %}
       <p>Payment breakdown:</p>
       <ul class="payment-breakdown">

--- a/templates/bar_admin_order_history.html
+++ b/templates/bar_admin_order_history.html
@@ -10,6 +10,7 @@
       <p>Total collected: CHF {{ "%.2f"|format(m.total_revenue) }}</p>
       <p>Total earned: CHF {{ "%.2f"|format(m.total_earned) }}</p>
       <p>Siplygo commission (5%): CHF {{ "%.2f"|format(m.siplygo_commission) }}</p>
+      <p>Amount to pay to bar: CHF {{ "%.2f"|format(m.bar_payout) }}</p>
       {% if m.payment_totals %}
       <p>Payment breakdown:</p>
       <ul class="payment-breakdown">

--- a/templates/bar_admin_order_history_view.html
+++ b/templates/bar_admin_order_history_view.html
@@ -4,6 +4,7 @@
 <p>Total collected: CHF {{ "%.2f"|format(closing.total_revenue) }}</p>
 <p>Total earned: CHF {{ "%.2f"|format(closing.total_earned) }}</p>
 <p>Siplygo commission (5%): CHF {{ "%.2f"|format(closing.siplygo_commission) }}</p>
+<p>Amount to pay to bar: CHF {{ "%.2f"|format(bar_payout) }}</p>
 {% if payment_totals %}
 <p>Payment breakdown:</p>
 <ul class="payment-breakdown">

--- a/tests/test_bar_admin_orders_html.py
+++ b/tests/test_bar_admin_orders_html.py
@@ -113,14 +113,17 @@ def test_auto_close_moves_orders_to_history():
         assert 'Total collected: CHF 12.00' in resp.text
         assert 'Total earned: CHF 11.40' in resp.text
         assert 'Siplygo commission (5%): CHF 0.60' in resp.text
+        assert 'Amount to pay to bar: CHF 11.40' in resp.text
         resp = client.get(f'/dashboard/bar/{bar.id}/orders/history/2024/1')
         assert 'Total collected: CHF 12.00' in resp.text
         assert 'Total earned: CHF 11.40' in resp.text
         assert 'Siplygo commission (5%): CHF 0.60' in resp.text
+        assert 'Amount to pay to bar: CHF 11.40' in resp.text
         resp = client.get(f'/dashboard/bar/{bar.id}/orders/history/{closing_id}')
         assert 'Total collected: CHF 12.00' in resp.text
         assert 'Total earned: CHF 11.40' in resp.text
         assert 'Siplygo commission (5%): CHF 0.60' in resp.text
+        assert 'Amount to pay to bar: CHF 11.40' in resp.text
         assert 'Credit Card: CHF 6.00' in resp.text
         assert 'Wallet: CHF 6.00' in resp.text
         assert 'Order #1' in resp.text


### PR DESCRIPTION
## Summary
- compute bar payout (card + wallet - commission)
- display amount to pay to bar on monthly and daily revenue pages
- document new payout metric

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba879f50348320b96e244d1d66c706