### PR TITLE
feat: add user profile editing page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,7 @@
 - Register form requires passwords 8–128 characters long; common passwords like `12345678` are rejected. Passwords are hashed with Argon2id. Forms include show/hide toggles and a Caps Lock indicator.
 - Register form includes a required `confirm_password` field that must match the password.
 - Register and login forms use a flex `.password-wrapper` so the show/hide password toggle sits on the right side of the card.
+- Profile page (`templates/profile.html`) lets logged-in users update username, email, password, prefix, and phone using the same validation rules as registration. `/profile` GET renders the form and `/profile` POST saves changes to the database and in-memory cache, logging the user out after password changes.
 - Admin user edit form: `templates/admin_edit_user.html` posts fields
     (`username`, `password`, `email`, `prefix`, `phone`, `role`, `bar_ids`, `credit`)
     to `/admin/users/edit/{id}`. Bar selection uses checkboxes for easier multi-bar assignment.

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,0 +1,45 @@
+{% extends "layout.html" %}
+{% block content %}
+<div class="auth-card">
+  <h1>Profile</h1>
+  {% if error %}<p class="alert">{{ error }}</p>{% endif %}
+  <form method="post" action="/profile">
+    <label for="username">Username
+      <input id="username" type="text" name="username" required autocomplete="username" inputmode="text" enterkeyhint="next" minlength="3" maxlength="24" pattern="(?![._-])(?!.*[._-]{2})(?!.*[._-]$)[a-z0-9._-]{3,24}" title="3–24 characters, lowercase letters, numbers, dot, hyphen or underscore. No spaces." value="{{ username|default(user.username) }}">
+    </label>
+    <label for="email">Email
+      <input id="email" type="email" name="email" required autocomplete="email" inputmode="email" enterkeyhint="next" pattern="[^@]+@[^@]+\.[^@]+" title="Email must be in the format text@text.text" value="{{ email|default(user.email) }}">
+    </label>
+    <label for="password">New Password
+      <div class="password-wrapper">
+        <input id="password" type="password" name="password" autocomplete="new-password" enterkeyhint="next" minlength="8" maxlength="128" title="Password must be between 8 and 128 characters">
+        <button type="button" class="toggle-password" aria-label="Show password"><i class="bi bi-eye"></i></button>
+      </div>
+      <span id="capsWarning" class="caps-warning" hidden>Caps Lock is on</span>
+    </label>
+    <label for="confirm_password">Confirm Password
+      <div class="password-wrapper">
+        <input id="confirm_password" type="password" name="confirm_password" autocomplete="new-password" enterkeyhint="next" minlength="8" maxlength="128" title="Passwords must match">
+        <button type="button" class="toggle-password" aria-label="Show password"><i class="bi bi-eye"></i></button>
+      </div>
+      <span id="capsWarningConfirm" class="caps-warning" hidden>Caps Lock is on</span>
+    </label>
+    <label for="prefix">Phone Prefix
+      <select id="prefix" name="prefix" required autocomplete="tel-country-code">
+        <option value="+41" {% if (prefix|default(user.prefix)) == "+41" %}selected{% endif %}>+41 (Switzerland)</option>
+        <option value="+1" {% if (prefix|default(user.prefix)) == "+1" %}selected{% endif %}>+1 (USA)</option>
+        <option value="+44" {% if (prefix|default(user.prefix)) == "+44" %}selected{% endif %}>+44 (UK)</option>
+      </select>
+    </label>
+    <label for="phone">Phone Number
+      <input id="phone" type="tel" name="phone" required autocomplete="tel-national" inputmode="tel" enterkeyhint="done" pattern="[0-9]{9,10}" minlength="9" maxlength="10" title="Phone number must be 9 to 10 digits" value="{{ phone|default(user.phone) }}">
+    </label>
+    <button class="btn btn--primary" type="submit">Save</button>
+  </form>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="/static/js/password.js" defer></script>
+{% endblock %}
+

--- a/tests/test_profile_update.py
+++ b/tests/test_profile_update.py
@@ -1,0 +1,95 @@
+import os
+import sys
+import pathlib
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, SessionLocal, engine  # noqa: E402
+from models import User, RoleEnum  # noqa: E402
+from main import app, hash_password, verify_password  # noqa: E402
+
+
+def setup_module(module):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def _create_user(username: str, email: str, phone: str, phone_e164: str) -> int:
+    db = SessionLocal()
+    user = User(
+        username=username,
+        email=email,
+        password_hash=hash_password("Oldpass123"),
+        role=RoleEnum.CUSTOMER,
+        phone=phone,
+        prefix="+41",
+        phone_e164=phone_e164,
+        phone_region="CH",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    db.close()
+    return user.id
+
+
+def _login(client: TestClient, email: str) -> None:
+    resp = client.post(
+        "/login",
+        data={"email": email, "password": "Oldpass123"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+def test_profile_update_details():
+    user_id = _create_user("olduser", "old@example.com", "0790000000", "+41790000000")
+    with TestClient(app) as client:
+        _login(client, "old@example.com")
+        resp = client.post(
+            "/profile",
+            data={
+                "username": "newuser",
+                "email": "new@example.com",
+                "password": "",
+                "confirm_password": "",
+                "prefix": "+41",
+                "phone": "0765551234",
+            },
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303
+        assert resp.headers["location"] == "/profile"
+    db = SessionLocal()
+    updated = db.query(User).filter(User.id == user_id).first()
+    assert updated.username == "newuser"
+    assert updated.email == "new@example.com"
+    assert updated.phone == "0765551234"
+    db.close()
+
+
+def test_profile_update_password_change():
+    user_id = _create_user("olduser2", "old2@example.com", "0790000001", "+41790000001")
+    with TestClient(app) as client:
+        _login(client, "old2@example.com")
+        resp = client.post(
+            "/profile",
+            data={
+                "username": "olduser2",
+                "email": "old2@example.com",
+                "password": "Newpass123",
+                "confirm_password": "Newpass123",
+                "prefix": "+41",
+                "phone": "0765551235",
+            },
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303
+        assert resp.headers["location"] == "/login"
+    db = SessionLocal()
+    updated = db.query(User).filter(User.id == user_id).first()
+    assert verify_password(updated.password_hash, "Newpass123")
+    db.close()
+


### PR DESCRIPTION
## Summary
- add profile page for updating username, email, password, and phone
- validate and persist profile changes to DB and in-memory cache
- cover profile edits with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c18f541eb08320af7aff6352b0cc0f