### PR TITLE
Remove credit column from login list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,7 +178,7 @@
 - Super admins can open `/admin/users/view/{id}` rendered by `templates/admin_view_user.html` to review a user's profile, orders, and audit logs
 - The Orders table on this view displays each order's `public_order_code` or `#id` in the ID column to match order card formatting
 - Admin user view lists orders and audit logs in fixed-height scrollable tables so longer histories don't stretch the page
-- Admin user view also shows login activity with IP, user agent, phone, credit, and date in a scrollable table
+- Admin user view also shows login activity with IP, user agent, phone, and date in a scrollable table
 - Login fetches the user's bar assignment from the database so the bar is available immediately after authentication
 - Login and Register pages show text prompts linking to each other: "Already registered? Log in" and "Not registered yet? Register"
 - Register form preserves entered username, email, phone number, and prefix when validation fails so users can correct errors without retyping.

--- a/templates/admin_view_user.html
+++ b/templates/admin_view_user.html
@@ -64,7 +64,6 @@
           <th>IP</th>
           <th>User Agent</th>
           <th>Phone</th>
-          <th>Credit</th>
           <th>Date</th>
         </tr>
       </thead>
@@ -74,12 +73,11 @@
           <td>{{ l.ip or '-' }}</td>
           <td>{{ l.user_agent or '-' }}</td>
           <td>{{ l.phone or '-' }}</td>
-          <td>{% if l.actor_credit is not none %}CHF {{ "%.2f"|format(l.actor_credit) }}{% else %}-{% endif %}</td>
           <td>{{ l.created_at|format_time }}</td>
         </tr>
         {% endfor %}
         {% if logins|length == 0 %}
-        <tr><td colspan="5">No logins found.</td></tr>
+        <tr><td colspan="4">No logins found.</td></tr>
         {% endif %}
       </tbody>
     </table>


### PR DESCRIPTION
## Summary
- drop credit column from admin user login activity table
- document login list without credit in AGENTS.md

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7d6d0c95c8320a6cc31454b4f5e41