### PR TITLE
feat(auth): validate phone number length

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,7 @@
 - Super admins can open `/admin/users/view/{id}` rendered by `templates/admin_view_user.html` to review a user's profile, orders, and audit logs
 - Login fetches the user's bar assignment from the database so the bar is available immediately after authentication
 - Login and Register pages show text prompts linking to each other: "Already registered? Log in" and "Not registered yet? Register"
+- Register form requires a phone number with 9–10 digits; invalid entries show an error
 - Admin user edit form: `templates/admin_edit_user.html` posts fields
     (`username`, `password`, `email`, `prefix`, `phone`, `role`, `bar_ids`, `credit`)
     to `/admin/users/edit/{id}`. Bar selection uses checkboxes for easier multi-bar assignment.

--- a/main.py
+++ b/main.py
@@ -2284,6 +2284,12 @@ async def register(request: Request, db: Session = Depends(get_db)):
     phone = form.get("phone")
     prefix = form.get("prefix")
     if all([username, password, email, phone, prefix]):
+        if not phone.isdigit() or not (9 <= len(phone) <= 10):
+            return render_template(
+                "register.html",
+                request=request,
+                error="Phone number must be 9-10 digits",
+            )
         if (
             username in users_by_username
             or db.query(User).filter(User.username == username).first()

--- a/templates/register.html
+++ b/templates/register.html
@@ -21,7 +21,7 @@
       </select>
     </label>
     <label for="phone">Phone Number
-      <input id="phone" type="tel" name="phone" required autocomplete="tel-national" inputmode="tel" enterkeyhint="done">
+      <input id="phone" type="tel" name="phone" required autocomplete="tel-national" inputmode="tel" enterkeyhint="done" pattern="[0-9]{9,10}" minlength="9" maxlength="10" title="Phone number must be 9 to 10 digits">
     </label>
     <button class="btn btn--primary" type="submit">Register</button>
   </form>

--- a/tests/test_register_phone_validation.py
+++ b/tests/test_register_phone_validation.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import pathlib
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, engine  # noqa: E402
+from main import app, users, users_by_email, users_by_username  # noqa: E402
+
+
+def setup_module(module):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()
+
+
+def test_register_phone_length_validation():
+    with TestClient(app) as client:
+        resp = client.post(
+            "/register",
+            data={
+                "username": "short",
+                "password": "pass",
+                "email": "short@example.com",
+                "prefix": "+41",
+                "phone": "12345678",
+            },
+        )
+        assert resp.status_code == 200
+        assert "Phone number must be 9-10 digits" in resp.text
+
+        resp_ok = client.post(
+            "/register",
+            data={
+                "username": "validuser",
+                "password": "pass",
+                "email": "valid@example.com",
+                "prefix": "+41",
+                "phone": "123456789",
+            },
+            follow_redirects=False,
+        )
+        assert resp_ok.status_code == 303
+        assert resp_ok.headers["location"] == "/login"


### PR DESCRIPTION
## Summary
- enforce 9-10 digit requirement for phone number during registration
- add client-side validation for phone number input
- document phone number requirement and add regression test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c01c1fd658832081e0c63005257d4f