### PR TITLE
Remove Add New User option from bar staff management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@
 - Admin Manage Bars actions use uppercase text-only pill buttons that expand to fit text; links and buttons inherit the base font so Delete matches Edit sizing while employing a brighter `.btn-danger-soft` red to deter accidental clicks
 - Admin Manage Categories page uses `templates/bar_manage_categories.html` with `.menu-page` styles in `static/css/components.css`, a client-side category search via `#categorySearch`, and grouped uppercase action pills (`.btn-outline` for Products and Edit, `.btn-danger-soft` for Delete). The page header stacks the title above the search and Add Category controls
 - Admin Manage Menu Items page uses `templates/bar_category_products.html` with a `.table-card`-wrapped `menu-table`; actions use text-only pill buttons (`.btn-outline`, `.btn-danger-soft`) with a prominent Delete
-- Admin Manage Users page uses `templates/admin_bar_users.html` with `.users-page` styles in `static/css/components.css`, a client-side username/email search via `#userSearch`, and grouped action pills. The page header stacks the title above the search controls
+- Admin Manage Users page uses `templates/admin_bar_users.html` with `.users-page` styles in `static/css/components.css`, a client-side username/email search via `#userSearch`, and grouped action pills. The page header stacks the title above an Add Existing User form and the search controls; new user creation has been removed
 - Admin Manage Bars delete links open a popup confirmation using `.cart-blocker` and `.cart-popup`
 - `BAR_CATEGORIES` defined in `main.py`; reused in `search.js` and `view-all.js`
 - Categories stored in `bars.bar_categories`

--- a/main.py
+++ b/main.py
@@ -2810,60 +2810,8 @@ async def manage_bar_users_post(
                     if demo.id in bar.bar_admin_ids:
                         bar.bar_admin_ids.remove(demo.id)
                 message = "User assigned"
-    elif action == "new":
-        username = form.get("username")
-        email = form.get("email")
-        password = form.get("password")
-        phone = form.get("phone")
-        prefix = form.get("prefix")
-        if not all([username, email, password, phone, prefix]) or role not in role_map:
-            error = "All fields are required"
-        elif (
-            username in users_by_username
-            or db.query(User).filter(User.username == username).first()
-        ):
-            error = "Username already taken"
-        elif (
-            email in users_by_email
-            or db.query(User).filter(User.email == email).first()
-        ):
-            error = "Email already taken"
-        else:
-            password_hash = hashlib.sha256(password.encode("utf-8")).hexdigest()
-            db_user = User(
-                username=username,
-                email=email,
-                password_hash=password_hash,
-                phone=phone,
-                prefix=prefix,
-                role=role_map[role],
-            )
-            db.add(db_user)
-            db.commit()
-            db.refresh(db_user)
-            db_role = UserBarRole(
-                user_id=db_user.id, bar_id=bar_id, role=role_map[role]
-            )
-            db.add(db_role)
-            db.commit()
-            demo = DemoUser(
-                id=db_user.id,
-                username=username,
-                password=password,
-                email=email,
-                phone=phone,
-                prefix=prefix,
-                role=role,
-                bar_ids=[bar_id],
-            )
-            users[demo.id] = demo
-            users_by_username[demo.username] = demo
-            users_by_email[demo.email] = demo
-            if role == "bar_admin":
-                bar.bar_admin_ids.append(demo.id)
-            else:
-                bar.bartender_ids.append(demo.id)
-            message = "User created"
+    else:
+        error = "Invalid action"
     staff = [_load_demo_user(uid, db) for uid in bar.bar_admin_ids + bar.bartender_ids]
     return render_template(
         "admin_bar_users.html",

--- a/templates/admin_bar_users.html
+++ b/templates/admin_bar_users.html
@@ -6,6 +6,23 @@
       <h1>Manage Users for {{ bar.name }}</h1>
       <p class="subtitle">Add or assign staff to this venue.</p>
     </div>
+    <details>
+      <summary>Add Existing User</summary>
+      <form class="form" method="post">
+        <input type="hidden" name="action" value="existing">
+        <label for="existing_email">Email
+          <input id="existing_email" name="email" type="email" required>
+        </label>
+        <label for="existing_role">Role
+          <select id="existing_role" name="role">
+            <option value="bar_admin">Bar Admin</option>
+            <option value="bartender">Bartender</option>
+          </select>
+        </label>
+        <p>Assigning to {{ bar.name }}</p>
+        <button class="btn btn--primary" type="submit">Add</button>
+      </form>
+    </details>
     <div class="toolbar-actions">
       <form class="users-search" role="search" aria-label="Search users" onsubmit="return false">
         <i class="bi bi-search" aria-hidden="true"></i>
@@ -20,58 +37,6 @@
 
   {% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
   {% if message %}<div class="alert alert-success">{{ message }}</div>{% endif %}
-
-  <details>
-    <summary>Add Existing User</summary>
-    <form class="form" method="post">
-      <input type="hidden" name="action" value="existing">
-      <label for="existing_email">Email
-        <input id="existing_email" name="email" type="email" required>
-      </label>
-      <label for="existing_role">Role
-        <select id="existing_role" name="role">
-          <option value="bar_admin">Bar Admin</option>
-          <option value="bartender">Bartender</option>
-        </select>
-      </label>
-      <p>Assigning to {{ bar.name }}</p>
-      <button class="btn btn--primary" type="submit">Add</button>
-    </form>
-  </details>
-
-  <details>
-    <summary>Add New User</summary>
-    <form class="form" method="post">
-      <input type="hidden" name="action" value="new">
-      <label for="username">Username
-        <input id="username" name="username" required>
-      </label>
-      <label for="email">Email
-        <input id="email" name="email" type="email" required>
-      </label>
-      <label for="password">Password
-        <input id="password" name="password" type="password" required>
-      </label>
-      <label for="prefix">Phone Prefix
-        <select id="prefix" name="prefix" required autocomplete="tel-country-code">
-          <option value="+41">+41 (Switzerland)</option>
-          <option value="+1">+1 (USA)</option>
-          <option value="+44">+44 (UK)</option>
-        </select>
-      </label>
-      <label for="phone">Phone Number
-        <input id="phone" name="phone" type="tel" required autocomplete="tel-national">
-      </label>
-      <label for="role">Role
-        <select id="role" name="role">
-          <option value="bar_admin">Bar Admin</option>
-          <option value="bartender">Bartender</option>
-        </select>
-      </label>
-      <p>Assigning to {{ bar.name }}</p>
-      <button class="btn btn--primary" type="submit">Create</button>
-    </form>
-  </details>
 
   <h2>Current Staff</h2>
   <div class="table-card">

--- a/tests/test_manage_bar_users.py
+++ b/tests/test_manage_bar_users.py
@@ -27,7 +27,7 @@ def _login_super_admin(client: TestClient) -> None:
     assert resp.status_code == 303
 
 
-def test_add_existing_and_new_user_to_bar():
+def test_add_existing_user_to_bar():
     db = SessionLocal()
     bar = Bar(name="My Bar", slug="my-bar")
     db.add(bar)
@@ -65,7 +65,7 @@ def test_add_existing_and_new_user_to_bar():
         }
         resp = client.post(f"/admin/bars/{bar.id}/users", data=form)
         assert resp.status_code == 200
-        assert "brandnew" in resp.text
+        assert "Invalid action" in resp.text
 
     db = SessionLocal()
     rel_existing = (
@@ -75,11 +75,5 @@ def test_add_existing_and_new_user_to_bar():
     )
     assert rel_existing is not None and rel_existing.role == RoleEnum.BARADMIN
     new_db_user = db.query(User).filter(User.email == "fresh@example.com").first()
-    assert new_db_user is not None and new_db_user.role == RoleEnum.BARTENDER
-    rel_new = (
-        db.query(UserBarRole)
-        .filter_by(user_id=new_db_user.id, bar_id=bar.id)
-        .first()
-    )
-    assert rel_new is not None and rel_new.role == RoleEnum.BARTENDER
+    assert new_db_user is None
     db.close()


### PR DESCRIPTION
## Summary
- Show only **Add Existing User** form above the user search on bar staff management
- Strip server-side handling for new user creation in bar staff management
- Update manage bar users test and developer notes accordingly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bacdc93d988320862df18606066d19