### PR TITLE
Hide pay-at-bar transactions from wallet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 - Wallet page UI lives in `templates/wallet.html` using a `.wallet-page` wrapper and inline scoped styles. Transaction rows render inside `<ul id="txList">` and link to `/wallet/tx/{index}`. "Load more," "Export CSV," "Manage payment methods," and all filters have been removed; the "Top Up" button uses `text-decoration:none` to avoid an underline.
 - Wallet transactions for orders begin in a `PROCESSING` state and update to `COMPLETED` once the order is accepted or to `CANCELED` if the order is canceled. Canceled transactions display a `- CHF 0.00` amount.
-- Card payments finalized by the Wallee webhook are added to the wallet feed so card orders appear alongside wallet and pay-at-bar transactions.
+- Card payments finalized by the Wallee webhook are added to the wallet feed so card orders appear alongside wallet transactions. Pay-at-bar orders are excluded from the wallet feed.
 - Top-ups append a `topup` transaction in a `PROCESSING` state during `/api/topup/init`; the Wallee webhook updates it to `COMPLETED` and refreshes the user's cached credit.
 
 - Core modules:

--- a/tests/test_wallet_transactions.py
+++ b/tests/test_wallet_transactions.py
@@ -43,3 +43,19 @@ def test_wallet_transaction_status_updates():
     users.clear()
     users_by_email.clear()
     users_by_username.clear()
+
+
+def test_bar_payments_hidden_from_wallet():
+    setup_db()
+    with TestClient(app) as client:
+        ids = create_order(client, 'bar')
+
+        client.post('/login', data={'email': ids['customer_email'], 'password': 'pass'})
+        wallet = client.get('/wallet')
+        assert 'Test Bar' not in wallet.text
+        assert 'No transactions yet' in wallet.text
+
+    user_carts.clear()
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()


### PR DESCRIPTION
## Summary
- avoid recording pay-at-bar orders as wallet transactions
- filter wallet views to exclude pay-at-bar payments
- document wallet behavior and add regression test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfebd98cf48320a1b444510026db24