### PR TITLE
fix: compute commission on total collected

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,12 +104,12 @@
     attached to the closing but do not count toward `total_revenue`. Editing a bar's hours immediately
     updates the automatic schedule.
   - The Order History & Revenue page groups closings by month, showing total collected, total earned,
-    and Siplygo commission (5% of card and wallet totals) for each month. Monthly "View" links point to
+    and Siplygo commission (5% of total collected) for each month. Monthly "View" links point to
     `/dashboard/bar/{id}/orders/history/{year}/{month}` with the list of that month's closings, and
     individual daily summaries still link to `/dashboard/bar/{id}/orders/history/{closing_id}`.
   - Daily closing views list a payment breakdown (credit card, wallet, etc.) for completed orders.
   - Monthly and daily summary cards now also show payment breakdowns on their revenue cards.
-  - Monthly and daily revenue cards display "Amount to pay to bar" calculated as credit card plus wallet totals minus the Siplygo commission. Commission is calculated only on credit card and wallet totals.
+  - Monthly and daily revenue cards display "Amount to pay to bar" calculated as total collected minus pay-at-bar totals minus the Siplygo commission. Commission is calculated on the total collected.
 - Order History & Revenue monthly cards use `card--placed` (blue) for the current month and `card--accepted` (orange) for past months; text color remains default.
 - Past months show a "Confirm Payment" button to super admins; confirmed months switch to `card--ready` (green).
   - WebSocket endpoints `/ws/bar/{bar_id}/orders` and `/ws/user/{user_id}/orders` push real-time status updates.

--- a/main.py
+++ b/main.py
@@ -2226,12 +2226,11 @@ async def bar_admin_order_history(request: Request, bar_id: int, db: Session = D
         }
         card_total = Decimal(str(payment_totals.get("Credit Card", 0)))
         wallet_total = Decimal(str(payment_totals.get("Wallet", 0)))
-        commission = (
-            (card_total + wallet_total) * PLATFORM_FEE_RATE
-        ).quantize(Decimal("0.01"))
+        pay_at_bar_total = Decimal(str(payment_totals.get("Bar", 0)))
+        commission = (total * PLATFORM_FEE_RATE).quantize(Decimal("0.01"))
         total_earned = (total - commission).quantize(Decimal("0.01"))
         bar_payout = float(
-            (card_total + wallet_total - commission).quantize(Decimal("0.01"))
+            (total - pay_at_bar_total - commission).quantize(Decimal("0.01"))
         )
         year, month = key.split("-")
         label = datetime(int(year), int(month), 1).strftime("%B %Y")
@@ -2313,13 +2312,12 @@ async def bar_admin_order_history_month(
         }
         card_total = Decimal(str(c.payment_totals.get("Credit Card", 0)))
         wallet_total = Decimal(str(c.payment_totals.get("Wallet", 0)))
-        commission = (
-            (card_total + wallet_total) * PLATFORM_FEE_RATE
-        ).quantize(Decimal("0.01"))
+        pay_at_bar_total = Decimal(str(c.payment_totals.get("Bar", 0)))
+        commission = (total * PLATFORM_FEE_RATE).quantize(Decimal("0.01"))
         c.siplygo_commission = float(commission)
         c.total_earned = float((total - commission).quantize(Decimal("0.01")))
         c.bar_payout = float(
-            (card_total + wallet_total - commission).quantize(Decimal("0.01"))
+            (total - pay_at_bar_total - commission).quantize(Decimal("0.01"))
         )
     month_label = start.strftime("%B %Y")
     return render_template(
@@ -2404,13 +2402,12 @@ async def bar_admin_order_history_view(
     }
     card_total = Decimal(str(payment_totals.get("Credit Card", 0)))
     wallet_total = Decimal(str(payment_totals.get("Wallet", 0)))
-    commission = (
-        (card_total + wallet_total) * PLATFORM_FEE_RATE
-    ).quantize(Decimal("0.01"))
+    pay_at_bar_total = Decimal(str(payment_totals.get("Bar", 0)))
+    commission = (total * PLATFORM_FEE_RATE).quantize(Decimal("0.01"))
     closing.siplygo_commission = float(commission)
     closing.total_earned = float((total - commission).quantize(Decimal("0.01")))
     bar_payout = float(
-        (card_total + wallet_total - commission).quantize(Decimal("0.01"))
+        (total - pay_at_bar_total - commission).quantize(Decimal("0.01"))
     )
     return render_template(
         "bar_admin_order_history_view.html",

--- a/tests/test_bar_admin_orders_html.py
+++ b/tests/test_bar_admin_orders_html.py
@@ -118,19 +118,19 @@ def test_auto_close_moves_orders_to_history():
         resp = client.get(f'/dashboard/bar/{bar.id}/orders/history')
         assert 'January 2024' in resp.text
         assert 'Total collected: CHF 18.00' in resp.text
-        assert 'Total earned: CHF 17.40' in resp.text
-        assert 'Siplygo commission (5%): CHF 0.60' in resp.text
-        assert 'Amount to pay to bar: CHF 11.40' in resp.text
+        assert 'Total earned: CHF 17.10' in resp.text
+        assert 'Siplygo commission (5%): CHF 0.90' in resp.text
+        assert 'Amount to pay to bar: CHF 11.10' in resp.text
         resp = client.get(f'/dashboard/bar/{bar.id}/orders/history/2024/1')
         assert 'Total collected: CHF 18.00' in resp.text
-        assert 'Total earned: CHF 17.40' in resp.text
-        assert 'Siplygo commission (5%): CHF 0.60' in resp.text
-        assert 'Amount to pay to bar: CHF 11.40' in resp.text
+        assert 'Total earned: CHF 17.10' in resp.text
+        assert 'Siplygo commission (5%): CHF 0.90' in resp.text
+        assert 'Amount to pay to bar: CHF 11.10' in resp.text
         resp = client.get(f'/dashboard/bar/{bar.id}/orders/history/{closing_id}')
         assert 'Total collected: CHF 18.00' in resp.text
-        assert 'Total earned: CHF 17.40' in resp.text
-        assert 'Siplygo commission (5%): CHF 0.60' in resp.text
-        assert 'Amount to pay to bar: CHF 11.40' in resp.text
+        assert 'Total earned: CHF 17.10' in resp.text
+        assert 'Siplygo commission (5%): CHF 0.90' in resp.text
+        assert 'Amount to pay to bar: CHF 11.10' in resp.text
         assert 'Credit Card: CHF 6.00' in resp.text
         assert 'Wallet: CHF 6.00' in resp.text
         assert 'Bar: CHF 6.00' in resp.text


### PR DESCRIPTION
## Summary
- compute Siplygo commission from total collected revenue
- derive total earned and bar payout using pay-at-bar totals
- document revised revenue formulas

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68baa2d5c6dc8320a717437776e1a18f