### PR TITLE
feat(auth): validate email format on registration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,7 @@
 - Login fetches the user's bar assignment from the database so the bar is available immediately after authentication
 - Login and Register pages show text prompts linking to each other: "Already registered? Log in" and "Not registered yet? Register"
 - Register form requires a phone number with 9–10 digits; invalid entries show an error
+- Register form requires an email in the format text@text.text; invalid entries show an error
 - Admin user edit form: `templates/admin_edit_user.html` posts fields
     (`username`, `password`, `email`, `prefix`, `phone`, `role`, `bar_ids`, `credit`)
     to `/admin/users/edit/{id}`. Bar selection uses checkboxes for easier multi-bar assignment.

--- a/main.py
+++ b/main.py
@@ -36,6 +36,7 @@ import asyncio
 import hashlib
 import json
 import random
+import re
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -2284,6 +2285,12 @@ async def register(request: Request, db: Session = Depends(get_db)):
     phone = form.get("phone")
     prefix = form.get("prefix")
     if all([username, password, email, phone, prefix]):
+        if not re.fullmatch(r"[^@]+@[^@]+\.[^@]+", email or ""):
+            return render_template(
+                "register.html",
+                request=request,
+                error="Invalid email format",
+            )
         if not phone.isdigit() or not (9 <= len(phone) <= 10):
             return render_template(
                 "register.html",

--- a/templates/register.html
+++ b/templates/register.html
@@ -8,7 +8,7 @@
       <input id="username" type="text" name="username" required autocomplete="username" inputmode="text" enterkeyhint="next">
     </label>
     <label for="email">Email
-      <input id="email" type="email" name="email" required autocomplete="email" inputmode="email" enterkeyhint="next">
+      <input id="email" type="email" name="email" required autocomplete="email" inputmode="email" enterkeyhint="next" pattern="[^@]+@[^@]+\.[^@]+" title="Email must be in the format text@text.text">
     </label>
     <label for="password">Password
       <input id="password" type="password" name="password" required autocomplete="new-password" enterkeyhint="next">

--- a/tests/test_register_email_validation.py
+++ b/tests/test_register_email_validation.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import pathlib
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, engine  # noqa: E402
+from main import app, users, users_by_email, users_by_username  # noqa: E402
+
+
+def setup_module(module):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()
+
+
+def test_register_email_format_validation():
+    with TestClient(app) as client:
+        resp = client.post(
+            "/register",
+            data={
+                "username": "invalid",
+                "password": "pass",
+                "email": "invalid",
+                "prefix": "+41",
+                "phone": "123456789",
+            },
+        )
+        assert resp.status_code == 200
+        assert "Invalid email format" in resp.text
+
+        resp_ok = client.post(
+            "/register",
+            data={
+                "username": "validuser",
+                "password": "pass",
+                "email": "valid@example.com",
+                "prefix": "+41",
+                "phone": "123456789",
+            },
+            follow_redirects=False,
+        )
+        assert resp_ok.status_code == 303
+        assert resp_ok.headers["location"] == "/login"
+


### PR DESCRIPTION
## Summary
- validate email addresses in registration with a text@text.text check
- add pattern-based email validation to register form
- test registration email validation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c01eb0c8688320b2cab5748dfbe7b1