### PR TITLE
style: widen order history columns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,7 +164,7 @@
 - Orders:
   - `/orders` page renders `templates/order_history.html` with past `Order` entries for the current user.
   - The page wraps content in `.orders-page`; pending and completed sections show counts and empty states, and order cards sit in a responsive `.orders-grid` without altering card markup. The previous status/date/search/sort/export toolbar has been removed.
-  - Desktop order grids center and show at most three columns via `max-width: calc(260px * 3 + 24px)`.
+  - Desktop order grids expand to full width with wider cards (minimum 320px) while still capping at three columns.
   - Order history lists all orders with no "Load more" button or "Back to top" link; the `.orders-actions` block was removed.
   - Checkout persists orders to the database and redirects to `/orders`.
   - Mobile hamburger menu links to order history via `bi bi-clock-history` icon.

--- a/templates/order_history.html
+++ b/templates/order_history.html
@@ -146,11 +146,14 @@
 /* Grid that hosts the EXISTING order cards */
 .orders-page .orders-grid{
   display:grid; gap:12px;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  max-width: calc(260px * 3 + 24px);
-  margin:0 auto;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  margin:0;
 }
 .orders-page .orders-grid .card{ width:100%; max-width:none; }
+
+@media (min-width: 960px){
+  .orders-page .orders-grid{ grid-template-columns: repeat(3, 1fr); }
+}
 
 /* Empty */
 .orders-page .empty{ display:none; text-align:center; border:1px dashed var(--border); border-radius:12px; padding:22px; color:var(--muted); background:#fff; }


### PR DESCRIPTION
## Summary
- widen order history columns and remove width cap
- document new order grid behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c12e9106ac8320a17b4d22b5ce1fe7