### PR TITLE
style: shrink order card min width to 100px

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,7 +165,7 @@
   - `/orders` page renders `templates/order_history.html` with past `Order` entries for the current user.
   - The page wraps content in `.orders-page`; pending and completed sections show counts and empty states, and order cards sit in a responsive `.orders-grid` without altering card markup. The previous status/date/search/sort/export toolbar has been removed.
   - Desktop order grids expand to full width with wider cards (minimum 100px) while still capping at three columns.
-  - Mobile order grids show a single full-width column.
+  - Mobile order grids show a single column with a 100px minimum card width.
   - Order history lists all orders with no "Load more" button or "Back to top" link; the `.orders-actions` block was removed.
   - Checkout persists orders to the database and redirects to `/orders`.
   - Mobile hamburger menu links to order history via `bi bi-clock-history` icon.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,7 +164,7 @@
 - Orders:
   - `/orders` page renders `templates/order_history.html` with past `Order` entries for the current user.
   - The page wraps content in `.orders-page`; pending and completed sections show counts and empty states, and order cards sit in a responsive `.orders-grid` without altering card markup. The previous status/date/search/sort/export toolbar has been removed.
-  - Desktop order grids expand to full width with wider cards (minimum 320px) while still capping at three columns.
+  - Desktop order grids expand to full width with wider cards (minimum 100px) while still capping at three columns.
   - Mobile order grids show a single full-width column.
   - Order history lists all orders with no "Load more" button or "Back to top" link; the `.orders-actions` block was removed.
   - Checkout persists orders to the database and redirects to `/orders`.

--- a/templates/order_history.html
+++ b/templates/order_history.html
@@ -151,8 +151,9 @@
 }
 .orders-page .orders-grid .card{ width:100%; max-width:none; }
 
+/* Desktop: keep three columns with 100px minimum card width */
 @media (min-width: 960px){
-  .orders-page .orders-grid{ grid-template-columns: repeat(3, minmax(320px, 1fr)); }
+  .orders-page .orders-grid{ grid-template-columns: repeat(3, minmax(100px, 1fr)); }
 }
 
 /* Empty */

--- a/templates/order_history.html
+++ b/templates/order_history.html
@@ -146,10 +146,10 @@
 /* Grid that hosts the EXISTING order cards */
 .orders-page .orders-grid{
   display:grid; gap:12px;
-  grid-template-columns: 1fr;
+  grid-template-columns: minmax(100px, 1fr);
   margin:0;
 }
-.orders-page .orders-grid .card{ width:100%; max-width:none; }
+.orders-page .orders-grid .card{ width:100%; max-width:none; min-width:100px; }
 
 /* Desktop: keep three columns with 100px minimum card width */
 @media (min-width: 960px){


### PR DESCRIPTION
## Summary
- reduce desktop order-card min width to 100px while keeping three-column layout
- document updated width in AGENTS notes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c13413255c83208f69d34c61fa4b20