### PR TITLE
Hide archived bar orders from dashboards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,10 +129,11 @@
   - WebSocket endpoints `/ws/bar/{bar_id}/orders` and `/ws/user/{user_id}/orders` push real-time status updates.
   - WebSocket support depends on `uvicorn[standard]` (or another backend that provides the `websockets` library).
   - `static/js/orders.js` selects `ws` or `wss` based on the page protocol for secure deployments.
-  - API endpoints `/api/bars/{bar_id}/orders` (GET) and `/api/orders/{id}/status` (POST) list and update orders for bartenders and bar admins.
-  - `/api/bars/{bar_id}/orders` returns all statuses so completed orders remain visible after reloads.
-  - Order status updates return the updated order; `static/js/orders.js` re-renders immediately after POST so staff see new states without reloading.
-  - Bartenders and bar admins can accept or cancel incoming orders; after acceptance, actions progress Ready → Complete.
+    - API endpoints `/api/bars/{bar_id}/orders` (GET) and `/api/orders/{id}/status` (POST) list and update orders for bartenders and bar admins.
+    - `/api/bars/{bar_id}/orders` returns all statuses so completed orders remain visible after reloads.
+    - Orders attached to a `BarClosing` (`closing_id` set) are excluded from `/api/bars/{bar_id}/orders` so dashboards show only current orders.
+    - Order status updates return the updated order; `static/js/orders.js` re-renders immediately after POST so staff see new states without reloading.
+    - Bartenders and bar admins can accept or cancel incoming orders; after acceptance, actions progress Ready → Complete.
   - Orders are grouped into four sections: Incoming (`PLACED`), Preparing (`ACCEPTED`), Ready (`READY`), and Completed (`COMPLETED`/`CANCELED`/`REJECTED`).
   - The `/orders` route treats `CANCELED` and `REJECTED` orders as completed so they're excluded from pending.
   - Order statuses progress `PLACED → ACCEPTED → READY → COMPLETED` (with optional `CANCELED/REJECTED`).

--- a/main.py
+++ b/main.py
@@ -1825,7 +1825,7 @@ async def get_bar_orders(
         raise HTTPException(status_code=403, detail="Not authorised")
     orders = (
         db.query(Order)
-        .filter(Order.bar_id == bar_id)
+        .filter(Order.bar_id == bar_id, Order.closing_id.is_(None))
         .order_by(Order.created_at.desc())
         .all()
     )

--- a/tests/test_archived_orders_hidden.py
+++ b/tests/test_archived_orders_hidden.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import pathlib
+import hashlib
+
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, engine, SessionLocal  # noqa: E402
+from models import Bar, User, RoleEnum, UserBarRole, Order, BarClosing  # noqa: E402
+from main import app, load_bars_from_db, user_carts, users, users_by_email, users_by_username  # noqa: E402
+
+
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    user_carts.clear()
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()
+
+
+def test_archived_orders_hidden_from_dashboards():
+    setup_db()
+    with TestClient(app) as client:
+        db = SessionLocal()
+        bar = Bar(name="Test Bar", slug="test-bar")
+        pwd = hashlib.sha256("pass".encode("utf-8")).hexdigest()
+        bartender = User(
+            username="b",
+            email="b@example.com",
+            password_hash=pwd,
+            role=RoleEnum.BARTENDER,
+        )
+        db.add_all([bar, bartender])
+        db.commit()
+        db.refresh(bar)
+        bar_id = bar.id
+        db.add(
+            UserBarRole(
+                user_id=bartender.id,
+                bar_id=bar_id,
+                role=RoleEnum.BARTENDER,
+            )
+        )
+        order = Order(bar_id=bar.id, status="COMPLETED")
+        closing = BarClosing(bar_id=bar.id)
+        db.add_all([order, closing])
+        db.commit()
+        order.closing_id = closing.id
+        db.commit()
+        db.close()
+        load_bars_from_db()
+
+        client.post('/login', data={'email': 'b@example.com', 'password': 'pass'})
+        resp = client.get(f'/api/bars/{bar_id}/orders')
+        assert resp.status_code == 200
+        assert resp.json() == []


### PR DESCRIPTION
## Summary
- exclude archived orders from `/api/bars/{bar_id}/orders`
- document dashboard order filtering in `AGENTS.md`
- test that archived orders are hidden from dashboards

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be7efe574c8320af601b994065396d