### PR TITLE
feat: reposition cart total and notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,8 @@
   - Menu pages pass `pause_popup_close` so the popup can be dismissed, while the cart page sets `pause_popup_back` and shows the popup on load with a "Back to the menu" button. The message advises contacting a staff member for more info.
   - `cart.html` displays the current bar's name, lists its tables for selection, and shows a wallet link for adding funds.
   - `cart.html` includes a disabled "Select table" placeholder so no table is chosen by default; checkout fails until a table is selected.
-  - The checkout form shows the order total beneath the table dropdown for clarity.
+  - The order total appears below the cart item list for quick review before selecting a table.
+  - The checkout form places the "Message to bartender" textarea immediately after the table dropdown.
   - The cart product list is rendered inside a `.table-card` with a `.menu-table` for consistent styling with other lists.
   - Checkout form asks for payment method (credit card, wallet credit, or pay at bar);
     selection is handled by `/cart/checkout` and stored in `Transaction.payment_method`.

--- a/templates/cart.html
+++ b/templates/cart.html
@@ -38,6 +38,7 @@
     </tbody>
   </table>
 </div>
+<p><strong>Total: CHF {{ "%.2f"|format(cart.total_price()) }}</strong></p>
 <h2>Select Table</h2>
 <form class="form" method="post" action="/cart/checkout">
   <label for="table_id">Table
@@ -48,16 +49,15 @@
       {% endfor %}
     </select>
   </label>
-  <p><strong>Total: CHF {{ "%.2f"|format(cart.total_price()) }}</strong></p>
+  <label for="notes">Message to bartender
+    <textarea id="notes" name="notes" rows="3" placeholder="Add a note for the bartender"></textarea>
+  </label>
   <fieldset>
     <legend>Payment Method</legend>
     <label><input type="radio" name="payment_method" value="card" required> Credit Card</label>
     <label><input type="radio" name="payment_method" value="wallet"> Wallet Credit</label>
     <label><input type="radio" name="payment_method" value="bar"> Pay at Bar</label>
   </fieldset>
-  <label for="notes">Message to bartender
-    <textarea id="notes" name="notes" rows="3" placeholder="Add a note for the bartender"></textarea>
-  </label>
   <button class="btn btn--success" type="submit">Place Order</button>
 </form>
 {% else %}


### PR DESCRIPTION
## Summary
- move cart total below item list
- place bartender note field directly under table selection
- document cart layout in AGENTS

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfc52946488320b093bb63ad1a30aa