### PR TITLE
style: mirror admin dashboard identity on bar admin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,7 @@
     `incoming-orders`, `preparing-orders`, `ready-orders`, and `completed-orders`.
   - The bartender dashboard lists assigned bars as `.bar-card` links to `/dashboard/bar/{id}/orders`.
   - The bar admin dashboard lists assigned bars as `.bar-card` items with edit and management links.
+  - The bar admin dashboard uses `admin-dashboard` `editbar` styling with an `admin-identity` card mirroring the admin dashboard.
   - Each bar card includes buttons for editing the bar and managing orders via `/dashboard/bar/{id}/orders`.
   - Bar admins view live orders in `bar_admin_orders.html`, which mirrors the bartender view and adds an
     "Order History & Revenue" button linking to `/dashboard/bar/{id}/orders/history`.

--- a/templates/bar_admin_dashboard.html
+++ b/templates/bar_admin_dashboard.html
@@ -1,37 +1,42 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1>Bar Admin Dashboard</h1>
-<div class="dashboard-info">
-  <div class="card">
-    <h2>{{ user.username }}</h2>
-    <p>{{ user.email }}</p>
-    <p>{{ user.prefix }} {{ user.phone }}</p>
-  </div>
-</div>
-{% if bars %}
-<div class="dashboard-actions">
-  <ul class="bars">
-    {% for bar in bars %}
-    <li>
-      <div class="bar-card">
-        <div class="thumb-wrapper">
-          {% if bar.photo_url %}
-          <img class="thumb" src="{{ bar.photo_url }}" alt="{{ bar.name }} photo" width="400" height="225">
-          {% endif %}
-        </div>
-        <h3 class="title">{{ bar.name }}</h3>
-        <address>{{ bar.city }}{% if bar.state %}, {{ bar.state }}{% endif %}</address>
-        <p class="desc">{{ bar.description }}</p>
-        <div class="bar-actions">
-          <a class="btn btn--primary" href="/admin/bars/edit/{{ bar.id }}">Edit Bar</a>
-          <a class="btn" href="/dashboard/bar/{{ bar.id }}/orders">Manage Orders</a>
-        </div>
+<section class="admin-dashboard editbar">
+  <header class="admin-header">
+    <h1>Bar Admin Dashboard</h1>
+    <div class="admin-identity card">
+      <div class="identity-row">
+        <span class="identity-name">{{ user.username }}</span>
+        <span class="identity-email">{{ user.email }}</span>
+        <span class="identity-phone">{{ user.prefix }} {{ user.phone }}</span>
       </div>
-    </li>
-    {% endfor %}
-  </ul>
-</div>
-{% else %}
-<p>No bar assigned.</p>
-{% endif %}
+    </div>
+  </header>
+  {% if bars %}
+  <section class="admin-section" aria-label="Bars">
+    <h2 class="section-title"><i class="bi bi-shop"></i> Your Bars</h2>
+    <ul class="bars">
+      {% for bar in bars %}
+      <li>
+        <div class="bar-card">
+          <div class="thumb-wrapper">
+            {% if bar.photo_url %}
+            <img class="thumb" src="{{ bar.photo_url }}" alt="{{ bar.name }} photo" width="400" height="225">
+            {% endif %}
+          </div>
+          <h3 class="title">{{ bar.name }}</h3>
+          <address>{{ bar.city }}{% if bar.state %}, {{ bar.state }}{% endif %}</address>
+          <p class="desc">{{ bar.description }}</p>
+          <div class="bar-actions">
+            <a class="btn btn--primary" href="/admin/bars/edit/{{ bar.id }}">Edit Bar</a>
+            <a class="btn" href="/dashboard/bar/{{ bar.id }}/orders">Manage Orders</a>
+          </div>
+        </div>
+      </li>
+      {% endfor %}
+    </ul>
+  </section>
+  {% else %}
+  <p>No bar assigned.</p>
+  {% endif %}
+</section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- style bar admin dashboard with same `admin-identity` card used on admin dashboard
- document new bar admin dashboard styling in AGENTS notes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68baf1f6cff88320b85989f71afd7ee1