### PR TITLE
Update About page intro copy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - Review recent commit history before starting new tasks.
 - Footer marketing pages (About, Help Center, For Bars, Terms) live in `templates/about.html`, `templates/help_center.html`, `templates/for_bars.html`, and `templates/terms.html`; they share the `.static-page` styles defined in `static/css/components.css`.
   - Support contact details for these static pages pull from Jinja globals defined in `main.py` (`SUPPORT_EMAIL`, `SUPPORT_NUMBER`, `TERMS_VERSION`, etc.); update those constants to change emails, phone numbers, or term dates sitewide.
+  - The About page intro copy reads "Built and operated by Siply..." followed by "We’re building a modern ordering experience..." to highlight Siply's role and hospitality focus.
 - Homepage image stored in photo/homepage.png.
 - `/photo` static path serves the homepage image.
 - Homepage hero displays the artwork as a single `<img class="hero-art">` absolutely positioned under the content with pointer-events disabled.

--- a/templates/about.html
+++ b/templates/about.html
@@ -2,8 +2,8 @@
 {% block content %}
 <article class="static-page">
   <h1>About SiplyGo</h1>
-  <p>SiplyGo is a web app created and hosted by Siply, a digital studio that designs websites, applications, and web experiences while managing server infrastructure, repairs, and broader IT services.</p>
-  <p>We are building a modern ordering experience that keeps the focus on great hospitality while giving guests and staff the tools they need to thrive.</p>
+  <p>Built and operated by Siply, a digital studio for web products and cloud infrastructure.</p>
+  <p>We’re building a modern ordering experience that keeps the focus on hospitality while giving guests and teams the tools they need to thrive.</p>
   <section>
     <h2>Our mission</h2>
     <p>SiplyGo makes it effortless for people to discover bars, order from their table, and enjoy their time without waiting in line. We partner closely with local venues to streamline service, reduce friction, and keep every order moving.</p>


### PR DESCRIPTION
## Summary
- update the About page hero copy to the new Siply messaging
- document the new intro text in AGENTS.md for future reference

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c93475776483209bd92894be71a72b