### PR TITLE
Add layout/home translations

### DIFF
--- a/app/i18n/translations/en.json
+++ b/app/i18n/translations/en.json
@@ -3,5 +3,98 @@
     "language": "English",
     "code": "en",
     "fallback": null
+  },
+  "common": {
+    "menu": "Menu",
+    "close": "Close",
+    "browse_bars": "Browse Bars",
+    "dashboard": "Dashboard",
+    "wallet": "Wallet",
+    "orders": "Orders",
+    "notifications": "Notifications",
+    "profile": "Profile",
+    "logout": "Logout",
+    "login": "Login",
+    "register": "Register",
+    "credits": "Credits",
+    "cart": "Cart",
+    "previous": "Previous",
+    "next": "Next",
+    "search": "Search"
+  },
+  "layout": {
+    "meta": {
+      "title": "SiplyGo Prototype",
+      "description": "SiplyGo helps you discover bars nearby and manage your orders effortlessly.",
+      "og_description": "Discover bars nearby and manage orders with SiplyGo."
+    },
+    "header": {
+      "menu_button_aria": "Menu",
+      "close_menu_aria": "Close menu",
+      "credit_aria": "Credits",
+      "cart_aria": "Cart ({count} items)"
+    },
+    "location": {
+      "change": "Change location",
+      "detecting": "Detecting location...",
+      "input_placeholder": "Enter city or ZIP",
+      "input_label": "Current location"
+    },
+    "search": {
+      "button_aria": "Search",
+      "input_placeholder": "Search bars...",
+      "input_aria": "Search bars",
+      "overlay_close": "Close"
+    },
+    "footer": {
+      "copyright": "SiplyGo © 2025",
+      "about": "About",
+      "help_center": "Help Center",
+      "for_bars": "For Bars",
+      "terms": "Terms"
+    },
+    "cart_blocker": {
+      "message": "You still have products in your cart at <strong>{bar_name}</strong>.",
+      "remove": "Remove products",
+      "go_to_menu": "Go to the bar menu"
+    },
+    "service_paused": {
+      "message": "Ordering is paused for <strong>{bar_name}</strong>. Please contact a staff member for more information.",
+      "close": "Close",
+      "back": "Back to the menu"
+    }
+  },
+  "home": {
+    "hero": {
+      "title": "Order drinks instantly, right from your table.",
+      "subtitle": "Skip the wait. Discover nearby bars and order with one tap.",
+      "greeting": "Hi {name} 👋",
+      "greeting_subtitle": "Ready for your next drink?"
+    },
+    "recent": {
+      "title": "Recently visited"
+    },
+    "bar_card": {
+      "open_label": "Open {bar_name}",
+      "status_open": "Open now",
+      "status_closed": "Closed now"
+    },
+    "bars": {
+      "title": "Nearby Open Bars",
+      "no_bars": "Sorry but all bars are closed at the moment"
+    },
+    "how": {
+      "title": "How it works",
+      "body": "Find a bar you love, take a seat, order and pay directly in the app—no more waiting, no more confusion."
+    },
+    "benefits": {
+      "title": "Benefits",
+      "order": "<strong>Order via app/web:</strong> Open, choose, and pay right from the browser.",
+      "faster": "<strong>Faster service:</strong> Skip the counter line and track your order in real time.",
+      "menu": "<strong>Always up-to-date menu:</strong> Variants, allergens, and live availability.",
+      "payments": "<strong>Modern payments:</strong> Supports gateways like Twint, Apple Pay, Google Pay, and many more.",
+      "wallet": "<strong>Wallet/Credits:</strong> Top-ups, bonuses, and quicker reorders.",
+      "multilingual": "<strong>Multilingual:</strong> Ideal for locals and tourists."
+    }
   }
 }

--- a/app/i18n/translations/it.json
+++ b/app/i18n/translations/it.json
@@ -3,5 +3,98 @@
     "language": "Italiano",
     "code": "it",
     "fallback": "en"
+  },
+  "common": {
+    "menu": "Menù",
+    "close": "Chiudi",
+    "browse_bars": "Esplora i bar",
+    "dashboard": "Pannello",
+    "wallet": "Portafoglio",
+    "orders": "Ordini",
+    "notifications": "Notifiche",
+    "profile": "Profilo",
+    "logout": "Esci",
+    "login": "Accedi",
+    "register": "Registrati",
+    "credits": "Crediti",
+    "cart": "Carrello",
+    "previous": "Precedente",
+    "next": "Successivo",
+    "search": "Cerca"
+  },
+  "layout": {
+    "meta": {
+      "title": "SiplyGo Prototype",
+      "description": "SiplyGo ti aiuta a scoprire i bar nelle vicinanze e a gestire i tuoi ordini senza sforzo.",
+      "og_description": "Scopri i bar vicino a te e gestisci gli ordini con SiplyGo."
+    },
+    "header": {
+      "menu_button_aria": "Menù",
+      "close_menu_aria": "Chiudi menù",
+      "credit_aria": "Crediti",
+      "cart_aria": "Carrello ({count} articoli)"
+    },
+    "location": {
+      "change": "Cambia posizione",
+      "detecting": "Rilevamento posizione...",
+      "input_placeholder": "Inserisci città o CAP",
+      "input_label": "Posizione attuale"
+    },
+    "search": {
+      "button_aria": "Cerca",
+      "input_placeholder": "Cerca bar...",
+      "input_aria": "Cerca bar",
+      "overlay_close": "Chiudi"
+    },
+    "footer": {
+      "copyright": "SiplyGo © 2025",
+      "about": "Chi siamo",
+      "help_center": "Centro assistenza",
+      "for_bars": "Per i bar",
+      "terms": "Termini"
+    },
+    "cart_blocker": {
+      "message": "Hai ancora prodotti nel carrello di <strong>{bar_name}</strong>.",
+      "remove": "Rimuovi prodotti",
+      "go_to_menu": "Vai al menù del bar"
+    },
+    "service_paused": {
+      "message": "Gli ordini per <strong>{bar_name}</strong> sono momentaneamente sospesi. Contatta lo staff per maggiori informazioni.",
+      "close": "Chiudi",
+      "back": "Torna al menù"
+    }
+  },
+  "home": {
+    "hero": {
+      "title": "Ordina drink all'istante, direttamente dal tuo tavolo.",
+      "subtitle": "Salta l'attesa. Scopri i bar vicini e ordina con un tocco.",
+      "greeting": "Ciao {name} 👋",
+      "greeting_subtitle": "Pronto per il prossimo drink?"
+    },
+    "recent": {
+      "title": "Visitati di recente"
+    },
+    "bar_card": {
+      "open_label": "Apri {bar_name}",
+      "status_open": "Aperto ora",
+      "status_closed": "Chiuso ora"
+    },
+    "bars": {
+      "title": "Bar aperti nelle vicinanze",
+      "no_bars": "Spiacenti, al momento tutti i bar sono chiusi"
+    },
+    "how": {
+      "title": "Come funziona",
+      "body": "Trova il tuo bar preferito, siediti, ordina e paga direttamente dall'app: niente più attese, niente più confusione."
+    },
+    "benefits": {
+      "title": "Vantaggi",
+      "order": "<strong>Ordina via app/web:</strong> Apri, scegli e paga direttamente dal browser.",
+      "faster": "<strong>Servizio più rapido:</strong> Salta la coda al bancone e segui l'ordine in tempo reale.",
+      "menu": "<strong>Menu sempre aggiornato:</strong> Varianti, allergeni e disponibilità in tempo reale.",
+      "payments": "<strong>Pagamenti moderni:</strong> Supporta circuiti come Twint, Apple Pay, Google Pay e molti altri.",
+      "wallet": "<strong>Portafoglio/Crediti:</strong> Ricariche, bonus e riordini più veloci.",
+      "multilingual": "<strong>Multilingue:</strong> Ideale per residenti e turisti."
+    }
   }
 }

--- a/templates/home.html
+++ b/templates/home.html
@@ -3,10 +3,10 @@
 {% set fallback_img = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCA0MDAgMjI1Jz48cmVjdCB3aWR0aD0nNDAwJyBoZWlnaHQ9JzIyNScgZmlsbD0nJTIzZjFmM2Y1Jy8+PC9zdmc+" %}
   <section class="hero home-hero">
   <div class="hero__content container">
-    <h1>Order drinks instantly, right from your table.</h1>
-    <p>Skip the wait. Discover nearby bars and order with one tap.</p>
+    <h1>{{ _('home.hero.title', default='Order drinks instantly, right from your table.') }}</h1>
+    <p>{{ _('home.hero.subtitle', default='Skip the wait. Discover nearby bars and order with one tap.') }}</p>
     <div class="hero__cta">
-      <a class="btn btn--primary" href="/search">Browse Bars</a>
+      <a class="btn btn--primary" href="/search">{{ _('common.browse_bars', default='Browse Bars') }}</a>
     </div>
   </div>
   <img class="hero-art" src="/photo/homepage.png" alt="" aria-hidden="true" draggable="false" width="1024" height="1024" />
@@ -14,8 +14,8 @@
 
 {% if user %}
 <section class="info-section">
-  <h2>Hi {{ user.username }} 👋</h2>
-  <p>Ready for your next drink?</p>
+  <h2>{{ _('home.hero.greeting', name=user.username, default='Hi {name} 👋') }}</h2>
+  <p>{{ _('home.hero.greeting_subtitle', default='Ready for your next drink?') }}</p>
 </section>
 {% endif %}
 
@@ -23,16 +23,16 @@
 <section class="bar-section">
   <div class="section-track">
     <div class="section-head">
-      <h2>Recently visited</h2>
+      <h2>{{ _('home.recent.title', default='Recently visited') }}</h2>
       <div class="scroller-nav">
-        <button class="scroll-btn prev" aria-label="Previous">‹</button>
-        <button class="scroll-btn next" aria-label="Next">›</button>
+        <button class="scroll-btn prev" aria-label="{{ _('common.previous', default='Previous') }}">‹</button>
+        <button class="scroll-btn next" aria-label="{{ _('common.next', default='Next') }}">›</button>
       </div>
     </div>
     <ul class="bars scroller">
       {% for bar in recent_bars %}
       <li>
-        <a class="bar-card{% if bar.is_open_now %} is-open{% endif %}" href="/bars/{{ bar.id }}" aria-label="Open {{ bar.name }}" data-name="{{ bar.name|lower }}" data-address="{{ bar.address|lower }}" data-city="{{ bar.city|lower }}" data-state="{{ bar.state|lower }}" data-latitude="{{ bar.latitude }}" data-longitude="{{ bar.longitude }}" data-rating="{{ bar.rating or '' }}" data-distance_km="{{ bar.distance_km or '' }}" data-categories="{{ bar.bar_categories|lower if bar.bar_categories else '' }}" data-open="{{ 'true' if bar.is_open_now else 'false' }}" itemscope itemtype="https://schema.org/BarOrPub">
+        <a class="bar-card{% if bar.is_open_now %} is-open{% endif %}" href="/bars/{{ bar.id }}" aria-label="{{ _('home.bar_card.open_label', bar_name=bar.name, default='Open {bar_name}') }}" data-name="{{ bar.name|lower }}" data-address="{{ bar.address|lower }}" data-city="{{ bar.city|lower }}" data-state="{{ bar.state|lower }}" data-latitude="{{ bar.latitude }}" data-longitude="{{ bar.longitude }}" data-rating="{{ bar.rating or '' }}" data-distance_km="{{ bar.distance_km or '' }}" data-categories="{{ bar.bar_categories|lower if bar.bar_categories else '' }}" data-open="{{ 'true' if bar.is_open_now else 'false' }}" itemscope itemtype="https://schema.org/BarOrPub">
         <div class="thumb-wrapper">
         {% if bar.photo_url %}
         <img class="thumb" src="{{ bar.photo_url }}" alt="{{ bar.name }} photo" itemprop="image" loading="lazy" decoding="async" width="400" height="225" srcset="{{ bar.photo_url }} 400w, {{ bar.photo_url }} 800w" sizes="(max-width: 600px) 100vw, 400px" onerror="this.src='{{ fallback_img }}';this.onerror=null;">
@@ -41,9 +41,9 @@
         {% endif %}
         </div>
         {% if bar.is_open_now %}
-        <span class="status status-open">Open now</span>
+        <span class="status status-open">{{ _('home.bar_card.status_open', default='Open now') }}</span>
         {% else %}
-        <span class="status status-closed">Closed now</span>
+        <span class="status status-closed">{{ _('home.bar_card.status_closed', default='Closed now') }}</span>
         {% endif %}
         <h3 class="title" itemprop="name">{{ bar.name }}</h3>
         <div class="bar-meta">
@@ -63,17 +63,17 @@
 <section class="bar-section">
   <div class="section-track">
     <div class="section-head">
-      <h2 id="bars">Nearby Open Bars</h2>
+      <h2 id="bars">{{ _('home.bars.title', default='Nearby Open Bars') }}</h2>
       <div class="scroller-nav">
-        <button class="scroll-btn prev" aria-label="Previous">‹</button>
-        <button class="scroll-btn next" aria-label="Next">›</button>
+        <button class="scroll-btn prev" aria-label="{{ _('common.previous', default='Previous') }}">‹</button>
+        <button class="scroll-btn next" aria-label="{{ _('common.next', default='Next') }}">›</button>
       </div>
     </div>
     <p id="nearestBar" aria-live="polite"></p>
     <ul class="bars scroller" id="barList">
       {% for bar in bars %}
       <li>
-          <a class="bar-card{% if bar.is_open_now %} is-open{% endif %}" href="/bars/{{ bar.id }}" aria-label="Open {{ bar.name }}" data-name="{{ bar.name|lower }}" data-address="{{ bar.address|lower }}" data-city="{{ bar.city|lower }}" data-state="{{ bar.state|lower }}" data-latitude="{{ bar.latitude }}" data-longitude="{{ bar.longitude }}" data-rating="{{ bar.rating or '' }}" data-distance_km="{{ bar.distance_km or '' }}" data-categories="{{ bar.bar_categories|lower if bar.bar_categories else '' }}" data-open="{{ 'true' if bar.is_open_now else 'false' }}" itemscope itemtype="https://schema.org/BarOrPub">
+          <a class="bar-card{% if bar.is_open_now %} is-open{% endif %}" href="/bars/{{ bar.id }}" aria-label="{{ _('home.bar_card.open_label', bar_name=bar.name, default='Open {bar_name}') }}" data-name="{{ bar.name|lower }}" data-address="{{ bar.address|lower }}" data-city="{{ bar.city|lower }}" data-state="{{ bar.state|lower }}" data-latitude="{{ bar.latitude }}" data-longitude="{{ bar.longitude }}" data-rating="{{ bar.rating or '' }}" data-distance_km="{{ bar.distance_km or '' }}" data-categories="{{ bar.bar_categories|lower if bar.bar_categories else '' }}" data-open="{{ 'true' if bar.is_open_now else 'false' }}" itemscope itemtype="https://schema.org/BarOrPub">
         <div class="thumb-wrapper">
         {% if bar.photo_url %}
         <img class="thumb" src="{{ bar.photo_url }}" alt="{{ bar.name }} photo" itemprop="image" loading="lazy" decoding="async" width="400" height="225" srcset="{{ bar.photo_url }} 400w, {{ bar.photo_url }} 800w" sizes="(max-width: 600px) 100vw, 400px" {% if not recent_bars and loop.first %}fetchpriority="high"{% endif %} onerror="this.src='{{ fallback_img }}';this.onerror=null;">
@@ -82,9 +82,9 @@
         {% endif %}
         </div>
         {% if bar.is_open_now %}
-        <span class="status status-open">Open now</span>
+        <span class="status status-open">{{ _('home.bar_card.status_open', default='Open now') }}</span>
         {% else %}
-        <span class="status status-closed">Closed now</span>
+        <span class="status status-closed">{{ _('home.bar_card.status_closed', default='Closed now') }}</span>
         {% endif %}
         <h3 class="title" itemprop="name">{{ bar.name }}</h3>
         <div class="bar-meta">
@@ -101,28 +101,28 @@
           <div class="thumb-wrapper">
             <i class="bi bi-arrow-left" aria-hidden="true"></i>
           </div>
-          <span>Browse Bars</span>
+          <span>{{ _('common.browse_bars', default='Browse Bars') }}</span>
         </a>
       </li>
     </ul>
-    <p id="noBarsMessage" hidden>Sorry but all bars are closed at the moment</p>
+    <p id="noBarsMessage" hidden>{{ _('home.bars.no_bars', default='Sorry but all bars are closed at the moment') }}</p>
   </div>
 </section>
 
 <section id="how" class="info-section">
-  <h2>How it works</h2>
-  <p>Find a bar you love, take a seat, order and pay directly in the app—no more waiting, no more confusion.</p>
+  <h2>{{ _('home.how.title', default='How it works') }}</h2>
+  <p>{{ _('home.how.body', default='Find a bar you love, take a seat, order and pay directly in the app—no more waiting, no more confusion.') }}</p>
 </section>
 
 <section class="info-section">
-  <h2>Benefits</h2>
+  <h2>{{ _('home.benefits.title', default='Benefits') }}</h2>
   <ul>
-    <li><strong>Order via app/web:</strong> Open, choose, and pay right from the browser.</li>
-    <li><strong>Faster service:</strong> Skip the counter line and track your order in real time.</li>
-    <li><strong>Always up-to-date menu:</strong> Variants, allergens, and live availability.</li>
-    <li><strong>Modern payments:</strong> Supports gateways like Twint, Apple Pay, Google Pay, and many more.</li>
-    <li><strong>Wallet/Credits:</strong> Top-ups, bonuses, and quicker reorders.</li>
-    <li><strong>Multilingual:</strong> Ideal for locals and tourists.</li>
+    <li>{{ _('home.benefits.order', default='<strong>Order via app/web:</strong> Open, choose, and pay right from the browser.')|safe }}</li>
+    <li>{{ _('home.benefits.faster', default='<strong>Faster service:</strong> Skip the counter line and track your order in real time.')|safe }}</li>
+    <li>{{ _('home.benefits.menu', default='<strong>Always up-to-date menu:</strong> Variants, allergens, and live availability.')|safe }}</li>
+    <li>{{ _('home.benefits.payments', default='<strong>Modern payments:</strong> Supports gateways like Twint, Apple Pay, Google Pay, and many more.')|safe }}</li>
+    <li>{{ _('home.benefits.wallet', default='<strong>Wallet/Credits:</strong> Top-ups, bonuses, and quicker reorders.')|safe }}</li>
+    <li>{{ _('home.benefits.multilingual', default='<strong>Multilingual:</strong> Ideal for locals and tourists.')|safe }}</li>
   </ul>
 </section>
 

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ language_code }}">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
@@ -8,11 +8,11 @@
   <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
-  <title>SiplyGo Prototype</title>
-  <meta name="description" content="SiplyGo helps you discover bars nearby and manage your orders effortlessly.">
+  <title>{{ _('layout.meta.title', default='SiplyGo Prototype') }}</title>
+  <meta name="description" content="{{ _('layout.meta.description', default='SiplyGo helps you discover bars nearby and manage your orders effortlessly.') }}">
   <link rel="canonical" href="https://siplygo.example.com/">
-  <meta property="og:title" content="SiplyGo Prototype">
-  <meta property="og:description" content="Discover bars nearby and manage orders with SiplyGo.">
+  <meta property="og:title" content="{{ _('layout.meta.title', default='SiplyGo Prototype') }}">
+  <meta property="og:description" content="{{ _('layout.meta.og_description', default='Discover bars nearby and manage orders with SiplyGo.') }}">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://siplygo.example.com/">
   <meta property="og:image" content="/static/favicon.png">
@@ -33,12 +33,12 @@
     {% if user and user.is_display %}
     <div class="display-header">
       <span class="hdr-logo">SiplyGo</span>
-      <a href="/logout">Logout</a>
+      <a href="/logout">{{ _('common.logout', default='Logout') }}</a>
     </div>
     {% else %}
     <div class="mobile-header">
       <!-- Premium hamburger trigger -->
-      <button class="nav-toggle js-open-menu" aria-label="Menu" aria-controls="mobileMenu" aria-expanded="false">
+      <button class="nav-toggle js-open-menu" aria-label="{{ _('layout.header.menu_button_aria', default='Menu') }}" aria-controls="mobileMenu" aria-expanded="false">
         <i class="bi bi-list" aria-hidden="true"></i>
         {% if unread_notifications %}
         <span class="notif-badge" aria-live="polite">{{ unread_notifications }}</span>
@@ -47,18 +47,19 @@
       <a class="hdr-logo" href="/">SiplyGo</a>
       <div class="hdr-actions">
         {% if user and not user.is_display %}
-        <a class="credit-pill" href="/wallet" aria-label="Credits">CHF {{ "%.2f"|format(user.credit) }}</a>
+        <a class="credit-pill" href="/wallet" aria-label="{{ _('common.credits', default='Credits') }}">CHF {{ "%.2f"|format(user.credit) }}</a>
         {% endif %}
         {% if not user or not user.is_display %}
-        <a class="cart-icon" href="/cart" aria-label="Cart">
+        {% set cart_count_display = cart_count if cart_count else 0 %}
+        <a class="cart-icon" href="/cart" aria-label="{{ _('layout.header.cart_aria', count=cart_count_display, default='Cart ({count} items)') }}">
           <i class="bi bi-cart2" aria-hidden="true"></i>
-          <span class="cart-badge" aria-live="polite">{% if cart_count %}{{ cart_count }}{% else %}0{% endif %}</span>
+          <span class="cart-badge" aria-live="polite">{{ cart_count_display }}</span>
         </a>
         {% endif %}
       </div>
     </div>
     <nav aria-label="Primary" class="navbar desktop-nav">
-      <button class="nav-toggle js-open-menu" aria-label="Menu" aria-controls="mobileMenu" aria-expanded="false">
+      <button class="nav-toggle js-open-menu" aria-label="{{ _('layout.header.menu_button_aria', default='Menu') }}" aria-controls="mobileMenu" aria-expanded="false">
         <i class="bi bi-list" aria-hidden="true"></i>
         {% if unread_notifications %}
         <span class="notif-badge" aria-live="polite">{{ unread_notifications }}</span>
@@ -67,31 +68,32 @@
       <a class="hdr-logo" href="/">SiplyGo</a>
       <div class="hdr-actions">
         {% if user and not user.is_display %}
-        <a class="credit-pill desktop-credit" href="/wallet" aria-label="Credits">CHF {{ "%.2f"|format(user.credit) }}</a>
+        <a class="credit-pill desktop-credit" href="/wallet" aria-label="{{ _('common.credits', default='Credits') }}">CHF {{ "%.2f"|format(user.credit) }}</a>
         {% endif %}
         {% if not user or not user.is_display %}
-        <a class="cart-icon" href="/cart" aria-label="Cart ({% if cart_count %}{{ cart_count }}{% else %}0{% endif %} items)">
+        {% set cart_count_display = cart_count if cart_count else 0 %}
+        <a class="cart-icon" href="/cart" aria-label="{{ _('layout.header.cart_aria', count=cart_count_display, default='Cart ({count} items)') }}">
           <i class="bi bi-cart2" aria-hidden="true"></i>
-          <span class="cart-badge" aria-live="polite">{% if cart_count %}{{ cart_count }}{% else %}0{% endif %}</span>
+          <span class="cart-badge" aria-live="polite">{{ cart_count_display }}</span>
         </a>
         {% endif %}
       </div>
     </nav>
     <nav id="mobileMenu" class="mobile-menu" aria-label="Menu" role="dialog" aria-modal="true" hidden>
-      <button class="menu-close js-close-menu" aria-label="Close menu"><i class="bi bi-x" aria-hidden="true"></i></button>
-      <a href="/search" role="menuitem"><i class="bi bi-geo-alt" aria-hidden="true"></i><span>Browse Bars</span></a>
+      <button class="menu-close js-close-menu" aria-label="{{ _('layout.header.close_menu_aria', default='Close menu') }}"><i class="bi bi-x" aria-hidden="true"></i></button>
+      <a href="/search" role="menuitem"><i class="bi bi-geo-alt" aria-hidden="true"></i><span>{{ _('common.browse_bars', default='Browse Bars') }}</span></a>
       {% if user and (user.is_super_admin or user.is_bar_admin or user.is_bartender) %}
-      <a href="/dashboard" role="menuitem"><i class="bi bi-speedometer2" aria-hidden="true"></i><span>Dashboard</span></a>
+      <a href="/dashboard" role="menuitem"><i class="bi bi-speedometer2" aria-hidden="true"></i><span>{{ _('common.dashboard', default='Dashboard') }}</span></a>
       {% endif %}
       {% if user %}
-      <a href="/wallet" role="menuitem"><i class="bi bi-wallet2" aria-hidden="true"></i><span>Wallet</span></a>
-      <a href="/orders" role="menuitem"><i class="bi bi-clock-history" aria-hidden="true"></i><span>Orders</span></a>
-      <a href="/notifications" role="menuitem"><i class="bi bi-bell" aria-hidden="true"></i><span>Notifications</span>{% if unread_notifications %}<span class="notif-badge" aria-live="polite">{{ unread_notifications }}</span>{% endif %}</a>
-      <a href="/profile" role="menuitem"><i class="bi bi-person" aria-hidden="true"></i><span>Profile</span></a>
-      <a href="/logout" role="menuitem"><i class="bi bi-box-arrow-right" aria-hidden="true"></i><span>Logout</span></a>
+      <a href="/wallet" role="menuitem"><i class="bi bi-wallet2" aria-hidden="true"></i><span>{{ _('common.wallet', default='Wallet') }}</span></a>
+      <a href="/orders" role="menuitem"><i class="bi bi-clock-history" aria-hidden="true"></i><span>{{ _('common.orders', default='Orders') }}</span></a>
+      <a href="/notifications" role="menuitem"><i class="bi bi-bell" aria-hidden="true"></i><span>{{ _('common.notifications', default='Notifications') }}</span>{% if unread_notifications %}<span class="notif-badge" aria-live="polite">{{ unread_notifications }}</span>{% endif %}</a>
+      <a href="/profile" role="menuitem"><i class="bi bi-person" aria-hidden="true"></i><span>{{ _('common.profile', default='Profile') }}</span></a>
+      <a href="/logout" role="menuitem"><i class="bi bi-box-arrow-right" aria-hidden="true"></i><span>{{ _('common.logout', default='Logout') }}</span></a>
       {% else %}
-      <a href="/login" role="menuitem" class="menu-login"><i class="bi bi-box-arrow-in-right" aria-hidden="true"></i><span>Login</span></a>
-      <a href="/register" role="menuitem" class="menu-register"><i class="bi bi-person-plus" aria-hidden="true"></i><span>Register</span></a>
+      <a href="/login" role="menuitem" class="menu-login"><i class="bi bi-box-arrow-in-right" aria-hidden="true"></i><span>{{ _('common.login', default='Login') }}</span></a>
+      <a href="/register" role="menuitem" class="menu-register"><i class="bi bi-person-plus" aria-hidden="true"></i><span>{{ _('common.register', default='Register') }}</span></a>
       {% endif %}
     </nav>
     <div class="menu-backdrop" hidden></div>
@@ -99,19 +101,19 @@
   </header>
     {% if not user or not user.is_display %}
     <div class="hdr-sub">
-      <button class="location-pill location-selector js-open-location" aria-label="Change location"><span id="locationDisplay">📍 Detecting location...</span></button>
-      <a class="btn-icon" href="/search" aria-label="Search"><i class="bi bi-search"></i></a>
+      <button class="location-pill location-selector js-open-location" aria-label="{{ _('layout.location.change', default='Change location') }}"><span id="locationDisplay">📍 {{ _('layout.location.detecting', default='Detecting location...') }}</span></button>
+      <a class="btn-icon" href="/search" aria-label="{{ _('layout.search.button_aria', default='Search') }}"><i class="bi bi-search"></i></a>
     </div>
-    <input type="search" id="locationInput" class="visually-hidden" value="Detecting location..." placeholder="Enter city or ZIP" aria-label="Current location" list="citySuggestionsMobile" autocomplete="postal-code">
+    <input type="search" id="locationInput" class="visually-hidden" value="{{ _('layout.location.detecting', default='Detecting location...') }}" placeholder="{{ _('layout.location.input_placeholder', default='Enter city or ZIP') }}" aria-label="{{ _('layout.location.input_label', default='Current location') }}" list="citySuggestionsMobile" autocomplete="postal-code">
     <datalist id="citySuggestionsMobile">
       <option value="Lugano"></option>
       <option value="Locarno"></option>
       <option value="Zurich"></option>
     </datalist>
     <div class="search-overlay" hidden>
-      <button class="overlay-close" aria-label="Close">×</button>
+      <button class="overlay-close" aria-label="{{ _('layout.search.overlay_close', default='Close') }}">×</button>
       <div class="overlay-body">
-        <input type="search" id="barSearch" placeholder="Search bars..." aria-label="Search bars" inputmode="search" autocomplete="off" enterkeyhint="search">
+        <input type="search" id="barSearch" placeholder="{{ _('layout.search.input_placeholder', default='Search bars...') }}" aria-label="{{ _('layout.search.input_aria', default='Search bars') }}" inputmode="search" autocomplete="off" enterkeyhint="search">
         <div id="searchSuggestions" class="search-suggestions"></div>
       </div>
     </div>
@@ -122,27 +124,27 @@
     {% if not user or not user.is_display %}
     <footer class="site-footer" role="contentinfo">
       <div class="container">
-        <p>SiplyGo © 2025 · <a href="/about">About</a> · <a href="/help-center">Help Center</a> · <a href="/for-bars">For Bars</a> · <a href="/terms">Terms</a></p>
+        <p>{{ _('layout.footer.copyright', default='SiplyGo © 2025') }} · <a href="/about">{{ _('layout.footer.about', default='About') }}</a> · <a href="/help-center">{{ _('layout.footer.help_center', default='Help Center') }}</a> · <a href="/for-bars">{{ _('layout.footer.for_bars', default='For Bars') }}</a> · <a href="/terms">{{ _('layout.footer.terms', default='Terms') }}</a></p>
       </div>
     </footer>
     <div id="cartBlocker" class="cart-blocker" {% if cart_bar_id and current_bar_id != cart_bar_id %}{% else %}hidden{% endif %}>
       <div class="cart-popup">
-        <p>You still have products in your cart at <strong>{{ cart_bar_name }}</strong>.</p>
+        <p>{{ _('layout.cart_blocker.message', bar_name=cart_bar_name, default='You still have products in your cart at <strong>{bar_name}</strong>.')|safe }}</p>
         <div class="cart-popup-actions">
-          <button type="button" class="btn btn--secondary js-clear-cart">Remove products</button>
-          <a class="btn btn--primary" href="/bars/{{ cart_bar_id }}">Go to the bar menu</a>
+          <button type="button" class="btn btn--secondary js-clear-cart">{{ _('layout.cart_blocker.remove', default='Remove products') }}</button>
+          <a class="btn btn--primary" href="/bars/{{ cart_bar_id }}">{{ _('layout.cart_blocker.go_to_menu', default='Go to the bar menu') }}</a>
         </div>
       </div>
     </div>
     <div id="servicePaused" class="cart-blocker" hidden>
       <div class="cart-popup">
-        <p>Ordering is paused for <strong>{{ cart_bar_name }}</strong>. Please contact a staff member for more information.</p>
+        <p>{{ _('layout.service_paused.message', bar_name=cart_bar_name, default='Ordering is paused for <strong>{bar_name}</strong>. Please contact a staff member for more information.')|safe }}</p>
         <div class="cart-popup-actions">
           {% if pause_popup_close|default(False) %}
-          <button type="button" class="btn btn--secondary js-close-service-paused">Close</button>
+          <button type="button" class="btn btn--secondary js-close-service-paused">{{ _('layout.service_paused.close', default='Close') }}</button>
           {% endif %}
           {% if pause_popup_back|default(False) %}
-          <a class="btn btn--primary" href="/bars/{{ cart_bar_id }}">Back to the menu</a>
+          <a class="btn btn--primary" href="/bars/{{ cart_bar_id }}">{{ _('layout.service_paused.back', default='Back to the menu') }}</a>
           {% endif %}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add english and italian translation data for layout/navigation and home page copy
- wire the shared layout to the translation helper for metadata, navigation, search, and cart popups
- localize the home page hero, bar listings, and benefits content

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c964230344832087a55c6b3d96e353