### PR TITLE
Enhance profile editing with verification icons and password check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,7 @@
 - Register form requires passwords 8–128 characters long; common passwords like `12345678` are rejected. Passwords are hashed with Argon2id. Forms include show/hide toggles and a Caps Lock indicator.
 - Register form includes a required `confirm_password` field that must match the password.
 - Register and login forms use a flex `.password-wrapper` so the show/hide password toggle sits on the right side of the card.
-- Profile page (`templates/profile.html`) lets logged-in users update username, email, password, prefix, and phone using the same validation rules as registration. `/profile` GET renders the form and `/profile` POST saves changes to the database and in-memory cache, logging the user out after password changes.
+- Profile page (`templates/profile.html`) lets logged-in users update username, email, password, prefix, and phone using the same validation rules as registration. `/profile` GET renders the form and `/profile` POST saves changes to the database and in-memory cache, logging the user out after password changes. Each field shows a Bootstrap pencil icon to indicate editability, and changing the password requires the current password for verification.
 - Admin user edit form: `templates/admin_edit_user.html` posts fields
     (`username`, `password`, `email`, `prefix`, `phone`, `role`, `bar_ids`, `credit`)
     to `/admin/users/edit/{id}`. Bar selection uses checkboxes for easier multi-bar assignment.

--- a/main.py
+++ b/main.py
@@ -2432,6 +2432,7 @@ async def register(request: Request, db: Session = Depends(get_db)):
     """Handle user registration submissions."""
     form = await request.form()
     username = form.get("username") or ""
+    current_password = form.get("current_password") or ""
     password = form.get("password") or ""
     confirm_password = form.get("confirm_password") or ""
     email = form.get("email") or ""
@@ -2634,6 +2635,7 @@ async def profile_update(request: Request, db: Session = Depends(get_db)):
     form = await request.form()
     username = form.get("username") or ""
     email = form.get("email") or ""
+    current_password = form.get("current_password") or ""
     password = form.get("password") or ""
     confirm_password = form.get("confirm_password") or ""
     phone = form.get("phone") or ""
@@ -2669,6 +2671,8 @@ async def profile_update(request: Request, db: Session = Depends(get_db)):
     ):
         return render_form(USERNAME_MESSAGE)
     if password:
+        if not current_password or not verify_password(user.password_hash, current_password):
+            return render_form("Current password is incorrect")
         if len(password) < 8 or len(password) > 128:
             return render_form("Password must be between 8 and 128 characters")
         if password.lower() in WEAK_PASSWORDS:

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -4,38 +4,56 @@
   <h1>Profile</h1>
   {% if error %}<p class="alert">{{ error }}</p>{% endif %}
   <form method="post" action="/profile">
-    <label for="username">Username
+    <label for="username" class="edit-field">Username
       <input id="username" type="text" name="username" required autocomplete="username" inputmode="text" enterkeyhint="next" minlength="3" maxlength="24" pattern="(?![._-])(?!.*[._-]{2})(?!.*[._-]$)[a-z0-9._-]{3,24}" title="3–24 characters, lowercase letters, numbers, dot, hyphen or underscore. No spaces." value="{{ username|default(user.username) }}">
+      <button type="button" class="btn-icon edit-btn" aria-label="Edit username"><i class="bi bi-pencil-square"></i></button>
     </label>
-    <label for="email">Email
+    <label for="email" class="edit-field">Email
       <input id="email" type="email" name="email" required autocomplete="email" inputmode="email" enterkeyhint="next" pattern="[^@]+@[^@]+\.[^@]+" title="Email must be in the format text@text.text" value="{{ email|default(user.email) }}">
+      <button type="button" class="btn-icon edit-btn" aria-label="Edit email"><i class="bi bi-pencil-square"></i></button>
     </label>
-    <label for="password">New Password
+    <label for="current_password" class="edit-field">Current Password
+      <div class="password-wrapper">
+        <input id="current_password" type="password" name="current_password" autocomplete="current-password" enterkeyhint="next" minlength="8" maxlength="128" title="Password must be between 8 and 128 characters">
+        <button type="button" class="toggle-password" aria-label="Show password"><i class="bi bi-eye"></i></button>
+      </div>
+      <span id="capsWarningCurrent" class="caps-warning" hidden>Caps Lock is on</span>
+      <button type="button" class="btn-icon edit-btn" aria-label="Edit current password"><i class="bi bi-pencil-square"></i></button>
+    </label>
+    <label for="password" class="edit-field">New Password
       <div class="password-wrapper">
         <input id="password" type="password" name="password" autocomplete="new-password" enterkeyhint="next" minlength="8" maxlength="128" title="Password must be between 8 and 128 characters">
         <button type="button" class="toggle-password" aria-label="Show password"><i class="bi bi-eye"></i></button>
       </div>
       <span id="capsWarning" class="caps-warning" hidden>Caps Lock is on</span>
+      <button type="button" class="btn-icon edit-btn" aria-label="Edit new password"><i class="bi bi-pencil-square"></i></button>
     </label>
-    <label for="confirm_password">Confirm Password
+    <label for="confirm_password" class="edit-field">Confirm Password
       <div class="password-wrapper">
         <input id="confirm_password" type="password" name="confirm_password" autocomplete="new-password" enterkeyhint="next" minlength="8" maxlength="128" title="Passwords must match">
         <button type="button" class="toggle-password" aria-label="Show password"><i class="bi bi-eye"></i></button>
       </div>
       <span id="capsWarningConfirm" class="caps-warning" hidden>Caps Lock is on</span>
+      <button type="button" class="btn-icon edit-btn" aria-label="Edit confirm password"><i class="bi bi-pencil-square"></i></button>
     </label>
-    <label for="prefix">Phone Prefix
+    <label for="prefix" class="edit-field">Phone Prefix
       <select id="prefix" name="prefix" required autocomplete="tel-country-code">
         <option value="+41" {% if (prefix|default(user.prefix)) == "+41" %}selected{% endif %}>+41 (Switzerland)</option>
         <option value="+1" {% if (prefix|default(user.prefix)) == "+1" %}selected{% endif %}>+1 (USA)</option>
         <option value="+44" {% if (prefix|default(user.prefix)) == "+44" %}selected{% endif %}>+44 (UK)</option>
       </select>
+      <button type="button" class="btn-icon edit-btn" aria-label="Edit phone prefix"><i class="bi bi-pencil-square"></i></button>
     </label>
-    <label for="phone">Phone Number
+    <label for="phone" class="edit-field">Phone Number
       <input id="phone" type="tel" name="phone" required autocomplete="tel-national" inputmode="tel" enterkeyhint="done" pattern="[0-9]{9,10}" minlength="9" maxlength="10" title="Phone number must be 9 to 10 digits" value="{{ phone|default(user.phone) }}">
+      <button type="button" class="btn-icon edit-btn" aria-label="Edit phone number"><i class="bi bi-pencil-square"></i></button>
     </label>
     <button class="btn btn--primary" type="submit">Save</button>
   </form>
+  <style>
+    .auth-card label.edit-field{position:relative;padding-right:40px;}
+    .auth-card label.edit-field .edit-btn{position:absolute;top:0;right:0;border:0;background:transparent;cursor:pointer;}
+  </style>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Add edit icon buttons to each profile field
- Require current password when updating the account password
- Document profile page changes in AGENTS guidelines

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c192980e148320b589fc4344348dc8