### PR TITLE
Translate about page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,3 +368,4 @@
 - Passing `?lang=<code>` in the query string updates the user's preferred language and persists it in the session for
   subsequent requests. Absent an explicit choice, the resolver checks the stored session value followed by the
   `Accept-Language` header before falling back to English.
+- About page strings live under the `about` namespace in `app/i18n/translations/*.json`; `templates/about.html` pulls from these keys.

--- a/app/i18n/translations/en.json
+++ b/app/i18n/translations/en.json
@@ -96,5 +96,39 @@
       "wallet": "<strong>Wallet/Credits:</strong> Top-ups, bonuses, and quicker reorders.",
       "multilingual": "<strong>Multilingual:</strong> Ideal for locals and tourists."
     }
+  },
+  "about": {
+    "title": "About SiplyGo",
+    "intro": {
+      "built": "Built and operated by Siply, a digital studio for web products and cloud infrastructure.",
+      "focus": "We're building a modern ordering experience that keeps the focus on hospitality while giving guests and teams the tools they need to thrive."
+    },
+    "mission": {
+      "title": "Our mission",
+      "body": "SiplyGo makes it effortless for people to discover bars, order from their table, and enjoy their time without waiting in line. We partner closely with local venues to streamline service, reduce friction, and keep every order moving."
+    },
+    "values": {
+      "title": "What we value",
+      "delight": {
+        "title": "Delightful guest journeys",
+        "body": "intuitive menus, real-time order tracking, and secure payments from any device."
+      },
+      "empowered": {
+        "title": "Empowered teams",
+        "body": "dashboards that help bartenders stay on top of tickets and respond to guests faster."
+      },
+      "insight": {
+        "title": "Operational insight",
+        "body": "revenue, payout, and menu analytics that turn nightly service into actionable data."
+      }
+    },
+    "future": {
+      "title": "Where we are headed",
+      "body": "We continue to expand the platform with richer loyalty tools, flexible payouts, and integrations that help bars focus on hospitality, not hardware. New releases are rolled out frequently and shared in our Help Center so teams can adopt them with confidence."
+    },
+    "contact": {
+      "title": "Stay in touch",
+      "body": "Questions about the roadmap or partnerships? Reach out at <a href=\"mailto:{email}\">{email}</a> and we will be happy to connect."
+    }
   }
 }

--- a/app/i18n/translations/it.json
+++ b/app/i18n/translations/it.json
@@ -96,5 +96,39 @@
       "wallet": "<strong>Portafoglio/Crediti:</strong> Ricariche, bonus e riordini più veloci.",
       "multilingual": "<strong>Multilingue:</strong> Ideale per residenti e turisti."
     }
+  },
+  "about": {
+    "title": "Informazioni su SiplyGo",
+    "intro": {
+      "built": "Creato e gestito da Siply, uno studio digitale specializzato in prodotti web e infrastrutture cloud.",
+      "focus": "Stiamo costruendo un'esperienza di ordinazione moderna che mantiene l'attenzione sull'ospitalità offrendo a ospiti e team gli strumenti di cui hanno bisogno per prosperare."
+    },
+    "mission": {
+      "title": "La nostra missione",
+      "body": "SiplyGo rende semplice per tutti scoprire nuovi bar, ordinare direttamente dal tavolo e godersi il tempo senza aspettare in fila. Collaboriamo a stretto contatto con i locali per snellire il servizio, ridurre gli attriti e tenere ogni ordine in movimento."
+    },
+    "values": {
+      "title": "I nostri valori",
+      "delight": {
+        "title": "Esperienze memorabili per gli ospiti",
+        "body": "menù intuitivi, monitoraggio degli ordini in tempo reale e pagamenti sicuri da qualsiasi dispositivo."
+      },
+      "empowered": {
+        "title": "Team responsabilizzati",
+        "body": "dashboard che aiutano i bartender a restare al passo con le comande e a rispondere più velocemente agli ospiti."
+      },
+      "insight": {
+        "title": "Visione operativa",
+        "body": "analisi su ricavi, pagamenti e menù che trasformano il servizio serale in dati utili."
+      }
+    },
+    "future": {
+      "title": "Dove stiamo andando",
+      "body": "Continuiamo ad ampliare la piattaforma con strumenti di fidelizzazione più ricchi, pagamenti flessibili e integrazioni che aiutano i bar a concentrarsi sull'ospitalità, non sull'hardware. Rilasciamo spesso nuove funzionalità e le condividiamo nel nostro Help Center, così i team possono adottarle con fiducia."
+    },
+    "contact": {
+      "title": "Rimaniamo in contatto",
+      "body": "Domande sulla roadmap o sulle partnership? Scrivici a <a href=\"mailto:{email}\">{email}</a> e saremo felici di metterci in contatto."
+    }
   }
 }

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,28 +1,28 @@
 {% extends "layout.html" %}
 {% block content %}
 <article class="static-page">
-  <h1>About SiplyGo</h1>
-  <p>Built and operated by Siply, a digital studio for web products and cloud infrastructure.</p>
-  <p>We’re building a modern ordering experience that keeps the focus on hospitality while giving guests and teams the tools they need to thrive.</p>
+  <h1>{{ _('about.title', default='About SiplyGo') }}</h1>
+  <p>{{ _('about.intro.built', default='Built and operated by Siply, a digital studio for web products and cloud infrastructure.') }}</p>
+  <p>{{ _("about.intro.focus", default="We're building a modern ordering experience that keeps the focus on hospitality while giving guests and teams the tools they need to thrive.") }}</p>
   <section>
-    <h2>Our mission</h2>
-    <p>SiplyGo makes it effortless for people to discover bars, order from their table, and enjoy their time without waiting in line. We partner closely with local venues to streamline service, reduce friction, and keep every order moving.</p>
+    <h2>{{ _('about.mission.title', default='Our mission') }}</h2>
+    <p>{{ _('about.mission.body', default='SiplyGo makes it effortless for people to discover bars, order from their table, and enjoy their time without waiting in line. We partner closely with local venues to streamline service, reduce friction, and keep every order moving.') }}</p>
   </section>
   <section>
-    <h2>What we value</h2>
+    <h2>{{ _('about.values.title', default='What we value') }}</h2>
     <ul>
-      <li><strong>Delightful guest journeys</strong> – intuitive menus, real-time order tracking, and secure payments from any device.</li>
-      <li><strong>Empowered teams</strong> – dashboards that help bartenders stay on top of tickets and respond to guests faster.</li>
-      <li><strong>Operational insight</strong> – revenue, payout, and menu analytics that turn nightly service into actionable data.</li>
+      <li><strong>{{ _('about.values.delight.title', default='Delightful guest journeys') }}</strong> – {{ _('about.values.delight.body', default='intuitive menus, real-time order tracking, and secure payments from any device.') }}</li>
+      <li><strong>{{ _('about.values.empowered.title', default='Empowered teams') }}</strong> – {{ _('about.values.empowered.body', default='dashboards that help bartenders stay on top of tickets and respond to guests faster.') }}</li>
+      <li><strong>{{ _('about.values.insight.title', default='Operational insight') }}</strong> – {{ _('about.values.insight.body', default='revenue, payout, and menu analytics that turn nightly service into actionable data.') }}</li>
     </ul>
   </section>
   <section>
-    <h2>Where we are headed</h2>
-    <p>We continue to expand the platform with richer loyalty tools, flexible payouts, and integrations that help bars focus on hospitality, not hardware. New releases are rolled out frequently and shared in our Help Center so teams can adopt them with confidence.</p>
+    <h2>{{ _('about.future.title', default='Where we are headed') }}</h2>
+    <p>{{ _('about.future.body', default='We continue to expand the platform with richer loyalty tools, flexible payouts, and integrations that help bars focus on hospitality, not hardware. New releases are rolled out frequently and shared in our Help Center so teams can adopt them with confidence.') }}</p>
   </section>
   <section>
-    <h2>Stay in touch</h2>
-    <p>Questions about the roadmap or partnerships? Reach out at <a href="mailto:{{ SUPPORT_EMAIL }}">{{ SUPPORT_EMAIL }}</a> and we will be happy to connect.</p>
+    <h2>{{ _('about.contact.title', default='Stay in touch') }}</h2>
+    <p>{{ _('about.contact.body', email=SUPPORT_EMAIL, default='Questions about the roadmap or partnerships? Reach out at <a href="mailto:{email}">{email}</a> and we will be happy to connect.')|safe }}</p>
   </section>
 </article>
 {% endblock %}


### PR DESCRIPTION
## Summary
- localize the About static page with translator helpers
- add English and Italian strings for the About namespace
- note the new About namespace in AGENTS.md for future localization work

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c97d8cd8788320a337e1edc8518852