### PR TITLE
Limit order history grid to three columns on desktop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,7 @@
 - Orders:
   - `/orders` page renders `templates/order_history.html` with past `Order` entries for the current user.
   - The page wraps content in `.orders-page`; pending and completed sections show counts and empty states, and order cards sit in a responsive `.orders-grid` without altering card markup. The previous status/date/search/sort/export toolbar has been removed.
+  - Desktop order grids cap at three columns (`max-width: calc(260px * 3 + 24px);`), centering the layout.
   - Order history lists all orders with no "Load more" button or "Back to top" link; the `.orders-actions` block was removed.
   - Checkout persists orders to the database and redirects to `/orders`.
   - Mobile hamburger menu links to order history via `bi bi-clock-history` icon.

--- a/templates/order_history.html
+++ b/templates/order_history.html
@@ -147,6 +147,8 @@
 .orders-page .orders-grid{
   display:grid; gap:12px;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  max-width: calc(260px * 3 + 24px);
+  margin:0 auto;
 }
 .orders-page .orders-grid .card{ width:100%; max-width:none; }
 


### PR DESCRIPTION
## Summary
- cap order history grid at three columns for desktop view and center the layout
- document three-column limit in AGENTS notes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c124f556f48320b8aae43d5dbd7c1d