### PR TITLE
style: align dashboard live order grids with history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,8 +172,9 @@
   - Mobile menu drops the "How it works" entry and adds a `bi bi-person` Profile link for logged-in users.
   - Bartenders manage live orders in `bartender_orders.html` using `static/js/orders.js`,
     which loads with `defer` and initializes `initBartender(bar.id)` on `DOMContentLoaded`.
-  - `templates/bartender_orders.html` groups orders into `<ul>` lists with IDs
-    `incoming-orders`, `preparing-orders`, `ready-orders`, and `completed-orders`.
+  - `templates/bartender_orders.html` wraps content in `.orders-page` and groups
+    orders into `.orders-grid` containers with IDs `incoming-orders`,
+    `preparing-orders`, `ready-orders`, and `completed-orders` for real-time lists.
   - The bartender dashboard lists assigned bars as `.bar-card` links to `/dashboard/bar/{id}/orders`.
   - The bartender dashboard uses `admin-dashboard` `editbar` styling with an `admin-header`, `admin-identity` card, and `admin-section` to match other dashboards.
   - The bar admin dashboard lists assigned bars as `.bar-card` items with edit and management links.
@@ -181,6 +182,9 @@
   - Each bar card includes buttons for editing the bar and managing orders via `/dashboard/bar/{id}/orders`.
   - Bar admins view live orders in `bar_admin_orders.html`, which mirrors the bartender view and adds an
     "Order History & Revenue" button linking to `/dashboard/bar/{id}/orders/history`.
+  - Bartender and bar admin live order pages reuse the order history grid styles
+    (`orders-page` wrapper with `orders-grid` for a single-column mobile layout and
+    100px minimum card width).
   - Bars close automatically at their scheduled closing time based on `opening_hours`, moving completed
     orders into a `bar_closings` record (see `BarClosing` model). Canceled or rejected orders are also
     attached to the closing but do not count toward `total_revenue`. Editing a bar's hours immediately

--- a/templates/bar_admin_orders.html
+++ b/templates/bar_admin_orders.html
@@ -1,19 +1,62 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1>{{ bar.name }} Orders</h1>
-<div class="orders-controls">
-  <a class="btn" href="/dashboard/bar/{{ bar.id }}/orders/history">Order History &amp; Revenue</a>
-</div>
-<div id="orders-section">
-  <h2>Incoming Orders</h2>
-  <div id="incoming-orders" class="order-list"></div>
-  <h2>Preparing</h2>
-  <div id="preparing-orders" class="order-list"></div>
-  <h2>Ready</h2>
-  <div id="ready-orders" class="order-list"></div>
-  <h2>Completed</h2>
-  <div id="completed-orders" class="order-list"></div>
-</div>
+<section class="orders-page">
+  <header class="orders-head">
+    <h1 class="orders-title">{{ bar.name }} Orders</h1>
+    <div class="orders-controls">
+      <a class="btn" href="/dashboard/bar/{{ bar.id }}/orders/history">Order History &amp; Revenue</a>
+    </div>
+  </header>
+
+  <section class="orders-section">
+    <div class="section-head"><h2>Incoming Orders</h2></div>
+    <div id="incoming-orders" class="orders-grid order-list"></div>
+  </section>
+
+  <section class="orders-section">
+    <div class="section-head"><h2>Preparing</h2></div>
+    <div id="preparing-orders" class="orders-grid order-list"></div>
+  </section>
+
+  <section class="orders-section">
+    <div class="section-head"><h2>Ready</h2></div>
+    <div id="ready-orders" class="orders-grid order-list"></div>
+  </section>
+
+  <section class="orders-section">
+    <div class="section-head"><h2>Completed</h2></div>
+    <div id="completed-orders" class="orders-grid order-list"></div>
+  </section>
+</section>
+
+<style>
+.orders-page{
+  --surface:#fff; --bg-subtle:#f6f8fb; --border:#e5e7eb;
+  --text:#0f172a; --muted:#475569; --accent:var(--brand,#7c3aed);
+  --radius:16px; --shadow:0 6px 16px rgba(0,0,0,.06);
+}
+.orders-page .orders-head{
+  display:flex; align-items:center; justify-content:space-between;
+  gap:10px; margin:8px 0 14px;
+}
+.orders-page .orders-title{ margin:0; font-size:1.6rem; font-weight:800; color:var(--text); }
+.orders-page .orders-section{ margin-top:18px; }
+.orders-page .section-head{ display:flex; align-items:center; gap:10px; margin-bottom:10px; }
+.orders-page .section-head h2{ margin:0; font-size:1.125rem; font-weight:800; color:var(--text); }
+.orders-page .orders-grid{
+  display:grid; gap:12px;
+  grid-template-columns:minmax(100px,1fr);
+  margin:0;
+}
+.orders-page .orders-grid .card{ width:100%; max-width:none; min-width:100px; }
+@media (min-width:960px){
+  .orders-page .orders-grid{ grid-template-columns:repeat(3,minmax(100px,1fr)); }
+}
+@media (max-width:768px){
+  .orders-page .orders-title{ font-size:1.4rem; }
+}
+</style>
+
 <script src="/static/js/orders.js" defer></script>
 <script>
   document.addEventListener('DOMContentLoaded', () => {

--- a/templates/bartender_orders.html
+++ b/templates/bartender_orders.html
@@ -1,17 +1,60 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1>{{ bar.name }} Orders</h1>
-<label><input type="checkbox" id="pause-ordering" {% if bar.ordering_paused %}checked{% endif %}> Pause ordering</label>
-<div id="orders-section">
-  <h2>Incoming Orders</h2>
-  <div id="incoming-orders" class="order-list"></div>
-  <h2>Preparing</h2>
-  <div id="preparing-orders" class="order-list"></div>
-  <h2>Ready</h2>
-  <div id="ready-orders" class="order-list"></div>
-  <h2>Completed</h2>
-  <div id="completed-orders" class="order-list"></div>
-</div>
+<section class="orders-page">
+  <header class="orders-head">
+    <h1 class="orders-title">{{ bar.name }} Orders</h1>
+    <label><input type="checkbox" id="pause-ordering" {% if bar.ordering_paused %}checked{% endif %}> Pause ordering</label>
+  </header>
+
+  <section class="orders-section">
+    <div class="section-head"><h2>Incoming Orders</h2></div>
+    <div id="incoming-orders" class="orders-grid order-list"></div>
+  </section>
+
+  <section class="orders-section">
+    <div class="section-head"><h2>Preparing</h2></div>
+    <div id="preparing-orders" class="orders-grid order-list"></div>
+  </section>
+
+  <section class="orders-section">
+    <div class="section-head"><h2>Ready</h2></div>
+    <div id="ready-orders" class="orders-grid order-list"></div>
+  </section>
+
+  <section class="orders-section">
+    <div class="section-head"><h2>Completed</h2></div>
+    <div id="completed-orders" class="orders-grid order-list"></div>
+  </section>
+</section>
+
+<style>
+.orders-page{
+  --surface:#fff; --bg-subtle:#f6f8fb; --border:#e5e7eb;
+  --text:#0f172a; --muted:#475569; --accent:var(--brand,#7c3aed);
+  --radius:16px; --shadow:0 6px 16px rgba(0,0,0,.06);
+}
+.orders-page .orders-head{
+  display:flex; align-items:center; justify-content:space-between;
+  gap:10px; margin:8px 0 14px;
+}
+.orders-page .orders-title{ margin:0; font-size:1.6rem; font-weight:800; color:var(--text); }
+.orders-page .orders-section{ margin-top:18px; }
+.orders-page .section-head{ display:flex; align-items:center; gap:10px; margin-bottom:10px; }
+.orders-page .section-head h2{ margin:0; font-size:1.125rem; font-weight:800; color:var(--text); }
+.orders-page .orders-grid{
+  display:grid; gap:12px;
+  grid-template-columns:minmax(100px,1fr);
+  margin:0;
+}
+.orders-page .orders-grid .card{ width:100%; max-width:none; min-width:100px; }
+@media (min-width:960px){
+  .orders-page .orders-grid{ grid-template-columns:repeat(3,minmax(100px,1fr)); }
+}
+@media (max-width:768px){
+  .orders-page .orders-title{ font-size:1.4rem; }
+}
+</style>
+
 <script src="/static/js/orders.js" defer></script>
 <script>
   document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- mirror order history layout in bartender and bar admin dashboards
- document shared live order grid styling in AGENTS notes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c138e90dd883208297b153d1754a36