### PR TITLE
Reset invalid table selection on cart page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@
   - `cart.html` lists available tables for selection and shows a wallet link for adding funds.
   - `cart.html` text is fully in English, including subtitle "Review your order, choose your table, and confirm payment." and payment method notes.
   - `cart.html` includes a disabled "Select table" placeholder so no table is chosen by default; checkout fails until a table is selected.
+  - The `/cart` route clears `cart.table_id` when it doesn't match an available table so the placeholder remains the default.
   - The order total appears below the cart item list for quick review before selecting a table.
   - The checkout form places the "Message to bartender" textarea immediately after the table dropdown.
   - The cart product list is rendered inside a `.table-card` with a `.menu-table` for consistent styling with other lists.

--- a/main.py
+++ b/main.py
@@ -1670,6 +1670,9 @@ async def view_cart(request: Request):
         return RedirectResponse(url="/login", status_code=status.HTTP_303_SEE_OTHER)
     cart = get_cart_for_user(user)
     current_bar: Optional[Bar] = bars.get(cart.bar_id) if cart.bar_id else None
+    if current_bar and cart.table_id not in current_bar.tables:
+        cart.table_id = None
+        save_cart_for_user(user.id, cart)
     if "application/json" in request.headers.get("accept", ""):
         count = sum(item.quantity for item in cart.items.values())
         total = cart.total_price()

--- a/tests/test_cart_table_default.py
+++ b/tests/test_cart_table_default.py
@@ -1,0 +1,63 @@
+import os
+import sys
+import pathlib
+import hashlib
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, SessionLocal, engine  # noqa: E402
+from models import Bar, Category, MenuItem, Table, User  # noqa: E402
+from main import app, user_carts, users, get_cart_for_user, save_cart_for_user  # noqa: E402
+
+
+def reset_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def test_cart_table_defaults_to_placeholder():
+    reset_db()
+    db = SessionLocal()
+    bar = Bar(name="Test Bar", slug="test-bar")
+    db.add(bar)
+    db.commit()
+    db.refresh(bar)
+    bar_id = bar.id
+    table = Table(bar_id=bar_id, name="T1")
+    db.add(table)
+    db.commit()
+    db.refresh(table)
+    cat = Category(bar_id=bar_id, name="Drinks")
+    db.add(cat)
+    db.commit()
+    db.refresh(cat)
+    item = MenuItem(bar_id=bar_id, category_id=cat.id, name="Water", price_chf=5)
+    db.add(item)
+    pwd = hashlib.sha256("pass".encode("utf-8")).hexdigest()
+    user = User(username="u", email="u@example.com", password_hash=pwd)
+    db.add(user)
+    db.commit()
+    db.refresh(item)
+    db.refresh(user)
+    item_id = item.id
+    user_email = user.email
+    user_id = user.id
+    # bar_id already captured
+    db.close()
+
+    with TestClient(app) as client:
+        client.post("/login", data={"email": user_email, "password": "pass"})
+        client.post(
+            f"/bars/{bar_id}/add_to_cart",
+            data={"product_id": item_id},
+            headers={"accept": "application/json"},
+        )
+        demo_user = users[user_id]
+        cart = get_cart_for_user(demo_user)
+        cart.table_id = 999
+        save_cart_for_user(user_id, cart)
+        resp = client.get("/cart")
+        assert '<option value="" disabled selected>Select table</option>' in resp.text
+        assert get_cart_for_user(demo_user).table_id is None


### PR DESCRIPTION
## Summary
- Clear stored table selection when loading cart if it doesn't match current bar
- Document cart table reset in AGENTS notes
- Add regression test for cart table placeholder

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfdca3c060832087934e77465c1eb1