### PR TITLE
Cap user view list lengths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,7 @@
 - Admin Manage Users page uses `templates/admin_users.html` with `.users-page` styles, a client-side username/email search via `#userSearch`, and grouped action pills (`View`, `Edit`) in each row
 - Super admins can open `/admin/users/view/{id}` rendered by `templates/admin_view_user.html` to review a user's profile, orders, and audit logs
 - The Orders table on this view displays each order's `public_order_code` or `#id` in the ID column to match order card formatting
+- User view shows only the 20 most recent orders and audit logs to keep the page concise
 - Login fetches the user's bar assignment from the database so the bar is available immediately after authentication
 - Login and Register pages show text prompts linking to each other: "Already registered? Log in" and "Not registered yet? Register"
 - Register form preserves entered username, email, phone number, and prefix when validation fails so users can correct errors without retyping.

--- a/main.py
+++ b/main.py
@@ -4608,6 +4608,7 @@ async def view_user(request: Request, user_id: int, db: Session = Depends(get_db
         db.query(Order)
         .filter(Order.customer_id == user.id)
         .order_by(Order.created_at.desc())
+        .limit(20)
         .all()
     )
     logs = (
@@ -4619,6 +4620,7 @@ async def view_user(request: Request, user_id: int, db: Session = Depends(get_db
             )
         )
         .order_by(AuditLog.created_at.desc())
+        .limit(20)
         .all()
     )
     return render_template(

--- a/templates/admin_view_user.html
+++ b/templates/admin_view_user.html
@@ -20,6 +20,7 @@
   </div>
 
   <h2>Orders</h2>
+  <p class="subtitle">Showing up to 20 recent orders.</p>
   <div class="table-card">
     <table class="users-table">
       <thead>
@@ -55,6 +56,7 @@
   </div>
 
   <h2>Audit Logs</h2>
+  <p class="subtitle">Showing up to 20 recent logs.</p>
   <div class="table-card">
     <table class="users-table">
       <thead>


### PR DESCRIPTION
## Summary
- Limit orders and audit logs on admin user view to 20 entries
- Document limit in AGENTS notes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7cdaa82588320a3b44d64fab5fbe5