### PR TITLE
Create footer static pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 - Notification subject line must not exceed 30 characters.
 - Admin notifications form subject input enforces this with `maxlength=30`.
 - Review recent commit history before starting new tasks.
+- Footer marketing pages (About, Help Center, For Bars, Terms) live in `templates/about.html`, `templates/help_center.html`, `templates/for_bars.html`, and `templates/terms.html`; they share the `.static-page` styles defined in `static/css/components.css`.
 - Homepage image stored in photo/homepage.png.
 - `/photo` static path serves the homepage image.
 - Homepage hero displays the artwork as a single `<img class="hero-art">` absolutely positioned under the content with pointer-events disabled.

--- a/main.py
+++ b/main.py
@@ -1585,6 +1585,34 @@ async def home(request: Request, db: Session = Depends(get_db)):
     return render_template("home.html", request=request, bars=db_bars)
 
 
+@app.get("/about", response_class=HTMLResponse)
+async def about(request: Request):
+    """Public overview of the SiplyGo platform."""
+
+    return render_template("about.html", request=request)
+
+
+@app.get("/help-center", response_class=HTMLResponse)
+async def help_center(request: Request):
+    """Frequently asked questions and support resources."""
+
+    return render_template("help_center.html", request=request)
+
+
+@app.get("/for-bars", response_class=HTMLResponse)
+async def for_bars(request: Request):
+    """Information for bar owners evaluating SiplyGo."""
+
+    return render_template("for_bars.html", request=request)
+
+
+@app.get("/terms", response_class=HTMLResponse)
+async def terms(request: Request):
+    """Terms of service for using SiplyGo."""
+
+    return render_template("terms.html", request=request)
+
+
 def _haversine_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     """Calculate distance in kilometers between two lat/lon points."""
     from math import asin, cos, radians, sin, sqrt

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -184,6 +184,16 @@ body.dark-mode{
   .chip.active{background:var(--sg-purple-700);color:#fff;}
   .nav-right .chip{min-height:44px;display:inline-flex;align-items:center;padding:0 var(--space-2);}
 
+.static-page{display:grid;gap:var(--space-3);padding-block:clamp(var(--space-3),6vw,80px);max-width:760px;margin-inline:auto;line-height:1.6;}
+.static-page>p{margin:0;color:var(--color-muted);}
+.static-page section{display:grid;gap:var(--space-1);}
+.static-page h1{font-size:clamp(32px,5vw,40px);margin:0;color:var(--text);}
+.static-page h2{font-size:clamp(20px,3vw,28px);margin:var(--space-3) 0 var(--space-1);color:var(--text);}
+.static-page p{margin:0;color:var(--color-muted);}
+.static-page ul,.static-page ol{margin:0;padding-left:1.25rem;display:grid;gap:.5rem;color:var(--color-muted);}
+.static-page a{color:var(--sg-purple-700);text-decoration:underline;}
+.static-page strong{color:var(--text);}
+
  .filters-toolbar{position:sticky;top:0;z-index:10;background:var(--bg);margin-bottom:var(--space-2);border-radius:var(--sg-card-radius);}
 .btn-filter{background:var(--sg-glass) padding-box,var(--sg-gradient) border-box;border:1.5px solid transparent;border-radius:var(--sg-radius);padding:8px 14px;display:inline-flex;align-items:center;gap:8px;font-weight:600;font-size:.875rem;line-height:1;color:var(--text);min-width:44px;min-height:44px;box-shadow:var(--sg-shadow);backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);transition:background .2s var(--ease),box-shadow .2s var(--ease),transform .12s var(--ease);text-decoration:none;}
  .btn-filter i{color:var(--sg-primary);transition:color .2s var(--ease);}

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,0 +1,27 @@
+{% extends "layout.html" %}
+{% block content %}
+<article class="static-page">
+  <h1>About SiplyGo</h1>
+  <p>We are building a modern ordering experience that keeps the focus on great hospitality while giving guests and staff the tools they need to thrive.</p>
+  <section>
+    <h2>Our mission</h2>
+    <p>SiplyGo makes it effortless for people to discover bars, order from their table, and enjoy their time without waiting in line. We partner closely with local venues to streamline service, reduce friction, and keep every order moving.</p>
+  </section>
+  <section>
+    <h2>What we value</h2>
+    <ul>
+      <li><strong>Delightful guest journeys</strong> – intuitive menus, real-time order tracking, and secure payments from any device.</li>
+      <li><strong>Empowered teams</strong> – dashboards that help bartenders stay on top of tickets and respond to guests faster.</li>
+      <li><strong>Operational insight</strong> – revenue, payout, and menu analytics that turn nightly service into actionable data.</li>
+    </ul>
+  </section>
+  <section>
+    <h2>Where we are headed</h2>
+    <p>We continue to expand the platform with richer loyalty tools, flexible payouts, and integrations that help bars focus on hospitality, not hardware. New releases are rolled out frequently and shared in our Help Center so teams can adopt them with confidence.</p>
+  </section>
+  <section>
+    <h2>Stay in touch</h2>
+    <p>Questions about the roadmap or partnerships? Reach out at <a href="mailto:hello@siplygo.example.com">hello@siplygo.example.com</a> and we will be happy to connect.</p>
+  </section>
+</article>
+{% endblock %}

--- a/templates/for_bars.html
+++ b/templates/for_bars.html
@@ -1,0 +1,36 @@
+{% extends "layout.html" %}
+{% block content %}
+<article class="static-page">
+  <h1>For Bars</h1>
+  <p>SiplyGo helps venues deliver quicker service, increase order value, and give staff clearer visibility into what guests need next.</p>
+  <section>
+    <h2>Why venues choose SiplyGo</h2>
+    <ul>
+      <li><strong>Digital menus that stay fresh</strong> – highlight specials, mark items out of stock, and share allergen details instantly.</li>
+      <li><strong>Faster fulfilment</strong> – bar dashboards show incoming orders, prep status, and ready times in one place.</li>
+      <li><strong>Flexible payments</strong> – accept wallet credit, cards, or pay-at-bar while keeping transaction fees predictable.</li>
+      <li><strong>Insights that matter</strong> – track nightly revenue, payouts, and repeat guests without spreadsheets.</li>
+    </ul>
+  </section>
+  <section>
+    <h2>How onboarding works</h2>
+    <ol>
+      <li>We map your menu, categories, and pricing in a shared workspace.</li>
+      <li>Staff receive a walkthrough covering live orders, notifications, and service best practices.</li>
+      <li>Go live with marketing assets, QR codes, and support resources tailored to your bar.</li>
+    </ol>
+  </section>
+  <section>
+    <h2>What you need</h2>
+    <ul>
+      <li>A tablet or laptop behind the bar to monitor orders.</li>
+      <li>Reliable Wi-Fi for staff devices and optional guest QR scanning.</li>
+      <li>A point of contact to manage payouts and menu updates.</li>
+    </ul>
+  </section>
+  <section>
+    <h2>Schedule a demo</h2>
+    <p>Email <a href="mailto:partners@siplygo.example.com">partners@siplygo.example.com</a> or call +41 91 555 01 23 to learn how SiplyGo can support your service model.</p>
+  </section>
+</article>
+{% endblock %}

--- a/templates/help_center.html
+++ b/templates/help_center.html
@@ -1,0 +1,30 @@
+{% extends "layout.html" %}
+{% block content %}
+<article class="static-page">
+  <h1>Help Center</h1>
+  <p>Find answers to the most common questions about browsing bars, placing orders, and managing your account. These guides apply to both the web app and the mobile experience.</p>
+  <section>
+    <h2>Getting started</h2>
+    <ol>
+      <li>Create an account or log in with your existing credentials.</li>
+      <li>Share your location or search for a city to find nearby venues.</li>
+      <li>Select a bar, pick your table, and add items to the cart.</li>
+      <li>Review your order, choose a payment method, and submit.</li>
+    </ol>
+    <p>After placing an order you can track the live status from the Orders page or receive updates via notifications.</p>
+  </section>
+  <section>
+    <h2>Managing your account</h2>
+    <ul>
+      <li>Update profile details, phone number, and password from the <a href="/profile">Profile</a> page.</li>
+      <li>Top up credits, review transactions, and download receipts in the <a href="/wallet">Wallet</a>.</li>
+      <li>Check unread messages from bar staff or administrators in <a href="/notifications">Notifications</a>.</li>
+    </ul>
+  </section>
+  <section>
+    <h2>Need more help?</h2>
+    <p>Send us a note at <a href="mailto:support@siplygo.example.com">support@siplygo.example.com</a>. Include the bar name, order code, and a short description so we can assist quickly.</p>
+    <p>We respond Monday through Friday, 9:00-18:00 CET.</p>
+  </section>
+</article>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -122,7 +122,7 @@
     {% if not user or not user.is_display %}
     <footer class="site-footer" role="contentinfo">
       <div class="container">
-        <p>SiplyGo © 2025 · <a href="#">About</a> · <a href="#">Help Center</a> · <a href="#">For Bars</a> · <a href="#">Legal</a></p>
+        <p>SiplyGo © 2025 · <a href="/about">About</a> · <a href="/help-center">Help Center</a> · <a href="/for-bars">For Bars</a> · <a href="/terms">Terms</a></p>
       </div>
     </footer>
     <div id="cartBlocker" class="cart-blocker" {% if cart_bar_id and current_bar_id != cart_bar_id %}{% else %}hidden{% endif %}>

--- a/templates/terms.html
+++ b/templates/terms.html
@@ -1,0 +1,36 @@
+{% extends "layout.html" %}
+{% block content %}
+<article class="static-page">
+  <h1>Terms of Use</h1>
+  <p>These terms explain how SiplyGo provides services to guests and bar partners. By creating an account or placing an order you agree to the rules below.</p>
+  <section>
+    <h2>1. Eligibility and accounts</h2>
+    <ul>
+      <li>You must be at least 18 years old and able to form a binding agreement.</li>
+      <li>Keep your login credentials secure and notify us immediately if you suspect unauthorized access.</li>
+      <li>We may suspend or close accounts that violate these terms or local regulations.</li>
+    </ul>
+  </section>
+  <section>
+    <h2>2. Ordering and payments</h2>
+    <ul>
+      <li>Orders placed through SiplyGo are fulfilled directly by the bar you select.</li>
+      <li>Displayed prices include any applicable taxes or service fees. The final receipt will be available in your wallet history.</li>
+      <li>Refunds for cancellations or order issues are managed jointly by SiplyGo and the venue.</li>
+    </ul>
+  </section>
+  <section>
+    <h2>3. Acceptable use</h2>
+    <ul>
+      <li>Use the platform responsibly and avoid activities that disrupt service, attempt fraud, or harm other guests and staff.</li>
+      <li>Content you submit, such as order notes, must be respectful and accurate.</li>
+      <li>We monitor usage to keep the experience safe and may remove content or limit access when necessary.</li>
+    </ul>
+  </section>
+  <section>
+    <h2>4. Contact</h2>
+    <p>For questions about these terms or to report an issue, email <a href="mailto:legal@siplygo.example.com">legal@siplygo.example.com</a>.</p>
+    <p>We update this page whenever policies change. Continued use of SiplyGo after updates means you accept the revised terms.</p>
+  </section>
+</article>
+{% endblock %}

--- a/tests/test_static_pages.py
+++ b/tests/test_static_pages.py
@@ -1,0 +1,19 @@
+from fastapi.testclient import TestClient  # noqa: E402
+
+from main import app  # noqa: E402
+
+
+PAGES = [
+    ("/about", "About SiplyGo"),
+    ("/help-center", "Help Center"),
+    ("/for-bars", "For Bars"),
+    ("/terms", "Terms of Use"),
+]
+
+
+def test_footer_pages_render():
+    with TestClient(app) as client:
+        for path, heading in PAGES:
+            response = client.get(path)
+            assert response.status_code == 200
+            assert heading in response.text


### PR DESCRIPTION
## Summary
- replace the Legal footer link with Terms and wire footer navigation to real marketing routes
- add static page templates for About, Help Center, For Bars, and Terms with shared `.static-page` styling
- document the new pages in AGENTS.md and cover them with a pytest smoke test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c920e5e8e88320b54b9571374a7da5