### PR TITLE
Fix Wallee webhook initialization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
   - `app/webhooks/wallee.py` – webhook endpoint for Wallee payments
 - Wallet top-ups use Wallee: `/api/topup/init` creates `wallet_topups` records and credits the user when the webhook reports a completed transaction
     - Initialize Wallee services with a `Configuration` instance (e.g., `TransactionServiceApi(config)`) rather than passing an `ApiClient` directly.
+    - Webhook signature verification should also pass the `Configuration` directly to `WebhookEncryptionServiceApi`; wrapping it in `ApiClient` raises `AttributeError: ApiClient object has no attribute verify_ssl`.
     - Amounts for `LineItemCreate` must be floats; passing `Decimal` values causes Wallee's SDK to raise an `AttributeError` during serialization.
   - `node-topup/` contains a TypeScript example service for initiating top-ups
   - Top-up flow:

--- a/app/webhooks/wallee.py
+++ b/app/webhooks/wallee.py
@@ -19,7 +19,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
-from wallee import ApiClient, Configuration
+from wallee import Configuration
 from wallee.api import WebhookEncryptionServiceApi
 
 from database import get_db
@@ -47,7 +47,7 @@ def get_public_key_pem(key_id: str) -> bytes:
     config = Configuration()
     config.user_id = int(os.getenv("WALLEE_USER_ID", "0"))
     config.api_secret = os.getenv("WALLEE_API_SECRET", "")
-    service = WebhookEncryptionServiceApi(ApiClient(config))
+    service = WebhookEncryptionServiceApi(config)
     key = service.read(id=key_id)
     pem = key.public_key.encode()
     _public_key_cache[key_id] = (pem, now + _CACHE_TTL)


### PR DESCRIPTION
## Summary
- build `WebhookEncryptionServiceApi` using the Wallee `Configuration` directly
- document proper configuration usage for webhook signatures

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bec59ee9048320a26d898a35dada16