### PR TITLE
fix: initialize wallee client correctly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
   - `payouts.py` – schedule periodic payouts for bars
   - `app/webhooks/wallee.py` – webhook endpoint for Wallee payments
   - Wallet top-ups use Wallee: `/api/topup/init` creates `wallet_topups` records and credits the user when the webhook reports a completed transaction
+    - Initialize Wallee services with a `Configuration` instance (e.g., `TransactionServiceApi(config)`) rather than passing an `ApiClient` directly.
   - `node-topup/` contains a TypeScript example service for initiating top-ups
   - Top-up flow:
     - `templates/topup.html` posts to `/api/topup/init`; non-2xx responses trigger a client alert "Unable to start top-up".

--- a/main.py
+++ b/main.py
@@ -651,6 +651,10 @@ async def on_startup():
     ensure_menu_item_columns()
     ensure_order_columns()
     ensure_bar_closing_columns()
+    users.clear()
+    users_by_username.clear()
+    users_by_email.clear()
+    user_carts.clear()
     seed_super_admin()
     load_bars_from_db()
     asyncio.create_task(auto_close_bars_worker())
@@ -2005,7 +2009,6 @@ async def init_topup(
         config = Configuration()
         config.user_id = int(os.environ["WALLEE_USER_ID"])
         config.api_secret = os.environ["WALLEE_API_SECRET"]
-        client = ApiClient(config)
         space_id = int(os.environ["WALLEE_SPACE_ID"])
     except (KeyError, ValueError):
         raise HTTPException(status_code=503, detail="Top-up service unavailable")
@@ -2023,12 +2026,12 @@ async def init_topup(
         success_url=f"{os.getenv('BASE_URL', '')}/wallet/topup/success?tid={{id}}",
         failed_url=f"{os.getenv('BASE_URL', '')}/wallet/topup/failed?tid={{id}}",
     )
-    tx_service = TransactionServiceApi(ApiClient(config))
+    tx_service = TransactionServiceApi(config)
     tx = tx_service.create(space_id, tx_create)
     topup.wallee_transaction_id = tx.id
     db.commit()
 
-    payment_service = TransactionPaymentPageServiceApi(ApiClient(config))
+    payment_service = TransactionPaymentPageServiceApi(config)
     url = payment_service.payment_page_url(space_id, tx.id)
     return {"paymentPageUrl": url}
 


### PR DESCRIPTION
## Summary
- use Wallee configuration when starting top-ups
- clear in-memory user caches on startup
- document Wallee initialization details

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68beb903e6cc8320be7fc3a50698e338