### PR TITLE
Display audit logs in local time

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@
     - Login and cart checkout log `login` and `order_create` actions via `log_action`
     - `AuditLogMiddleware` logs authenticated requests excluding `.css`, `.js`, `.png`, and `.ico` files with IP, user agent, and phone
     - Startup ensures `audit_logs` has `ip`, `user_agent`, and `phone` via `ensure_audit_log_columns()`
+    - Admin audit logs display times with `format_time` to honor local time
   - `finance.py` – VAT and payout calculations
   - `payouts.py` – schedule periodic payouts for bars
   - `app/webhooks/wallee.py` – webhook endpoint for Wallee payments

--- a/templates/admin_audit_logs.html
+++ b/templates/admin_audit_logs.html
@@ -29,7 +29,7 @@
       <tbody>
       {% for entry in logs %}
         <tr>
-          <td>{{ entry.log.created_at }}</td>
+          <td>{{ entry.log.created_at|format_time }}</td>
           <td>{{ entry.user_name }}</td>
           <td>{{ entry.log.action }}</td>
           <td>{{ entry.log.entity_type }}</td>


### PR DESCRIPTION
## Summary
- show admin audit logs using local time
- document audit logs time formatting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7bac587408320b1dc715aba8a49a5