### PR TITLE
fix: encode wallee redirect urls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@
     - The endpoint requires authentication and accepts amounts between 1 and 1000 CHF.
     - Wallee integration uses `WALLEE_SPACE_ID`, `WALLEE_USER_ID`, and `WALLEE_API_SECRET`; misconfiguration results in an error.
     - If any of these variables are missing or invalid, `/api/topup/init` returns 503 "Top-up service unavailable".
+    - Wallee requires redirect URLs to be valid RFC 3986 URIs. Encode the `{id}` placeholder as `%7Bid%7D` when building `success_url` and `failed_url`.
     - `tests/test_topup_init.py` demonstrates record creation with patched Wallee services.
 - Front-end mapping:
   - Styles in `static/css/components.css` (`components.min.css` for minified)

--- a/main.py
+++ b/main.py
@@ -95,7 +95,7 @@ from finance import (
 )
 from payouts import schedule_payout
 from audit import log_action
-from urllib.parse import urljoin
+from urllib.parse import urljoin, quote
 from app.webhooks.wallee import router as wallee_webhook_router
 from wallee import ApiClient, Configuration
 from wallee.api.transaction_service_api import TransactionServiceApi
@@ -2022,12 +2022,13 @@ async def init_topup(
         quantity=1,
         type="PRODUCT",
     )
+    placeholder = quote("{id}")
     tx_create = TransactionCreate(
         currency=os.getenv("CURRENCY", "CHF"),
         line_items=[line],
         auto_confirmation_enabled=True,
-        success_url=f"{os.getenv('BASE_URL', '')}/wallet/topup/success?tid={{id}}",
-        failed_url=f"{os.getenv('BASE_URL', '')}/wallet/topup/failed?tid={{id}}",
+        success_url=f"{os.getenv('BASE_URL', '')}/wallet/topup/success?tid={placeholder}",
+        failed_url=f"{os.getenv('BASE_URL', '')}/wallet/topup/failed?tid={placeholder}",
     )
     tx_service = TransactionServiceApi(config)
     tx = tx_service.create(space_id, tx_create)

--- a/node-topup/src/server.ts
+++ b/node-topup/src/server.ts
@@ -24,8 +24,9 @@ app.post('/api/topup/init', async (req, res) => {
     txCreate.lineItems = [lineItem];
     txCreate.currency = 'CHF';
     txCreate.autoConfirmationEnabled = true;
-    txCreate.successUrl = `${process.env.BASE_URL}/wallet/topup/success?tid={id}`;
-    txCreate.failedUrl = `${process.env.BASE_URL}/wallet/topup/failed?tid={id}`;
+    const placeholder = encodeURIComponent('{id}');
+    txCreate.successUrl = `${process.env.BASE_URL}/wallet/topup/success?tid=${placeholder}`;
+    txCreate.failedUrl = `${process.env.BASE_URL}/wallet/topup/failed?tid=${placeholder}`;
 
     const tx = await transactionService.create(spaceId, txCreate);
     const url = await paymentPageService.paymentPageUrl(spaceId, tx.body.id);


### PR DESCRIPTION
## Summary
- encode Wallee redirect URLs for top-ups to be RFC 3986 compliant
- document redirect URL encoding requirement for Wallee top-ups

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bec136fbc08320a267e4c1cc30b2a7