### PR TITLE
Preserve registration form values after validation errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,7 @@
 - Super admins can open `/admin/users/view/{id}` rendered by `templates/admin_view_user.html` to review a user's profile, orders, and audit logs
 - Login fetches the user's bar assignment from the database so the bar is available immediately after authentication
 - Login and Register pages show text prompts linking to each other: "Already registered? Log in" and "Not registered yet? Register"
+- Register form preserves entered username, email, phone number, and prefix when validation fails so users can correct errors without retyping.
 - Register form requires a phone number with 9–10 digits; invalid entries show an error
 - Register form rejects duplicate phone numbers; the combination of prefix and phone must be unique
 - Register form requires an email in the format text@text.text; invalid entries show an error

--- a/templates/register.html
+++ b/templates/register.html
@@ -5,10 +5,10 @@
   {% if error %}<p class="alert">{{ error }}</p>{% endif %}
   <form method="post" action="/register">
     <label for="username">Username
-      <input id="username" type="text" name="username" required autocomplete="username" inputmode="text" enterkeyhint="next" minlength="3" maxlength="24" pattern="(?![._-])(?!.*[._-]{2})(?!.*[._-]$)[a-z0-9._-]{3,24}" title="3–24 characters, lowercase letters, numbers, dot, hyphen or underscore. No spaces.">
+      <input id="username" type="text" name="username" required autocomplete="username" inputmode="text" enterkeyhint="next" minlength="3" maxlength="24" pattern="(?![._-])(?!.*[._-]{2})(?!.*[._-]$)[a-z0-9._-]{3,24}" title="3–24 characters, lowercase letters, numbers, dot, hyphen or underscore. No spaces." value="{{ username|default('') }}">
     </label>
     <label for="email">Email
-      <input id="email" type="email" name="email" required autocomplete="email" inputmode="email" enterkeyhint="next" pattern="[^@]+@[^@]+\.[^@]+" title="Email must be in the format text@text.text">
+      <input id="email" type="email" name="email" required autocomplete="email" inputmode="email" enterkeyhint="next" pattern="[^@]+@[^@]+\.[^@]+" title="Email must be in the format text@text.text" value="{{ email|default('') }}">
     </label>
     <label for="password">Password
       <div class="password-wrapper">
@@ -26,13 +26,13 @@
     </label>
     <label for="prefix">Phone Prefix
       <select id="prefix" name="prefix" required autocomplete="tel-country-code">
-        <option value="+41">+41 (Switzerland)</option>
-        <option value="+1">+1 (USA)</option>
-        <option value="+44">+44 (UK)</option>
+        <option value="+41" {% if prefix == "+41" %}selected{% endif %}>+41 (Switzerland)</option>
+        <option value="+1" {% if prefix == "+1" %}selected{% endif %}>+1 (USA)</option>
+        <option value="+44" {% if prefix == "+44" %}selected{% endif %}>+44 (UK)</option>
       </select>
     </label>
     <label for="phone">Phone Number
-      <input id="phone" type="tel" name="phone" required autocomplete="tel-national" inputmode="tel" enterkeyhint="done" pattern="[0-9]{9,10}" minlength="9" maxlength="10" title="Phone number must be 9 to 10 digits">
+      <input id="phone" type="tel" name="phone" required autocomplete="tel-national" inputmode="tel" enterkeyhint="done" pattern="[0-9]{9,10}" minlength="9" maxlength="10" title="Phone number must be 9 to 10 digits" value="{{ phone|default('') }}">
     </label>
     <button class="btn btn--primary" type="submit">Register</button>
   </form>

--- a/tests/test_register_field_persistence.py
+++ b/tests/test_register_field_persistence.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import pathlib
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, engine  # noqa: E402
+from main import app, users, users_by_email, users_by_username  # noqa: E402
+
+
+def setup_module(module):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()
+
+
+def test_register_preserves_fields_on_error():
+    with TestClient(app) as client:
+        resp = client.post(
+            "/register",
+            data={
+                "username": "myuser",
+                "password": "pass1234",
+                "confirm_password": "pass1234",
+                "email": "invalid",
+                "prefix": "+44",
+                "phone": "123456789",
+            },
+        )
+        assert resp.status_code == 200
+        assert 'value="myuser"' in resp.text
+        assert 'value="invalid"' in resp.text
+        assert 'value="123456789"' in resp.text
+        assert '<option value="+44" selected>' in resp.text
+


### PR DESCRIPTION
## Summary
- Keep submitted username, email, phone and prefix when registration validation fails
- Pre-populate form fields and prefix selection in the register template
- Document and test registration field persistence

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c18481d7048320b90e194bc1e5db40