### PR TITLE
feat: use textarea for table description

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@
   - `.bar-detail` has `margin-bottom: var(--space-4)` to add space before product categories
   - Open status uses `.status-open` (green) and closed status uses `.status-closed` (red)
   - Bar ordering pause state stored in `bars.ordering_paused` (BOOLEAN, defaults to FALSE)
-  - Bar edit options page links to table management (`templates/admin_bar_tables.html`) where staff can add, edit, and delete tables. Add and edit forms live in `templates/admin_bar_new_table.html` and `templates/admin_bar_edit_table.html`; table descriptions are for staff only
+  - Bar edit options page links to table management (`templates/admin_bar_tables.html`) where staff can add, edit, and delete tables. Add and edit forms live in `templates/admin_bar_new_table.html` and `templates/admin_bar_edit_table.html`; table descriptions use a `<textarea>` styled by the `.form textarea` rule and are for staff only
   - Admin Manage Tables page uses `templates/admin_bar_tables.html` with `.menu-page` styles, a client-side table search via `#tableSearch`, and grouped action pills (`.btn-outline` for Edit, `.btn-danger-soft` for Delete)
   - Deleting a table triggers a confirmation popup using `.cart-blocker` and `.cart-popup` like other admin pages
   - Edit Bar options UI uses `templates/admin_edit_bar_options.html` with `.bar-edit-page` and `.action-card` links in a 2-column grid (1 column on mobile)

--- a/templates/admin_bar_edit_table.html
+++ b/templates/admin_bar_edit_table.html
@@ -6,7 +6,7 @@
     <input id="name" name="name" value="{{ table.name }}" required>
   </label>
   <label for="description">Description
-    <input id="description" name="description" value="{{ table.description }}">
+    <textarea id="description" name="description" maxlength="190">{{ table.description }}</textarea>
   </label>
   <button class="btn btn--primary" type="submit">Save</button>
 </form>

--- a/templates/admin_bar_new_table.html
+++ b/templates/admin_bar_new_table.html
@@ -6,7 +6,7 @@
     <input id="name" name="name" required>
   </label>
   <label for="description">Description
-    <input id="description" name="description">
+    <textarea id="description" name="description" maxlength="190"></textarea>
   </label>
   <button class="btn btn--primary" type="submit">Create</button>
 </form>


### PR DESCRIPTION
## Summary
- use textarea for table description in table add and edit forms
- document table form description styling in AGENTS

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bae535b99483208957c696049aa4d4