### PR TITLE
Show processing and canceled statuses in wallet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # AGENT Notes
 
 - Wallet page UI lives in `templates/wallet.html` using a `.wallet-page` wrapper and inline scoped styles. Transaction rows render inside `<ul id="txList">` and link to `/wallet/tx/{index}`. "Load more," "Export CSV," "Manage payment methods," and all filters have been removed; the "Top Up" button uses `text-decoration:none` to avoid an underline.
+- Wallet transactions for orders begin in a `PROCESSING` state and update to `COMPLETED` once the order is accepted or to `CANCELED` if the order is canceled. Canceled transactions display a `- CHF 0.00` amount.
 
 - Core modules:
   - `main.py` – routes and helpers

--- a/templates/wallet.html
+++ b/templates/wallet.html
@@ -55,7 +55,7 @@
                 {% if ttype == 'payment' %}-{% else %}+{% endif %} CHF {{ "%.2f"|format(tx.total) }}
               </div>
               {% set status = tx.status if tx.status is defined else 'COMPLETED' %}
-              <span class="pill {% if status|lower == 'pending' %}pending{% elif status|lower == 'refunded' %}refunded{% else %}success{% endif %}">{{ status|replace('_',' ')|title }}</span>
+              <span class="pill {% if status|lower in ['processing','pending'] %}pending{% elif status|lower == 'refunded' %}refunded{% elif status|lower in ['canceled','cancelled'] %}canceled{% else %}success{% endif %}">{{ status|replace('_',' ')|title }}</span>
             </div>
           </a>
         </li>
@@ -120,6 +120,7 @@
 .pill.success{ background:#f0fdf4; border-color:#bbf7d0; color:#166534; }
 .pill.pending{ background:#fff7ed; border-color:#fed7aa; color:#9a3412; }
 .pill.refunded{ background:#eff6ff; border-color:#bfdbfe; color:#1d4ed8; }
+.pill.canceled{ background:#fef2f2; border-color:#fecaca; color:#991b1b; }
 
 /* Empty & actions */
 .empty{ display:none; text-align:center; padding:28px 18px 24px; }

--- a/tests/test_wallet_transactions.py
+++ b/tests/test_wallet_transactions.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import pathlib
+
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from main import app, user_carts, users, users_by_email, users_by_username  # noqa: E402
+from test_cancel_order import setup_db, create_order  # noqa: E402
+
+
+def test_wallet_transaction_status_updates():
+    setup_db()
+    with TestClient(app) as client:
+        ids = create_order(client, 'wallet')
+
+        client.post('/login', data={'email': ids['customer_email'], 'password': 'pass'})
+        wallet = client.get('/wallet')
+        assert 'Processing' in wallet.text
+        client.get('/logout')
+
+        client.post('/login', data={'email': ids['bartender_email'], 'password': 'pass'})
+        client.post(f"/api/orders/{ids['order_id']}/status", json={'status': 'ACCEPTED'})
+        client.get('/logout')
+
+        client.post('/login', data={'email': ids['customer_email'], 'password': 'pass'})
+        wallet = client.get('/wallet')
+        assert 'Completed' in wallet.text
+        client.get('/logout')
+
+        client.post('/login', data={'email': ids['bartender_email'], 'password': 'pass'})
+        client.post(f"/api/orders/{ids['order_id']}/status", json={'status': 'CANCELED'})
+        client.get('/logout')
+
+        client.post('/login', data={'email': ids['customer_email'], 'password': 'pass'})
+        wallet = client.get('/wallet')
+        assert 'Canceled' in wallet.text
+        assert '- CHF 0.00' in wallet.text
+
+    user_carts.clear()
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()


### PR DESCRIPTION
## Summary
- track order IDs and statuses for user wallet transactions
- display Processing, Completed, and Canceled states with new styling
- test wallet transaction status updates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfe68d0bd08320a9912a944d7e3a02