### PR TITLE
Cancel orders when card payments fail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,8 @@
     `/cart/checkout` records a `payments` row with `wallee_tx_id` and
     redirects to Wallee's payment page. The `/webhooks/wallee` endpoint
     updates `payments.state` from webhook events.
+  - Card orders are only broadcast after the webhook reports a successful
+    state; failed payments automatically cancel the order.
   - Checkout form includes an optional "notes" textarea for special requests;
     notes are saved on orders and shown on bartender and user order cards.
   - The popup offers "Remove products" (clears cart via `POST /cart/clear`) or "Go to the bar menu".

--- a/main.py
+++ b/main.py
@@ -1799,13 +1799,14 @@ async def checkout(
         subtotal=order_total,
         status="PLACED",
         payment_method=payment_method,
-        paid_at=datetime.utcnow(),
+        paid_at=datetime.utcnow() if payment_method != "card" else None,
         items=order_items,
         notes=notes,
     )
     db.add(db_order)
     db.commit()
-    await send_order_update(db_order)
+    if payment_method != "card":
+        await send_order_update(db_order)
     if bar:
         user.transactions.append(
             Transaction(

--- a/tests/test_failed_card_payment_cancels_order.py
+++ b/tests/test_failed_card_payment_cancels_order.py
@@ -1,0 +1,84 @@
+import os
+import sys
+import pathlib
+import hashlib
+from types import SimpleNamespace
+from unittest.mock import patch
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ["WALLEE_VERIFY_SIGNATURE"] = "false"
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, engine, SessionLocal  # noqa: E402
+from models import Bar, Category, MenuItem, Table, User, Order, Payment  # noqa: E402
+from main import app, load_bars_from_db  # noqa: E402
+
+
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def test_failed_card_payment_cancels_order():
+    setup_db()
+    with TestClient(app) as client:
+        db = SessionLocal()
+        bar = Bar(name="Test Bar", slug="test-bar")
+        db.add(bar)
+        db.commit()
+        db.refresh(bar)
+        cat = Category(bar_id=bar.id, name="Drinks")
+        db.add(cat)
+        db.commit()
+        db.refresh(cat)
+        item = MenuItem(bar_id=bar.id, category_id=cat.id, name="Water", price_chf=5)
+        db.add(item)
+        table = Table(bar_id=bar.id, name="T1")
+        db.add(table)
+        pwd = hashlib.sha256("pass".encode("utf-8")).hexdigest()
+        user = User(username="u", email="u@example.com", password_hash=pwd)
+        db.add(user)
+        db.commit()
+        db.refresh(item)
+        db.refresh(table)
+        item_id, bar_id, table_id, user_email = item.id, bar.id, table.id, user.email
+        db.close()
+        load_bars_from_db()
+
+        client.post("/login", data={"email": user_email, "password": "pass"})
+        client.post(f"/bars/{bar_id}/add_to_cart", data={"product_id": item_id})
+
+        with patch("app.wallee_client.space_id", 1), patch(
+            "app.wallee_client.cfg"
+        ) as MockCfg, patch("app.wallee_client.tx_service") as MockTx, patch(
+            "app.wallee_client.pp_service"
+        ) as MockPage:
+            MockCfg.user_id = 1
+            MockCfg.api_secret = "secret"
+            MockTx.create.return_value = SimpleNamespace(id=123)
+            MockPage.payment_page_url.return_value = "https://pay.example/123"
+            resp = client.post(
+                "/cart/checkout",
+                data={"table_id": table_id, "payment_method": "card"},
+                follow_redirects=False,
+            )
+            assert resp.status_code == 303
+
+        db = SessionLocal()
+        payment = db.query(Payment).first()
+        order = db.query(Order).first()
+        db.close()
+
+        payload = {"entityId": int(payment.wallee_tx_id), "state": "FAILED"}
+        resp2 = client.post("/webhooks/wallee", json=payload)
+        assert resp2.status_code == 200
+
+        db = SessionLocal()
+        order = db.get(Order, order.id)
+        payment = db.get(Payment, payment.id)
+        db.close()
+        assert order.status == "CANCELED"
+        assert payment.state == "FAILED"
+


### PR DESCRIPTION
## Summary
- defer order broadcasts until card payments succeed
- cancel orders via webhook when Wallee reports failed card payments
- document card payment behaviour and add regression test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bee50d4d408320803736b64d856ba8