### PR TITLE
Prevent hero image text shift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - Homepage image stored in photo/homepage.png.
 - `/photo` static path serves the homepage image.
 - Homepage hero displays this image behind text via an absolutely positioned `.hero__image` with pointer-events disabled.
+- Inline style on `.hero__image` keeps it from shifting text before CSS loads.
 - Homepage hero only shows a Browse Bars button linking to `/search`; Search and How it works buttons and promo chips were removed.
 - Browse Bars button is centered in the hero section.
 - Registration is a two-step flow. `/register` collects email and password and assigns a temporary `REGISTERING` role. Users are redirected to `/register/details` to supply username, phone prefix, and number, and cannot access other pages until this step completes.

--- a/templates/home.html
+++ b/templates/home.html
@@ -2,7 +2,7 @@
 {% block content %}
 {% set fallback_img = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCA0MDAgMjI1Jz48cmVjdCB3aWR0aD0nNDAwJyBoZWlnaHQ9JzIyNScgZmlsbD0nJTIzZjFmM2Y1Jy8+PC9zdmc+" %}
 <section class="hero">
-  <img src="/photo/homepage.png" alt="" class="hero__image" aria-hidden="true">
+  <img src="/photo/homepage.png" alt="" class="hero__image" aria-hidden="true" style="position:absolute;inset:0;width:100%;height:100%;object-fit:cover;z-index:0;pointer-events:none;">
   <div class="hero__content container">
     <h1>Order drinks instantly, right from your table.</h1>
     <p>Skip the wait. Discover nearby bars and order with one tap.</p>


### PR DESCRIPTION
## Summary
- keep homepage hero image from displacing text by applying inline absolute positioning
- note inline hero image style in AGENTS for future reference

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7f8fc20948320a10508bb25d12c1c