### PR TITLE
feat(auth): use text prompts for login/register links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,7 @@
 - Admin Manage Users page uses `templates/admin_users.html` with `.users-page` styles, a client-side username/email search via `#userSearch`, and grouped action pills (`View`, `Edit`) in each row
 - Super admins can open `/admin/users/view/{id}` rendered by `templates/admin_view_user.html` to review a user's profile, orders, and audit logs
 - Login fetches the user's bar assignment from the database so the bar is available immediately after authentication
-- Login and Register pages link to each other via `btn-outline` buttons with English labels
+- Login and Register pages show text prompts linking to each other: "Already registered? Log in" and "Not registered yet? Register"
 - Admin user edit form: `templates/admin_edit_user.html` posts fields
     (`username`, `password`, `email`, `prefix`, `phone`, `role`, `bar_ids`, `credit`)
     to `/admin/users/edit/{id}`. Bar selection uses checkboxes for easier multi-bar assignment.

--- a/templates/login.html
+++ b/templates/login.html
@@ -12,7 +12,7 @@
     </label>
     <button class="btn btn--primary" type="submit">Login</button>
   </form>
-  <a class="btn-outline" style="align-self:center" href="/register">Register</a>
+  <p style="align-self:center">Not registered yet? <a href="/register">Register</a></p>
 </div>
 {% endblock %}
 

--- a/templates/register.html
+++ b/templates/register.html
@@ -25,7 +25,7 @@
     </label>
     <button class="btn btn--primary" type="submit">Register</button>
   </form>
-  <a class="btn-outline" style="align-self:center" href="/login">Login</a>
+  <p style="align-self:center">Already registered? <a href="/login">Log in</a></p>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- display 'Not registered yet? Register' under login form
- display 'Already registered? Log in' under register form
- document cross-link prompt behavior in AGENTS.md

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c013f466408320a21649f6a73553cd