### PR TITLE
Hide top-up button after card recharge click

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@
   - `node-topup/` contains a TypeScript example service for initiating top-ups
   - Top-up flow:
     - `templates/topup.html` posts to `/api/topup/init`; non-2xx responses trigger a client alert "Unable to start top-up".
-    - The submit button disables after submission to prevent duplicate requests.
+    - The submit button hides and disables after submission to prevent duplicate requests.
     - The endpoint requires authentication and accepts amounts between 1 and 1000 CHF.
     - Wallee integration uses `WALLEE_SPACE_ID`, `WALLEE_USER_ID`, and `WALLEE_API_SECRET`; misconfiguration results in an error.
     - If any of these variables are missing or invalid, `/api/topup/init` returns 503 "Top-up service unavailable".

--- a/templates/topup.html
+++ b/templates/topup.html
@@ -32,6 +32,7 @@
       return;
     }
     submitBtn.disabled = true;
+    submitBtn.style.display = 'none';
     try {
       const resp = await fetch('/api/topup/init', {
         method: 'POST',
@@ -42,14 +43,16 @@
         const data = await resp.json();
         if (data.paymentPageUrl) {
           window.location.replace(data.paymentPageUrl);
+          return;
         }
-      } else {
-        alert('Unable to start top-up');
       }
+      alert('Unable to start top-up');
+      submitBtn.disabled = false;
+      submitBtn.style.display = '';
     } catch {
       alert('Unable to start top-up');
-    } finally {
       submitBtn.disabled = false;
+      submitBtn.style.display = '';
     }
   });
 </script>


### PR DESCRIPTION
## Summary
- hide top-up submit button after click to avoid duplicate submissions
- document new top-up behavior in AGENTS notes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c000c58cfc83208630829bef524cfb