### PR TITLE
feat: store wallee transaction id

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@
   - `app/webhooks/wallee.py` – webhook endpoint for Wallee payments
 - Wallet top-ups use Wallee: `/api/topup/init` creates `wallet_topups` records and credits the user when the webhook reports a completed transaction
     - Webhook `/webhooks/wallee` updates `wallet_topups` by `wallee_tx_id` with a row-level lock; processed records are skipped so repeated calls stay idempotent.
-    - `wallet_topups` columns include `id`, `user_id`, `amount_decimal`, `currency`, `wallee_tx_id` (unique), `status`, `processed_at`, `created_at`, and `updated_at`.
+    - `wallet_topups` columns include `id`, `user_id`, `amount_decimal`, `currency`, `wallee_tx_id` (unique BIGINT), `status`, `processed_at`, `created_at`, and `updated_at`.
+    - Save `int(tx.id)` to `wallet_topups.wallee_tx_id` and query by this field in the webhook.
     - The `payments` table tracks order payments only and no longer defines a `user_id` column.
     - Wallee API clients live in `app/wallee_client.py`; reuse the module's `tx_service`, `pp_service`, and `whenc_srv` instead of creating new clients.
     - Public keys returned by Wallee are base64‑encoded DER; signature checks should call `load_der_public_key` via `app/webhooks/wallee_verify.py`.

--- a/main.py
+++ b/main.py
@@ -2054,7 +2054,8 @@ async def init_topup(
         db.commit()
         raise HTTPException(status_code=502, detail=f"Wallee create error: {e}")
 
-    topup.wallee_tx_id = tx.id
+    topup.wallee_tx_id = int(tx.id)
+    db.add(topup)
     db.commit()
 
     try:

--- a/models.py
+++ b/models.py
@@ -9,7 +9,6 @@ from sqlalchemy import (
     Enum,
     ForeignKey,
     Integer,
-    BigInteger,
     Numeric,
     String,
     Text,
@@ -18,7 +17,7 @@ from sqlalchemy import (
     JSON,
 )
 from sqlalchemy.orm import relationship
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB, BIGINT
 
 from database import Base
 
@@ -324,7 +323,7 @@ class WalletTopup(Base):
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     amount_decimal = Column(Numeric(12, 2), nullable=False)
     currency = Column(String, nullable=False, default="CHF")
-    wallee_tx_id = Column(BigInteger, unique=True, nullable=True)
+    wallee_tx_id = Column(BIGINT, unique=True, nullable=True)
     status = Column(String, nullable=False, default="PENDING")
     processed_at = Column(DateTime, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)


### PR DESCRIPTION
## Summary
- persist Wallee transaction IDs for wallet top-ups
- save the transaction id after init and process webhook updates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bed327842483209d7719fa5c892fb6