### PR TITLE
feat: add daily public order codes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,7 @@
     throughout to manage permissions and dashboard views.
 - Orders:
   - `/orders` page renders `templates/order_history.html` with past `Order` entries for the current user.
+  - Orders include a `public_order_code` formatted `BBB-DDMMAA-SEQ` using the bar's 3-digit ID, the Europe/Zurich order date, and a bar-local daily counter that resets at midnight.
   - The page wraps content in `.orders-page`; pending and completed sections show counts and empty states, and order cards sit in a responsive `.orders-grid` without altering card markup. The previous status/date/search/sort/export toolbar has been removed.
   - Desktop order grids expand to full width with wider cards (minimum 100px) while still capping at three columns.
   - Mobile order grids show a single column with a 100px minimum card width.

--- a/models.py
+++ b/models.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 from sqlalchemy import (
     Boolean,
     Column,
+    Date,
     DateTime,
     Enum,
     ForeignKey,
@@ -15,6 +16,7 @@ from sqlalchemy import (
     Float,
     LargeBinary,
     JSON,
+    UniqueConstraint,
 )
 from sqlalchemy.orm import relationship
 from sqlalchemy.dialects.postgresql import JSONB, BIGINT
@@ -183,8 +185,19 @@ class BarClosing(Base):
     orders = relationship("Order", back_populates="closing")
 
 
+class OrderCounter(Base):
+    __tablename__ = "order_counters"
+
+    bar_id = Column(Integer, primary_key=True)
+    order_local_date = Column(Date, primary_key=True)
+    counter = Column(Integer, default=0)
+
+
 class Order(Base):
     __tablename__ = "orders"
+    __table_args__ = (
+        UniqueConstraint("bar_id", "order_local_date", "daily_seq"),
+    )
 
     id = Column(Integer, primary_key=True)
     bar_id = Column(Integer, ForeignKey("bars.id"), nullable=False)
@@ -205,6 +218,9 @@ class Order(Base):
     notes = Column(Text)
     source_channel = Column(String(30))
     closing_id = Column(Integer, ForeignKey("bar_closings.id"))
+    order_local_date = Column(Date)
+    daily_seq = Column(Integer)
+    public_order_code = Column(String(20), index=True)
 
     items = relationship("OrderItem", back_populates="order")
     customer = relationship("User")

--- a/tests/test_order_code.py
+++ b/tests/test_order_code.py
@@ -1,0 +1,44 @@
+import os
+import sys
+import pathlib
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from database import Base, SessionLocal, engine  # noqa: E402
+from models import Bar  # noqa: E402
+from main import generate_public_order_code  # noqa: E402
+
+
+def setup_function(function):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def test_order_code_sequence_and_reset():
+    db = SessionLocal()
+    bar = Bar(name="Test Bar", slug="test-bar")
+    db.add(bar)
+    db.commit()
+    db.refresh(bar)
+
+    tz = ZoneInfo("Europe/Zurich")
+    now = datetime(2025, 1, 1, 10, 0, tzinfo=timezone.utc)
+    d1, seq1, code1 = generate_public_order_code(db, bar.id, now)
+    assert seq1 == 1
+    assert code1 == f"{bar.id:03d}-{now.astimezone(tz).strftime('%d%m%y')}-001"
+
+    now2 = now + timedelta(minutes=5)
+    d2, seq2, code2 = generate_public_order_code(db, bar.id, now2)
+    assert seq2 == 2
+    assert code2.endswith("-002")
+    assert d1 == d2
+
+    next_day = now + timedelta(days=1)
+    d3, seq3, code3 = generate_public_order_code(db, bar.id, next_day)
+    assert seq3 == 1
+    assert code3.endswith("-001")
+    assert d3 != d1
+    db.close()


### PR DESCRIPTION
## Summary
- add `OrderCounter` table and fields for order-local date, daily sequence, and public order code
- generate codes `BBB-DDMMAA-SEQ` with Europe/Zurich date and daily bar counter
- document order code format and cover with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c13cf9fec483208e7bdfbcdbb1d0b1