### PR TITLE
Revert payout calculation changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,6 @@
   - Daily closing views list a payment breakdown (credit card, wallet, etc.) for completed orders.
   - Monthly and daily summary cards now also show payment breakdowns on their revenue cards.
   - Monthly and daily revenue cards display "Amount to pay to bar" calculated as credit card plus wallet totals minus the Siplygo commission.
-  - Commission is applied only to credit card and wallet totals; pay-at-bar orders incur no commission and are excluded from payouts.
 - Order History & Revenue monthly cards use `card--placed` (blue) for the current month and `card--accepted` (orange) for past months; text color remains default.
 - Past months show a "Confirm Payment" button to super admins; confirmed months switch to `card--ready` (green).
   - WebSocket endpoints `/ws/bar/{bar_id}/orders` and `/ws/user/{user_id}/orders` push real-time status updates.
@@ -162,3 +161,4 @@
   - Run `pytest`
 - Meta:
   - Reverted merge commit 9bc986e (PR #315) in commit 11e13a9 to restore the bar admin dashboard to its previous state; `static/js/bar_admin_dashboard.js` was removed.
+  - Reverted merge commit a169f9f (PR #359) and its fix commit 2617f16 to restore payout calculations to their previous logic.

--- a/tests/test_bar_admin_orders_html.py
+++ b/tests/test_bar_admin_orders_html.py
@@ -91,15 +91,8 @@ def test_auto_close_moves_orders_to_history():
             vat_total=2,
             payment_method="wallet",
         )
-        pay_at_bar = Order(
-            bar=bar,
-            status="COMPLETED",
-            subtotal=4,
-            vat_total=0,
-            payment_method="pay_at_bar",
-        )
         canceled = Order(bar=bar, status="CANCELED", subtotal=5, vat_total=1, payment_method="credit_card")
-        db.add_all([bar, admin, cc, wallet, pay_at_bar, canceled])
+        db.add_all([bar, admin, cc, wallet, canceled])
         db.commit()
         db.add(UserBarRole(user_id=admin.id, bar_id=bar.id, role=RoleEnum.BARADMIN))
         db.commit(); db.refresh(bar); db.close()
@@ -110,31 +103,29 @@ def test_auto_close_moves_orders_to_history():
             auto_close_bars_once(db2, now)
             closings = db2.query(BarClosing).filter_by(bar_id=bar.id).all()
             assert len(closings) == 1
-            assert float(closings[0].total_revenue) == 16.0
+            assert float(closings[0].total_revenue) == 12.0
             orders = db2.query(Order).order_by(Order.id).all()
-            assert [o.closing_id for o in orders] == [closings[0].id] * 4
+            assert [o.closing_id for o in orders] == [closings[0].id] * 3
             closing_id = closings[0].id
         client.post('/login', data={'email': 'a@example.com', 'password': 'pass'})
         resp = client.get(f'/dashboard/bar/{bar.id}/orders/history')
         assert 'January 2024' in resp.text
-        assert 'Total collected: CHF 16.00' in resp.text
-        assert 'Total earned: CHF 15.40' in resp.text
+        assert 'Total collected: CHF 12.00' in resp.text
+        assert 'Total earned: CHF 11.40' in resp.text
         assert 'Siplygo commission (5%): CHF 0.60' in resp.text
         assert 'Amount to pay to bar: CHF 11.40' in resp.text
         resp = client.get(f'/dashboard/bar/{bar.id}/orders/history/2024/1')
-        assert 'Total collected: CHF 16.00' in resp.text
-        assert 'Total earned: CHF 15.40' in resp.text
+        assert 'Total collected: CHF 12.00' in resp.text
+        assert 'Total earned: CHF 11.40' in resp.text
         assert 'Siplygo commission (5%): CHF 0.60' in resp.text
         assert 'Amount to pay to bar: CHF 11.40' in resp.text
         resp = client.get(f'/dashboard/bar/{bar.id}/orders/history/{closing_id}')
-        assert 'Total collected: CHF 16.00' in resp.text
-        assert 'Total earned: CHF 15.40' in resp.text
+        assert 'Total collected: CHF 12.00' in resp.text
+        assert 'Total earned: CHF 11.40' in resp.text
         assert 'Siplygo commission (5%): CHF 0.60' in resp.text
         assert 'Amount to pay to bar: CHF 11.40' in resp.text
         assert 'Credit Card: CHF 6.00' in resp.text
         assert 'Wallet: CHF 6.00' in resp.text
-        assert 'Pay At Bar: CHF 4.00' in resp.text
         assert 'Order #1' in resp.text
         assert 'Order #2' in resp.text
         assert 'Order #3' in resp.text
-        assert 'Order #4' in resp.text


### PR DESCRIPTION
## Summary
- Revert merge PR #359 restoring previous payout computation logic
- Document revert in AGENTS guidance

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba914d358083209f312dc20237c54b