### PR TITLE
Align edit bar save button style with other forms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@
 - Input fields on this page use a rounded "premium" style with a soft focus ring and invalid states.
 - Name, Address, City, Canton, and Rating inputs share the pill-shaped `input-pill` style; `#description` textarea retains the focus ring.
 - Save button sits at the bottom of the form in a `.save-inline` wrapper (non-sticky) and only appears once.
+- Save button uses `.btn--primary` styling consistent with product and category forms.
 - `Promo Label` and `Tags` fields have been removed from the project.
   - Opening hours data is sanitized; invalid or non-dict values are treated as closed
   - Category `sort_order` defaults to `0` when missing to avoid menu sorting errors

--- a/templates/admin_edit_bar.html
+++ b/templates/admin_edit_bar.html
@@ -111,7 +111,7 @@
     <input type="hidden" name="tags" value="">
 
     <div class="form-actions save-inline">
-      <button type="submit" class="btn btn-primary"><i class="bi bi-check2-circle" aria-hidden="true"></i> Save</button>
+      <button type="submit" class="btn btn--primary">Save</button>
     </div>
   </form>
 </section>


### PR DESCRIPTION
## Summary
- Match Edit Bar save button styling with product and category forms by using `btn--primary`
- Document save button styling in AGENTS notes for easier maintenance

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bae9cc245483208467d48e723a0653