### PR TITLE
fix: compute payouts from card and wallet totals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,7 @@
   - Daily closing views list a payment breakdown (credit card, wallet, etc.) for completed orders.
   - Monthly and daily summary cards now also show payment breakdowns on their revenue cards.
   - Monthly and daily revenue cards display "Amount to pay to bar" calculated as credit card plus wallet totals minus the Siplygo commission.
+  - Commission is applied only to credit card and wallet totals; pay-at-bar orders incur no commission and are excluded from payouts.
 - Order History & Revenue monthly cards use `card--placed` (blue) for the current month and `card--accepted` (orange) for past months; text color remains default.
 - Past months show a "Confirm Payment" button to super admins; confirmed months switch to `card--ready` (green).
   - WebSocket endpoints `/ws/bar/{bar_id}/orders` and `/ws/user/{user_id}/orders` push real-time status updates.

--- a/main.py
+++ b/main.py
@@ -2205,8 +2205,6 @@ async def bar_admin_order_history(request: Request, bar_id: int, db: Session = D
     current_year, current_month = now.year, now.month
     for key, clist in monthly_map.items():
         total = sum(Decimal(c.total_revenue or 0) for c in clist)
-        commission = (total * PLATFORM_FEE_RATE).quantize(Decimal("0.01"))
-        total_earned = (total - commission).quantize(Decimal("0.01"))
         payment_rows = (
             db.query(
                 Order.payment_method,
@@ -2228,9 +2226,10 @@ async def bar_admin_order_history(request: Request, bar_id: int, db: Session = D
         }
         card_total = Decimal(str(payment_totals.get("Credit Card", 0)))
         wallet_total = Decimal(str(payment_totals.get("Wallet", 0)))
-        bar_payout = float(
-            (card_total + wallet_total - commission).quantize(Decimal("0.01"))
-        )
+        commission_base = card_total + wallet_total
+        commission = (commission_base * PLATFORM_FEE_RATE).quantize(Decimal("0.01"))
+        total_earned = (total - commission).quantize(Decimal("0.01"))
+        bar_payout = float((commission_base - commission).quantize(Decimal("0.01")))
         year, month = key.split("-")
         label = datetime(int(year), int(month), 1).strftime("%B %Y")
         is_past = int(year) < current_year or (
@@ -2290,9 +2289,6 @@ async def bar_admin_order_history_month(
     )
     for c in closings:
         total = Decimal(c.total_revenue or 0)
-        commission = (total * PLATFORM_FEE_RATE).quantize(Decimal("0.01"))
-        c.siplygo_commission = float(commission)
-        c.total_earned = float((total - commission).quantize(Decimal("0.01")))
         payment_rows = (
             db.query(
                 Order.payment_method,
@@ -2314,9 +2310,11 @@ async def bar_admin_order_history_month(
         }
         card_total = Decimal(str(c.payment_totals.get("Credit Card", 0)))
         wallet_total = Decimal(str(c.payment_totals.get("Wallet", 0)))
-        c.bar_payout = float(
-            (card_total + wallet_total - commission).quantize(Decimal("0.01"))
-        )
+        commission_base = card_total + wallet_total
+        commission = (commission_base * PLATFORM_FEE_RATE).quantize(Decimal("0.01"))
+        c.siplygo_commission = float(commission)
+        c.total_earned = float((total - commission).quantize(Decimal("0.01")))
+        c.bar_payout = float((commission_base - commission).quantize(Decimal("0.01")))
     month_label = start.strftime("%B %Y")
     return render_template(
         "bar_admin_month_history.html",
@@ -2388,9 +2386,6 @@ async def bar_admin_order_history_view(
         .all()
     )
     total = Decimal(closing.total_revenue or 0)
-    commission = (total * PLATFORM_FEE_RATE).quantize(Decimal("0.01"))
-    closing.siplygo_commission = float(commission)
-    closing.total_earned = float((total - commission).quantize(Decimal("0.01")))
     payment_totals: Dict[str, Decimal] = {}
     for o in orders:
         if o.status != "COMPLETED":
@@ -2403,9 +2398,11 @@ async def bar_admin_order_history_view(
     }
     card_total = Decimal(str(payment_totals.get("Credit Card", 0)))
     wallet_total = Decimal(str(payment_totals.get("Wallet", 0)))
-    bar_payout = float(
-        (card_total + wallet_total - commission).quantize(Decimal("0.01"))
-    )
+    commission_base = card_total + wallet_total
+    commission = (commission_base * PLATFORM_FEE_RATE).quantize(Decimal("0.01"))
+    closing.siplygo_commission = float(commission)
+    closing.total_earned = float((total - commission).quantize(Decimal("0.01")))
+    bar_payout = float((commission_base - commission).quantize(Decimal("0.01")))
     return render_template(
         "bar_admin_order_history_view.html",
         request=request,

--- a/tests/test_bar_admin_orders_html.py
+++ b/tests/test_bar_admin_orders_html.py
@@ -91,8 +91,15 @@ def test_auto_close_moves_orders_to_history():
             vat_total=2,
             payment_method="wallet",
         )
+        pay_at_bar = Order(
+            bar=bar,
+            status="COMPLETED",
+            subtotal=4,
+            vat_total=0,
+            payment_method="pay_at_bar",
+        )
         canceled = Order(bar=bar, status="CANCELED", subtotal=5, vat_total=1, payment_method="credit_card")
-        db.add_all([bar, admin, cc, wallet, canceled])
+        db.add_all([bar, admin, cc, wallet, pay_at_bar, canceled])
         db.commit()
         db.add(UserBarRole(user_id=admin.id, bar_id=bar.id, role=RoleEnum.BARADMIN))
         db.commit(); db.refresh(bar); db.close()
@@ -103,29 +110,31 @@ def test_auto_close_moves_orders_to_history():
             auto_close_bars_once(db2, now)
             closings = db2.query(BarClosing).filter_by(bar_id=bar.id).all()
             assert len(closings) == 1
-            assert float(closings[0].total_revenue) == 12.0
+            assert float(closings[0].total_revenue) == 16.0
             orders = db2.query(Order).order_by(Order.id).all()
-            assert [o.closing_id for o in orders] == [closings[0].id] * 3
+            assert [o.closing_id for o in orders] == [closings[0].id] * 4
             closing_id = closings[0].id
         client.post('/login', data={'email': 'a@example.com', 'password': 'pass'})
         resp = client.get(f'/dashboard/bar/{bar.id}/orders/history')
         assert 'January 2024' in resp.text
-        assert 'Total collected: CHF 12.00' in resp.text
-        assert 'Total earned: CHF 11.40' in resp.text
+        assert 'Total collected: CHF 16.00' in resp.text
+        assert 'Total earned: CHF 15.40' in resp.text
         assert 'Siplygo commission (5%): CHF 0.60' in resp.text
         assert 'Amount to pay to bar: CHF 11.40' in resp.text
         resp = client.get(f'/dashboard/bar/{bar.id}/orders/history/2024/1')
-        assert 'Total collected: CHF 12.00' in resp.text
-        assert 'Total earned: CHF 11.40' in resp.text
+        assert 'Total collected: CHF 16.00' in resp.text
+        assert 'Total earned: CHF 15.40' in resp.text
         assert 'Siplygo commission (5%): CHF 0.60' in resp.text
         assert 'Amount to pay to bar: CHF 11.40' in resp.text
         resp = client.get(f'/dashboard/bar/{bar.id}/orders/history/{closing_id}')
-        assert 'Total collected: CHF 12.00' in resp.text
-        assert 'Total earned: CHF 11.40' in resp.text
+        assert 'Total collected: CHF 16.00' in resp.text
+        assert 'Total earned: CHF 15.40' in resp.text
         assert 'Siplygo commission (5%): CHF 0.60' in resp.text
         assert 'Amount to pay to bar: CHF 11.40' in resp.text
         assert 'Credit Card: CHF 6.00' in resp.text
         assert 'Wallet: CHF 6.00' in resp.text
+        assert 'Pay At Bar: CHF 4.00' in resp.text
         assert 'Order #1' in resp.text
         assert 'Order #2' in resp.text
         assert 'Order #3' in resp.text
+        assert 'Order #4' in resp.text


### PR DESCRIPTION
## Summary
- ensure payouts use credit card and wallet totals minus commission
- clarify commission rules in agent notes
- test payout calculation when pay-at-bar orders exist

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba8a2dd71c8320998a484e8feb8883