### PR TITLE
Ensure phone errors use English text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 - Commit messages subject line must not exceed 30 characters.
 - Notification subject line must not exceed 30 characters.
 - Admin notifications form subject input enforces this with `maxlength=30`.
+- Phone validation errors must use English messaging; see `app/phone.py` and `tests/test_register_phone_validation.py`.
 - Review recent commit history before starting new tasks.
 - Footer marketing pages (About, Help Center, For Bars, Terms) live in `templates/about.html`, `templates/help_center.html`, `templates/for_bars.html`, and `templates/terms.html`; they share the `.static-page` styles defined in `static/css/components.css`.
   - Support contact details for these static pages pull from Jinja globals defined in `main.py` (`SUPPORT_EMAIL`, `SUPPORT_NUMBER`, `TERMS_VERSION`, etc.); update those constants to change emails, phone numbers, or term dates sitewide.

--- a/app/phone.py
+++ b/app/phone.py
@@ -32,26 +32,26 @@ def validate_and_format_phone(
 ) -> Tuple[str, str]:
     """Validate a phone number and return (E.164, region)."""
     if re.search(r"(ext\.?|x)\s*\d+", number_raw, re.IGNORECASE):
-        raise PhoneValidationError("Le estensioni non sono supportate.")
+        raise PhoneValidationError("Phone extensions are not supported.")
     region = region_from_dial_code(dial_code)
     try:
         num = phonenumbers.parse(number_raw, region)
     except phonenumbers.NumberParseException:
         raise PhoneValidationError(
-            "Numero di telefono non valido per la nazione selezionata."
+            "Invalid phone number for the selected country."
         )
     if getattr(num, "extension", None):
-        raise PhoneValidationError("Le estensioni non sono supportate.")
+        raise PhoneValidationError("Phone extensions are not supported.")
     if not phonenumbers.is_possible_number(num):
-        raise PhoneValidationError("Lunghezza numero non valida.")
+        raise PhoneValidationError("Invalid phone number length.")
     if not phonenumbers.is_valid_number(num):
-        raise PhoneValidationError("Numero di telefono non valido per la nazione selezionata.")
+        raise PhoneValidationError("Invalid phone number for the selected country.")
     if num.country_code != int(dial_code.lstrip("+")):
         raise PhoneValidationError(
-            f"Il numero non corrisponde al prefisso selezionato ({dial_code})."
+            f"The number does not match the selected dial code ({dial_code})."
         )
     if allowed_types is not None and phonenumbers.number_type(num) not in allowed_types:
-        raise PhoneValidationError("Numero di telefono non valido per la nazione selezionata.")
+        raise PhoneValidationError("Invalid phone number for the selected country.")
     e164 = phonenumbers.format_number(num, PhoneNumberFormat.E164)
     region_code = phonenumbers.region_code_for_number(num) or ""
     return e164, region_code
@@ -73,5 +73,5 @@ def normalize_phone_or_raise(dial_code: str, phone: str) -> Tuple[str, str]:
     except Exception:
         raise HTTPException(
             status_code=422,
-            detail="Numero di telefono non valido o non coerente con il prefisso selezionato.",
+            detail="Invalid phone number or it does not match the selected dial code.",
         )

--- a/main.py
+++ b/main.py
@@ -2874,7 +2874,7 @@ async def register_details(request: Request, db: Session = Depends(get_db)):
         try:
             RegisterIn.model_validate({"dial_code": prefix, "phone": phone})
         except ValidationError:
-            return render_form("Lunghezza numero non valida.", status_code=422)
+            return render_form("Invalid phone number length.", status_code=422)
         try:
             phone_e164, phone_region = normalize_phone_or_raise(prefix, phone)
         except HTTPException as exc:
@@ -3094,7 +3094,7 @@ async def profile_update(request: Request, db: Session = Depends(get_db)):
     try:
         RegisterIn.model_validate({"dial_code": prefix, "phone": phone})
     except ValidationError:
-        return render_form("Lunghezza numero non valida.", status_code=422)
+        return render_form("Invalid phone number length.", status_code=422)
     try:
         phone_e164, phone_region = normalize_phone_or_raise(prefix, phone)
     except HTTPException as exc:
@@ -4876,7 +4876,7 @@ async def update_user(request: Request, user_id: int, db: Session = Depends(get_
                 user=user,
                 bars=bars.values(),
                 current=current,
-                error="Lunghezza numero non valida.",
+                error="Invalid phone number length.",
                 status_code=422,
             )
         try:

--- a/tests/test_register_phone_validation.py
+++ b/tests/test_register_phone_validation.py
@@ -67,7 +67,7 @@ def test_register_phone_prefix_mismatch():
             data={"username": "mismatch1", "prefix": "+41", "phone": "0039 345 123 4567"},
         )
         assert resp.status_code == 422
-        assert "Il numero non corrisponde al prefisso selezionato (+41)." in resp.text
+        assert "The number does not match the selected dial code (+41)." in resp.text
         client.get("/logout")
         _start(client, "mm2@example.com")
         resp2 = client.post(
@@ -75,7 +75,7 @@ def test_register_phone_prefix_mismatch():
             data={"username": "mismatch2", "prefix": "+39", "phone": "0041 76 555 12 34"},
         )
         assert resp2.status_code == 422
-        assert "Il numero non corrisponde al prefisso selezionato (+39)." in resp2.text
+        assert "The number does not match the selected dial code (+39)." in resp2.text
 
 
 def test_register_phone_format_errors():
@@ -91,7 +91,7 @@ def test_register_phone_format_errors():
             data={"username": "shortnum", "prefix": "+41", "phone": "123"},
         )
         assert resp_short.status_code == 422
-        assert "Lunghezza numero non valida." in resp_short.text
+        assert "Invalid phone number length." in resp_short.text
         client.get("/logout")
         _start(client, "ext@example.com")
         resp_ext = client.post(
@@ -99,7 +99,7 @@ def test_register_phone_format_errors():
             data={"username": "extnum", "prefix": "+39", "phone": "345-123-4567 ext. 2"},
         )
         assert resp_ext.status_code == 422
-        assert "Le estensioni non sono supportate." in resp_ext.text
+        assert "Phone extensions are not supported." in resp_ext.text
 
 
 def test_register_phone_duplicate():


### PR DESCRIPTION
## Summary
- translate phone validation and HTTP detail messages to English
- update registration and profile flows to surface the English phone length error
- refresh the phone validation test expectations and note the requirement in AGENTS.md

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c93ce3f90c832095c10cf227e4801e