### PR TITLE
Capture login location data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,7 +178,7 @@
 - Super admins can open `/admin/users/view/{id}` rendered by `templates/admin_view_user.html` to review a user's profile, orders, and audit logs
 - The Orders table on this view displays each order's `public_order_code` or `#id` in the ID column to match order card formatting
 - Admin user view lists orders and audit logs in fixed-height scrollable tables so longer histories don't stretch the page
-- Admin user view also shows login activity with IP, user agent, phone, and date in a scrollable table
+- Admin user view also shows login activity with IP, user agent, phone, location, and date in a scrollable table
 - Login fetches the user's bar assignment from the database so the bar is available immediately after authentication
 - Login and Register pages show text prompts linking to each other: "Already registered? Log in" and "Not registered yet? Register"
 - Register form preserves entered username, email, phone number, and prefix when validation fails so users can correct errors without retyping.

--- a/audit.py
+++ b/audit.py
@@ -20,6 +20,8 @@ def log_action(
     user_agent: Optional[str] = None,
     phone: Optional[str] = None,
     credit: Optional[float] = None,
+    latitude: Optional[float] = None,
+    longitude: Optional[float] = None,
 ) -> AuditLog:
     """Persist an audit log entry to the database."""
     log = AuditLog(
@@ -31,6 +33,8 @@ def log_action(
         ip=ip,
         user_agent=user_agent,
         phone=phone,
+        latitude=Decimal(str(latitude)) if latitude is not None else None,
+        longitude=Decimal(str(longitude)) if longitude is not None else None,
         actor_credit=Decimal(str(credit)) if credit is not None else None,
         created_at=datetime.utcnow(),
     )

--- a/main.py
+++ b/main.py
@@ -877,6 +877,8 @@ def ensure_audit_log_columns() -> None:
         "ip": "VARCHAR(50)",
         "user_agent": "VARCHAR(255)",
         "phone": "VARCHAR(30)",
+        "latitude": "NUMERIC(9, 6)",
+        "longitude": "NUMERIC(9, 6)",
         "actor_credit": "NUMERIC(10, 2)",
     }
     missing = {name: ddl for name, ddl in required.items() if name not in columns}
@@ -2861,6 +2863,10 @@ async def login(request: Request, db: Session = Depends(get_db)):
     form = await request.form()
     email = form.get("email")
     password = form.get("password")
+    latitude = form.get("latitude")
+    longitude = form.get("longitude")
+    lat = float(latitude) if latitude else None
+    lon = float(longitude) if longitude else None
     if email and password:
         record = login_attempts[email]
         if record["count"] >= 5:
@@ -2947,6 +2953,8 @@ async def login(request: Request, db: Session = Depends(get_db)):
             user_agent=request.headers.get("user-agent"),
             phone=user.phone_e164,
             credit=float(user.credit or 0),
+            latitude=lat,
+            longitude=lon,
         )
         return RedirectResponse(url="/dashboard", status_code=status.HTTP_303_SEE_OTHER)
     return render_template(

--- a/models.py
+++ b/models.py
@@ -384,6 +384,8 @@ class AuditLog(Base):
     ip = Column(String(50))
     user_agent = Column(String(255))
     phone = Column(String(30))
+    latitude = Column(Numeric(9, 6))
+    longitude = Column(Numeric(9, 6))
     actor_credit = Column(Numeric(10, 2))
     created_at = Column(DateTime, default=datetime.utcnow)
 

--- a/templates/admin_view_user.html
+++ b/templates/admin_view_user.html
@@ -64,6 +64,7 @@
           <th>IP</th>
           <th>User Agent</th>
           <th>Phone</th>
+          <th>Location</th>
           <th>Date</th>
         </tr>
       </thead>
@@ -73,11 +74,12 @@
           <td>{{ l.ip or '-' }}</td>
           <td>{{ l.user_agent or '-' }}</td>
           <td>{{ l.phone or '-' }}</td>
+          <td>{% if l.latitude is not none and l.longitude is not none %}{{ l.latitude }}, {{ l.longitude }}{% else %}-{% endif %}</td>
           <td>{{ l.created_at|format_time }}</td>
         </tr>
         {% endfor %}
         {% if logins|length == 0 %}
-        <tr><td colspan="4">No logins found.</td></tr>
+        <tr><td colspan="5">No logins found.</td></tr>
         {% endif %}
       </tbody>
     </table>

--- a/templates/login.html
+++ b/templates/login.html
@@ -14,6 +14,8 @@
       </div>
       <span id="capsWarning" class="caps-warning" hidden>Caps Lock is on</span>
     </label>
+    <input type="hidden" name="latitude" id="latitude">
+    <input type="hidden" name="longitude" id="longitude">
     <button class="btn btn--primary" type="submit">Login</button>
   </form>
   <p style="align-self:center">Not registered yet? <a href="/register">Register</a></p>
@@ -22,5 +24,13 @@
 
 {% block scripts %}
 <script src="/static/js/password.js" defer></script>
+<script>
+  if (navigator.geolocation) {
+    navigator.geolocation.getCurrentPosition(function(pos) {
+      document.getElementById('latitude').value = pos.coords.latitude;
+      document.getElementById('longitude').value = pos.coords.longitude;
+    });
+  }
+</script>
 {% endblock %}
 

--- a/tests/test_admin_view_user.py
+++ b/tests/test_admin_view_user.py
@@ -84,6 +84,8 @@ def test_view_user_lists_login_activity():
         entity_id=user.id,
         ip="1.2.3.4",
         user_agent="test-agent",
+        latitude=12.34,
+        longitude=56.78,
     )
     db.add(log)
     db.commit()
@@ -96,6 +98,8 @@ def test_view_user_lists_login_activity():
         assert resp.status_code == 200
         assert "1.2.3.4" in resp.text
         assert "test-agent" in resp.text
+        assert "12.34" in resp.text
+        assert "56.78" in resp.text
 
 
 def test_order_detail_view():

--- a/tests/test_login_and_checkout_audit.py
+++ b/tests/test_login_and_checkout_audit.py
@@ -18,7 +18,12 @@ def test_login_creates_audit_log():
     with TestClient(app) as client:
         resp = client.post(
             "/login",
-            data={"email": "admin@example.com", "password": "ChangeMe!123"},
+            data={
+                "email": "admin@example.com",
+                "password": "ChangeMe!123",
+                "latitude": "12.34",
+                "longitude": "56.78",
+            },
             follow_redirects=False,
             headers={"User-Agent": "test-agent"},
         )
@@ -32,6 +37,12 @@ def test_login_creates_audit_log():
         and log.phone == "+41000000000"
         and log.ip
         and log.actor_credit == Decimal("0")
+        for log in logs
+    )
+    assert any(
+        log.action == "login"
+        and log.latitude == Decimal("12.34")
+        and log.longitude == Decimal("56.78")
         for log in logs
     )
     db.close()


### PR DESCRIPTION
## Summary
- log user latitude/longitude when logging in
- show login location in admin user view
- document login location capture

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7dbaa52a483208197c87eb4fa5cef