### PR TITLE
Prevent bar admins from changing ratings

### DIFF
--- a/main.py
+++ b/main.py
@@ -2606,7 +2606,7 @@ async def edit_bar_post(request: Request, bar_id: int, db: Session = Depends(get
     description = form.get("description")
     if description:
         description = description[:120]
-    rating = form.get("rating")
+    rating = form.get("rating") if user.is_super_admin else None
     manual_closed = form.get("manual_closed") == "on"
     hours = {}
     for i in range(7):
@@ -2652,7 +2652,8 @@ async def edit_bar_post(request: Request, bar_id: int, db: Session = Depends(get
         bar.longitude = lon
         bar.description = description
         bar.photo_url = photo_url
-        bar.rating = float(rating) if rating else 0.0
+        if user.is_super_admin:
+            bar.rating = float(rating) if rating else 0.0
         bar.opening_hours = opening_hours
         bar.manual_closed = manual_closed
         bar.is_open_now = is_open_now_from_hours(hours) and not manual_closed
@@ -2668,7 +2669,8 @@ async def edit_bar_post(request: Request, bar_id: int, db: Session = Depends(get
             mem_bar.longitude = lon
             mem_bar.description = description
             mem_bar.photo_url = photo_url
-            mem_bar.rating = float(rating) if rating else 0.0
+            if user.is_super_admin:
+                mem_bar.rating = float(rating) if rating else 0.0
             mem_bar.opening_hours = hours
             mem_bar.manual_closed = manual_closed
             mem_bar.is_open_now = is_open_now_from_hours(hours) and not manual_closed

--- a/templates/admin_edit_bar.html
+++ b/templates/admin_edit_bar.html
@@ -71,10 +71,12 @@
           <input id="photo" name="photo" type="file">
         </div>
 
+        {% if user.is_super_admin %}
         <div class="field-group">
           <label for="rating">Rating</label>
           <input id="rating" name="rating" class="input-pill" type="number" min="0" max="5" step="0.1" value="{{ bar.rating or 0 }}">
         </div>
+        {% endif %}
 
         <div class="field-group">
           <label class="switch-label">

--- a/tests/test_bar_admin_edit_rating.py
+++ b/tests/test_bar_admin_edit_rating.py
@@ -1,0 +1,87 @@
+import os
+import pathlib
+import sys
+
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, SessionLocal, engine  # noqa: E402
+from models import Bar  # noqa: E402
+from main import app, DemoUser, users, users_by_email, users_by_username, bars  # noqa: E402
+
+
+def setup_module(module):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()
+    bars.clear()
+
+
+def teardown_module(module):
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()
+    bars.clear()
+
+
+def test_bar_admin_cannot_edit_rating():
+    db = SessionLocal()
+    bar = Bar(
+        name='Test Bar',
+        slug='test-bar',
+        rating=3.5,
+        address='Addr',
+        city='City',
+        state='State',
+        latitude=0.0,
+        longitude=0.0,
+        description='Desc',
+    )
+    db.add(bar)
+    db.commit()
+    db.refresh(bar)
+    bars[bar.id] = bar
+    db.close()
+
+    admin = DemoUser(
+        id=1,
+        username='baradmin',
+        password='pass',
+        email='admin@example.com',
+        role='bar_admin',
+        bar_ids=[bar.id],
+    )
+    users[admin.id] = admin
+    users_by_email[admin.email] = admin
+    users_by_username[admin.username] = admin
+
+    client = TestClient(app)
+    client.post('/login', data={'email': admin.email, 'password': admin.password})
+
+    resp = client.get(f'/admin/bars/edit/{bar.id}/info')
+    assert resp.status_code == 200
+    assert 'name="rating"' not in resp.text
+
+    resp = client.post(
+        f'/admin/bars/edit/{bar.id}/info',
+        data={
+            'name': 'Test Bar',
+            'address': 'Addr',
+            'city': 'City',
+            'state': 'State',
+            'latitude': '0',
+            'longitude': '0',
+            'description': 'Desc',
+            'rating': '4.9',
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    check = SessionLocal()
+    updated = check.get(Bar, bar.id)
+    assert updated.rating == 3.5
+    check.close()


### PR DESCRIPTION
## Summary
- Hide rating field on bar edit form unless a super admin
- Ignore rating updates from bar admins in backend
- Add regression test ensuring bar admins cannot modify ratings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be8408919c8320bc9b609f43a0b4f5