### PR TITLE
Add terms acceptance notice to registration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@
 - Browse Bars button is centered in the hero section.
 - Horizontal scrolling is locked with `overflow-x: clip` on `html, body`, and header width uses `100%` to avoid viewport overflow.
 - Registration is a two-step flow. `/register` collects email and password and assigns a temporary `REGISTERING` role. Users are redirected to `/register/details` to supply username, phone prefix, and number, and cannot access other pages until this step completes.
+  - Each registration step displays a disclaimer stating that creating an account accepts the Terms of Service, with the link pointing to `/terms`.
 - Registering users hitting any other route are redirected back to `/register/details` by middleware until step two finishes.
 - Super admins can create users directly from the Admin Users page by entering only an email and password; this bypasses the normal registration flow and checks.
 - Startup ensures the `roleenum` type contains `REGISTERING` via `ensure_role_enum()`.

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -312,6 +312,8 @@ body.dark-mode{
 .auth-card label{display:flex;flex-direction:column;font-weight:600;gap:var(--space-1);}
 .auth-card input,.auth-card select{padding:var(--space-2);border:1px solid #d1d5db;border-radius:var(--radius);min-height:44px;}
 .auth-card button{align-self:center;margin-top:var(--space-1);}
+.auth-card__disclaimer{font-size:.875rem;color:var(--muted);text-align:center;margin:0;}
+.auth-card__disclaimer a{color:var(--brand);text-decoration:underline;font-weight:600;}
 .auth-card .password-wrapper{display:flex;align-items:center;gap:var(--space-1);}
 .auth-card .password-wrapper input{flex:1;}
 .auth-card .password-wrapper .toggle-password{align-self:stretch;margin-top:0;padding:0 var(--space-2);border:1px solid #d1d5db;border-radius:var(--radius);background:transparent;}

--- a/templates/register.html
+++ b/templates/register.html
@@ -18,6 +18,7 @@
     <label for="phone">Phone Number
       <input id="phone" type="tel" name="phone" required autocomplete="tel-national" inputmode="tel" enterkeyhint="done" pattern="[0-9]{9,10}" minlength="9" maxlength="10" title="Phone number must be 9 to 10 digits" value="{{ phone|default('') }}">
     </label>
+    <p class="auth-card__disclaimer">By finishing your registration you accept our <a href="/terms">Terms of Service</a>.</p>
     <button class="btn btn--primary" type="submit">Finish</button>
   </form>
 </div>

--- a/templates/register_step1.html
+++ b/templates/register_step1.html
@@ -21,6 +21,7 @@
       </div>
       <span id="capsWarningConfirm" class="caps-warning" hidden>Caps Lock is on</span>
     </label>
+    <p class="auth-card__disclaimer">By registering you accept our <a href="/terms">Terms of Service</a>.</p>
     <button class="btn btn--primary" type="submit">Next</button>
   </form>
   <p style="align-self:center">Already registered? <a href="/login">Log in</a></p>


### PR DESCRIPTION
## Summary
- add a terms of service disclaimer to both registration forms with a link to /terms
- style the disclaimer text to match auth card visuals
- document the registration disclaimer in AGENTS.md for future reference

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c92d6d9bf883209617687eb4134966