### PR TITLE
Remove order history load more & back to top actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,7 @@
 - Orders:
   - `/orders` page renders `templates/order_history.html` with past `Order` entries for the current user.
   - The page wraps content in `.orders-page`; pending and completed sections show counts and empty states, and order cards sit in a responsive `.orders-grid` without altering card markup. The previous status/date/search/sort/export toolbar has been removed.
+  - Order history lists all orders with no "Load more" button or "Back to top" link; the `.orders-actions` block was removed.
   - Checkout persists orders to the database and redirects to `/orders`.
   - Mobile hamburger menu links to order history via `bi bi-clock-history` icon.
   - Bartenders manage live orders in `bartender_orders.html` using `static/js/orders.js`,

--- a/templates/order_history.html
+++ b/templates/order_history.html
@@ -122,10 +122,6 @@
     </div>
     {% endif %}
 
-    <div class="orders-actions">
-      <button class="btn-outline" type="button" id="loadMoreOrders">Load more</button>
-      <a href="#top" class="btn-ghost">Back to top</a>
-    </div>
   </section>
 </section>
 
@@ -158,11 +154,6 @@
 .orders-page .empty{ display:none; text-align:center; border:1px dashed var(--border); border-radius:12px; padding:22px; color:var(--muted); background:#fff; }
 .orders-page .empty.show{ display:block; }
 .orders-page .empty h3{ margin:0 0 6px; font-size:1.05rem; color:var(--text); }
-
-/* Actions */
-.orders-page .orders-actions{ display:flex; gap:10px; margin-top:12px; }
-.orders-page .btn-outline{ background:transparent; color:var(--text); border:1px solid var(--border); border-radius:12px; padding:10px 14px; font-weight:600; }
-.orders-page .btn-ghost{ background:transparent; color:var(--accent); border:1px solid transparent; border-radius:12px; padding:10px 12px; font-weight:600; }
 
 /* Responsiveness */
 @media (max-width: 768px){


### PR DESCRIPTION
## Summary
- remove Load more button and Back to top link from order history
- clean up unused action styles
- document order history simplification in AGENTS notes

## Testing
- `pytest` *(fails: Interrupted: 59 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c044eaaaa083209c130f3c1bea9ce2