### PR TITLE
feat: show public order codes in order listings

### DIFF
--- a/static/js/orders.js
+++ b/static/js/orders.js
@@ -65,7 +65,7 @@ function initBartender(barId) {
     el.dataset.createdAt = order.created_at;
     el.innerHTML =
       `<header class="order-card__header">` +
-      `<h3 id="order-${order.id}-title">Order #${order.id}</h3>` +
+      `<h3 id="order-${order.id}-title">Order ${order.public_order_code || ('#' + order.id)}</h3>` +
       `<span class="order-status chip status status-${order.status.toLowerCase()}" aria-label="Order status: ${formatStatus(order.status)}">${formatStatus(order.status)}</span>` +
       `</header>` +
       `<div class="order-card__divider"></div>` +
@@ -159,7 +159,7 @@ function initUser(userId) {
       : '';
     el.innerHTML =
       `<header class="order-card__header">` +
-      `<h3 id="order-${order.id}-title">Order #${order.id}</h3>` +
+      `<h3 id="order-${order.id}-title">Order ${order.public_order_code || ('#' + order.id)}</h3>` +
       `<span class="order-status chip status status-${order.status.toLowerCase()}" aria-label="Order status: ${formatStatus(order.status)}">${formatStatus(order.status)}</span>` +
       `</header>` +
       `<div class="order-card__divider"></div>` +

--- a/templates/admin_order_detail.html
+++ b/templates/admin_order_detail.html
@@ -1,10 +1,10 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1>Order #{{ order.id }}</h1>
+<h1>Order {{ order.public_order_code or ('#' ~ order.id) }}</h1>
 <div class="order-list">
   <article class="order-card card card--{{ order.status|lower }}" role="article" aria-labelledby="order-{{ order.id }}-title" data-status="{{ order.status }}">
     <header class="order-card__header">
-      <h3 id="order-{{ order.id }}-title">Order #{{ order.id }}</h3>
+      <h3 id="order-{{ order.id }}-title">Order {{ order.public_order_code or ('#' ~ order.id) }}</h3>
       <span class="order-status chip status status-{{ order.status|lower }}" aria-label="Order status: {{ order.status|replace('_', ' ')|title }}">{{ order.status|replace('_', ' ')|title }}</span>
     </header>
     <div class="order-card__divider"></div>

--- a/templates/bar_admin_order_history_view.html
+++ b/templates/bar_admin_order_history_view.html
@@ -40,7 +40,7 @@
   {% for order in orders %}
   <article class="order-card card card--{{ order.status|lower }}" role="article" aria-labelledby="order-{{ order.id }}-title" data-status="{{ order.status }}">
     <header class="order-card__header">
-      <h3 id="order-{{ order.id }}-title">Order #{{ order.id }}</h3>
+      <h3 id="order-{{ order.id }}-title">Order {{ order.public_order_code or ('#' ~ order.id) }}</h3>
       <span class="order-status chip status status-{{ order.status|lower }}" aria-label="Order status: {{ order.status|replace('_', ' ')|title }}">{{ order.status|replace('_', ' ')|title }}</span>
     </header>
     <div class="order-card__divider"></div>

--- a/templates/order_history.html
+++ b/templates/order_history.html
@@ -17,7 +17,7 @@
       {% for order in pending_orders %}
       <article id="user-order-{{ order.id }}" class="order-card card card--{{ order.status|lower }}" role="article" aria-labelledby="order-{{ order.id }}-title" data-status="{{ order.status }}">
         <header class="order-card__header">
-          <h3 id="order-{{ order.id }}-title">Order #{{ order.id }}</h3>
+          <h3 id="order-{{ order.id }}-title">Order {{ order.public_order_code or ('#' ~ order.id) }}</h3>
           <span class="order-status chip status status-{{ order.status|lower }}" aria-label="Order status: {{ order.status|replace('_', ' ')|title }}">{{ order.status|replace('_', ' ')|title }}</span>
         </header>
         <div class="order-card__divider"></div>
@@ -78,7 +78,7 @@
       {% for order in completed_orders %}
       <article id="user-order-{{ order.id }}" class="order-card card card--{{ order.status|lower }}" role="article" aria-labelledby="order-{{ order.id }}-title" data-status="{{ order.status }}">
         <header class="order-card__header">
-          <h3 id="order-{{ order.id }}-title">Order #{{ order.id }}</h3>
+          <h3 id="order-{{ order.id }}-title">Order {{ order.public_order_code or ('#' ~ order.id) }}</h3>
           <span class="order-status chip status status-{{ order.status|lower }}" aria-label="Order status: {{ order.status|replace('_', ' ')|title }}">{{ order.status|replace('_', ' ')|title }}</span>
         </header>
         <div class="order-card__divider"></div>

--- a/tests/test_admin_view_user.py
+++ b/tests/test_admin_view_user.py
@@ -77,6 +77,7 @@ def test_order_detail_view():
     order = Order(bar_id=bar.id, customer_id=user.id, subtotal=5, vat_total=0)
     db.add(order)
     db.commit()
+    code = order.public_order_code
     order_item = OrderItem(
         order_id=order.id,
         menu_item_id=item.id,
@@ -93,6 +94,7 @@ def test_order_detail_view():
         _login_super_admin(client)
         resp = client.get(f"/admin/orders/{order_id}")
         assert resp.status_code == 200
-        assert f"Order #{order_id}" in resp.text
+        expected = f"Order {code}" if code else f"Order #{order_id}"
+        assert expected in resp.text
         assert "Water" in resp.text
 

--- a/tests/test_bar_admin_orders_html.py
+++ b/tests/test_bar_admin_orders_html.py
@@ -134,6 +134,11 @@ def test_auto_close_moves_orders_to_history():
         assert 'Credit Card</span><span class="amount">CHF 6.00' in resp.text
         assert 'Wallet</span><span class="amount">CHF 6.00' in resp.text
         assert 'Bar</span><span class="amount">CHF 6.00' in resp.text
-        assert 'Order #1' in resp.text
-        assert 'Order #2' in resp.text
-        assert 'Order #3' in resp.text
+        with SessionLocal() as db_codes:
+            codes = [
+                (o.public_order_code or f"#{o.id}")
+                for o in db_codes.query(Order).order_by(Order.id).limit(3)
+            ]
+        assert f'Order {codes[0]}' in resp.text
+        assert f'Order {codes[1]}' in resp.text
+        assert f'Order {codes[2]}' in resp.text

--- a/tests/test_rejected_order_history.py
+++ b/tests/test_rejected_order_history.py
@@ -8,7 +8,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 from fastapi.testclient import TestClient  # noqa: E402
 from database import Base, engine, SessionLocal  # noqa: E402
-from models import Bar, Category, MenuItem, Table, User, RoleEnum, UserBarRole  # noqa: E402
+from models import Bar, Category, MenuItem, Table, User, RoleEnum, UserBarRole, Order  # noqa: E402
 from main import (
     app,
     load_bars_from_db,
@@ -60,12 +60,15 @@ def test_rejected_order_moves_to_completed_history():
         client.post('/cart/checkout', data={'table_id': table_id, 'payment_method': 'bar'})
         client.post('/login', data={'email': bartender_email, 'password': 'pass'})
         client.post('/api/orders/1/status', json={'status': 'REJECTED'})
+        with SessionLocal() as db2:
+            order_code = db2.get(Order, 1)
+            code = order_code.public_order_code or f"#{order_code.id}"
         client.post('/login', data={'email': user_email, 'password': 'pass'})
         resp = client.get('/orders')
         pending = resp.text.split('<h2>Pending Orders</h2>')[1].split('<h2>Completed Orders</h2>')[0]
         completed = resp.text.split('<h2>Completed Orders</h2>')[1]
-        assert 'Order #1' not in pending
-        assert 'Order #1' in completed
+        assert f'Order {code}' not in pending
+        assert f'Order {code}' in completed
         assert 'Rejected' in completed
     user_carts.clear()
     users.clear()


### PR DESCRIPTION
## Summary
- display public order codes on user and admin order listings
- render public codes in live order updates
- generate public order codes for card orders via Wallee webhook

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c13fa872808320a17b5a9ab76503bc