### PR TITLE
Remove wallet balance update timestamp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # AGENT Notes
 
 - Wallet page UI lives in `templates/wallet.html` using a `.wallet-page` wrapper and inline scoped styles. Transaction rows render inside `<ul id="txList">` and link to `/wallet/tx/{index}`. "Load more," "Export CSV," "Manage payment methods," and all filters have been removed; the "Top Up" button uses `text-decoration:none` to avoid an underline.
+- The balance card's meta now only shows an `Available` badge and omits any "last updated" text.
 - Wallet transactions for orders begin in a `PROCESSING` state and update to `COMPLETED` once the order is accepted or to `CANCELED` if the order is canceled. Canceled transactions display a `- CHF 0.00` amount.
 - Card payments finalized by the Wallee webhook are added to the wallet feed so card orders appear alongside wallet transactions. Pay-at-bar orders are excluded from the wallet feed.
 - Top-ups append a `topup` transaction in a `PROCESSING` state during `/api/topup/init`; the Wallee webhook updates it to `COMPLETED` and refreshes the user's cached credit.

--- a/templates/wallet.html
+++ b/templates/wallet.html
@@ -10,7 +10,7 @@
     <div class="balance-left">
       <span class="label">Current balance</span>
       <div class="amount">CHF {{ "%.2f"|format(user.credit) }}</div>
-      <div class="meta"><span class="badge success">Available</span> <span class="dot">•</span> Updated just now</div>
+      <div class="meta"><span class="badge success">Available</span></div>
     </div>
   <div class="balance-right wallet-actions">
       <a href="/topup" class="btn-primary">Top Up</a>
@@ -93,7 +93,6 @@
 .balance-card .meta{ color:var(--muted); font-size:.85rem; display:flex; align-items:center; gap:8px; }
 .balance-card .badge{ display:inline-flex; align-items:center; gap:6px; padding:4px 8px; border-radius:999px; font-size:.75rem; border:1px solid var(--border); }
 .balance-card .badge.success{ background:#f0fdf4; border-color:#bbf7d0; color:#166534; }
-.balance-card .dot{ opacity:.5; }
 .wallet-actions{ display:flex; gap:10px; flex-wrap:wrap; }
 
 /* Transaction FEED */


### PR DESCRIPTION
## Summary
- hide outdated "Updated just now" note on wallet balance card
- document wallet balance meta change

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bff7b5d0708320bf428462c05b94eb