### PR TITLE
feat: add user detail view and improve admin users list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,10 +88,12 @@
   - Credit stored in `users.credit`; ensured by `ensure_credit_column()` on startup
   - Admin user edits clear old bar roles before saving new assignments
   - Admin user edits persist credit and current bar assignment; `_load_demo_user` hydrates both from the database
-  - Admin users list loads each user's `bar_id` and `credit` directly from the database so assignments survive restarts
-  - Admin user edits update passwords and refresh user caches so new assignments replace old data
-  - Login fetches the user's bar assignment from the database so the bar is available immediately after authentication
-  - Admin user edit form: `templates/admin_edit_user.html` posts fields
+- Admin users list loads each user's `bar_id` and `credit` directly from the database so assignments survive restarts
+- Admin user edits update passwords and refresh user caches so new assignments replace old data
+- Admin Manage Users page uses `templates/admin_users.html` with `.users-page` styles, a client-side username/email search via `#userSearch`, and grouped action pills (`View`, `Edit`) in each row
+- Super admins can open `/admin/users/view/{id}` rendered by `templates/admin_view_user.html` to review a user's profile, orders, and audit logs
+- Login fetches the user's bar assignment from the database so the bar is available immediately after authentication
+- Admin user edit form: `templates/admin_edit_user.html` posts fields
     (`username`, `password`, `email`, `prefix`, `phone`, `role`, `bar_ids`, `credit`)
     to `/admin/users/edit/{id}`. Bar selection uses checkboxes for easier multi-bar assignment.
   - Bar admins and bartenders may be assigned to multiple bars. `bar_ids` lists are used

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -1,35 +1,91 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1>Manage Users</h1>
-<div class="dashboard-info">
-  <div class="card">
-    <h2>{{ user.username }}</h2>
-    <p>{{ user.email }}</p>
-    <p>{{ user.prefix }} {{ user.phone }}</p>
+<section class="users-page">
+  <header class="users-toolbar">
+    <div class="title-wrap">
+      <h1>Users</h1>
+      <p class="subtitle">Manage platform accounts.</p>
+    </div>
+    <div class="toolbar-actions">
+      <form class="users-search" role="search" aria-label="Search users" onsubmit="return false">
+        <i class="bi bi-search" aria-hidden="true"></i>
+        <input id="userSearch" type="search" inputmode="search" autocomplete="off"
+               placeholder="Search users by name or email…" aria-label="Search users by name or email">
+        <button class="clear" type="button" aria-label="Clear search">
+          <i class="bi bi-x-circle" aria-hidden="true"></i>
+        </button>
+      </form>
+    </div>
+  </header>
+
+  <div class="table-card">
+    <table class="users-table">
+      <thead>
+        <tr>
+          <th>Username</th>
+          <th>Email</th>
+          <th>Phone</th>
+          <th>Role</th>
+          <th>Bar</th>
+          <th>Credit</th>
+          <th class="actions">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for u in users %}
+        <tr>
+          <td>{{ u.username }}</td>
+          <td>{{ u.email }}</td>
+          <td>{{ u.prefix }} {{ u.phone }}</td>
+          <td>{{ u.role }}</td>
+          <td>
+            {% if u.bar_ids %}
+              {% for bid in u.bar_ids %}
+                {{ bars[bid].name }}{% if not loop.last %}, {% endif %}
+              {% endfor %}
+            {% else %}-{% endif %}
+          </td>
+          <td>CHF {{ "%.2f"|format(u.credit) }}</td>
+          <td class="actions">
+            <div class="actions-group">
+              <a href="/admin/users/view/{{ u.id }}" class="btn-outline">View</a>
+              <a href="/admin/users/edit/{{ u.id }}" class="btn-outline">Edit</a>
+            </div>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
   </div>
-</div>
-<table class="table">
-  <thead>
-    <tr><th>Username</th><th>Email</th><th>Phone</th><th>Role</th><th>Bar</th><th>Credit</th><th></th></tr>
-  </thead>
-  <tbody>
-    {% for u in users %}
-    <tr>
-      <td>{{ u.username }}</td>
-      <td>{{ u.email }}</td>
-      <td>{{ u.prefix }} {{ u.phone }}</td>
-      <td>{{ u.role }}</td>
-      <td>
-        {% if u.bar_ids %}
-          {% for bid in u.bar_ids %}
-            {{ bars[bid].name }}{% if not loop.last %}, {% endif %}
-          {% endfor %}
-        {% else %}-{% endif %}
-      </td>
-      <td>CHF {{ "%.2f"|format(u.credit) }}</td>
-      <td><a href="/admin/users/edit/{{ u.id }}">Edit</a></td>
-    </tr>
-    {% endfor %}
-  </tbody>
-</table>
+</section>
+
+<script>
+(function(){
+  const input = document.getElementById('userSearch');
+  const tbody = document.querySelector('.users-table tbody');
+  if(input && tbody){
+    const rows = Array.from(tbody.rows);
+    const norm = s => (s||'').toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g,'').trim();
+    function applyFilter(){
+      const q = norm(input.value);
+      rows.forEach(tr=>{
+        const name = tr.cells && tr.cells[0] ? tr.cells[0].textContent : '';
+        const email = tr.cells && tr.cells[1] ? tr.cells[1].textContent : '';
+        const match = !q || norm(name).includes(q) || norm(email).includes(q);
+        tr.style.display = match ? '' : 'none';
+      });
+    }
+    function debounce(fn,ms){let t;return (...a)=>{clearTimeout(t);t=setTimeout(()=>fn.apply(this,a),ms)}}
+    const run = debounce(applyFilter,120);
+    input.addEventListener('input', run);
+    document.querySelector('.users-search .clear')?.addEventListener('click',()=>{
+      input.value=''; applyFilter(); input.focus();
+    });
+    const qs = new URLSearchParams(location.search);
+    const q = qs.get('q');
+    if(q){ input.value = q; applyFilter(); }
+  }
+})();
+</script>
 {% endblock %}
+

--- a/templates/admin_view_user.html
+++ b/templates/admin_view_user.html
@@ -1,0 +1,75 @@
+{% extends "layout.html" %}
+{% block content %}
+<section class="users-page">
+  <header class="users-toolbar">
+    <div class="title-wrap">
+      <h1>User: {{ user.username }}</h1>
+      <p class="subtitle">Account details and activity.</p>
+    </div>
+  </header>
+
+  <div class="card">
+    <h2>Profile</h2>
+    <ul>
+      <li>Email: {{ user.email }}</li>
+      <li>Phone: {{ user.prefix }} {{ user.phone }}</li>
+      <li>Role: {{ user.role }}</li>
+      <li>Credit: CHF {{ "%.2f"|format(user.credit) }}</li>
+      <li>Bars: {% if user.bar_ids %}{% for bid in user.bar_ids %}{{ bars[bid].name }}{% if not loop.last %}, {% endif %}{% endfor %}{% else %}-{% endif %}</li>
+    </ul>
+  </div>
+
+  <h2>Orders</h2>
+  <div class="table-card">
+    <table class="users-table">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Bar</th>
+          <th>Total</th>
+          <th>Status</th>
+          <th>Placed</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for o in orders %}
+        <tr>
+          <td>{{ o.id }}</td>
+          <td>{{ o.bar_name }}</td>
+          <td>CHF {{ "%.2f"|format(o.total) }}</td>
+          <td>{{ o.status }}</td>
+          <td>{{ o.created_at|format_time }}</td>
+        </tr>
+        {% endfor %}
+        {% if orders|length == 0 %}
+        <tr><td colspan="5">No orders found.</td></tr>
+        {% endif %}
+      </tbody>
+    </table>
+  </div>
+
+  <h2>Audit Logs</h2>
+  <div class="table-card">
+    <table class="users-table">
+      <thead>
+        <tr>
+          <th>Action</th>
+          <th>Date</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for l in logs %}
+        <tr>
+          <td>{{ l.action }}</td>
+          <td>{{ l.created_at|format_time }}</td>
+        </tr>
+        {% endfor %}
+        {% if logs|length == 0 %}
+        <tr><td colspan="2">No activity found.</td></tr>
+        {% endif %}
+      </tbody>
+    </table>
+  </div>
+</section>
+{% endblock %}
+

--- a/tests/test_admin_view_user.py
+++ b/tests/test_admin_view_user.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import hashlib
+import pathlib
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, engine, SessionLocal  # noqa: E402
+from models import User, RoleEnum, Bar, Order  # noqa: E402
+from main import app, refresh_bar_from_db  # noqa: E402
+
+
+def setup_module(module):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def _login_super_admin(client: TestClient) -> None:
+    resp = client.post(
+        "/login",
+        data={"email": "admin@example.com", "password": "ChangeMe!123"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+def test_view_user_lists_orders():
+    db = SessionLocal()
+    password_hash = hashlib.sha256("pass".encode("utf-8")).hexdigest()
+    user = User(
+        username="cust",
+        email="cust@example.com",
+        password_hash=password_hash,
+        role=RoleEnum.CUSTOMER,
+    )
+    bar = Bar(name="BarX", slug="barx")
+    db.add_all([user, bar])
+    db.commit()
+    refresh_bar_from_db(bar.id, db)
+    order = Order(bar_id=bar.id, customer_id=user.id, subtotal=5, vat_total=0)
+    db.add(order)
+    db.commit()
+    order_id = order.id
+    user_id = user.id
+    db.close()
+
+    with TestClient(app) as client:
+        _login_super_admin(client)
+        resp = client.get(f"/admin/users/view/{user_id}")
+        assert resp.status_code == 200
+        assert str(order_id) in resp.text
+


### PR DESCRIPTION
## Summary
- style admin user management list like other dashboard sections
- add view button linking to user detail page with orders and audit logs
- cover user detail view with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be72674e508320a6d44693e25479b1