### PR TITLE
Replace How it works with Profile in menu

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,7 @@
   - Order history lists all orders with no "Load more" button or "Back to top" link; the `.orders-actions` block was removed.
   - Checkout persists orders to the database and redirects to `/orders`.
   - Mobile hamburger menu links to order history via `bi bi-clock-history` icon.
+  - Mobile menu drops the "How it works" entry and adds a `bi bi-person` Profile link for logged-in users.
   - Bartenders manage live orders in `bartender_orders.html` using `static/js/orders.js`,
     which loads with `defer` and initializes `initBartender(bar.id)` on `DOMContentLoaded`.
   - `templates/bartender_orders.html` groups orders into `<ul>` lists with IDs

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -64,13 +64,13 @@
       <nav id="mobileMenu" class="mobile-menu" aria-label="Menu" role="dialog" aria-modal="true" hidden>
         <button class="menu-close js-close-menu" aria-label="Close menu"><i class="bi bi-x" aria-hidden="true"></i></button>
         <a href="/search" role="menuitem"><i class="bi bi-geo-alt" aria-hidden="true"></i><span>Browse Bars</span></a>
-        <a href="#how" role="menuitem"><i class="bi bi-stars" aria-hidden="true"></i><span>How it works</span></a>
         {% if user and (user.is_super_admin or user.is_bar_admin or user.is_bartender) %}
         <a href="/dashboard" role="menuitem"><i class="bi bi-speedometer2" aria-hidden="true"></i><span>Dashboard</span></a>
         {% endif %}
         {% if user %}
         <a href="/wallet" role="menuitem"><i class="bi bi-wallet2" aria-hidden="true"></i><span>Wallet</span></a>
         <a href="/orders" role="menuitem"><i class="bi bi-clock-history" aria-hidden="true"></i><span>Orders</span></a>
+        <a href="/profile" role="menuitem"><i class="bi bi-person" aria-hidden="true"></i><span>Profile</span></a>
         <a href="/logout" role="menuitem"><i class="bi bi-box-arrow-right" aria-hidden="true"></i><span>Logout</span></a>
         {% else %}
         <a href="/login" role="menuitem" class="menu-login"><i class="bi bi-box-arrow-in-right" aria-hidden="true"></i><span>Login</span></a>


### PR DESCRIPTION
## Summary
- remove obsolete How it works item from mobile menu
- add Profile link with bootstrap icon
- document new menu structure in AGENTS notes

## Testing
- `pytest` (fails: 59 errors during collection)

------
https://chatgpt.com/codex/tasks/task_e_68c049bf93888320a1e80914e5ba8c77