### PR TITLE
Name Siply without Studio

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -2,6 +2,7 @@
 {% block content %}
 <article class="static-page">
   <h1>About SiplyGo</h1>
+  <p>SiplyGo is a web app created and hosted by Siply, a digital studio that designs websites, applications, and web experiences while managing server infrastructure, repairs, and broader IT services.</p>
   <p>We are building a modern ordering experience that keeps the focus on great hospitality while giving guests and staff the tools they need to thrive.</p>
   <section>
     <h2>Our mission</h2>


### PR DESCRIPTION
## Summary
- note that SiplyGo is created and hosted by Siply and highlight the studio's digital services

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9307cb24c8320bc2165aeb99f8a56