### PR TITLE
Translate help center page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,3 +369,4 @@
   subsequent requests. Absent an explicit choice, the resolver checks the stored session value followed by the
   `Accept-Language` header before falling back to English.
 - About page strings live under the `about` namespace in `app/i18n/translations/*.json`; `templates/about.html` pulls from these keys.
+- Help Center page strings live under the `help_center` namespace in `app/i18n/translations/*.json`; `templates/help_center.html` pulls from these keys.

--- a/app/i18n/translations/en.json
+++ b/app/i18n/translations/en.json
@@ -130,5 +130,30 @@
       "title": "Stay in touch",
       "body": "Questions about the roadmap or partnerships? Reach out at <a href=\"mailto:{email}\">{email}</a> and we will be happy to connect."
     }
+  },
+  "help_center": {
+    "title": "Help Center",
+    "intro": "Find answers to the most common questions about browsing bars, placing orders, and managing your account. These guides apply to both the web app and the mobile experience.",
+    "getting_started": {
+      "title": "Getting started",
+      "steps": {
+        "one": "Create an account or log in with your existing credentials.",
+        "two": "Share your location or search for a city to find nearby venues.",
+        "three": "Select a bar, pick your table, and add items to the cart.",
+        "four": "Review your order, choose a payment method, and submit."
+      },
+      "after": "After placing an order you can track the live status from the Orders page or receive updates via notifications."
+    },
+    "account": {
+      "title": "Managing your account",
+      "profile": "Update profile details, phone number, and password from the <a href=\"/profile\">Profile</a> page.",
+      "wallet": "Top up credits, review transactions, and download receipts in the <a href=\"/wallet\">Wallet</a>.",
+      "notifications": "Check unread messages from bar staff or administrators in <a href=\"/notifications\">Notifications</a>."
+    },
+    "support": {
+      "title": "Need more help?",
+      "contact": "Send us a note at <a href=\"mailto:{email}\">{email}</a>. Include the bar name, order code, and a short description so we can assist quickly.",
+      "hours": "We respond Monday through Friday, 9:00-18:00 CET."
+    }
   }
 }

--- a/app/i18n/translations/it.json
+++ b/app/i18n/translations/it.json
@@ -130,5 +130,30 @@
       "title": "Rimaniamo in contatto",
       "body": "Domande sulla roadmap o sulle partnership? Scrivici a <a href=\"mailto:{email}\">{email}</a> e saremo felici di metterci in contatto."
     }
+  },
+  "help_center": {
+    "title": "Centro assistenza",
+    "intro": "Trova le risposte alle domande più frequenti su come esplorare i bar, effettuare ordini e gestire il tuo account. Queste guide valgono sia per l'app web che per l'esperienza mobile.",
+    "getting_started": {
+      "title": "Per iniziare",
+      "steps": {
+        "one": "Crea un account o accedi con le tue credenziali esistenti.",
+        "two": "Condividi la tua posizione o cerca una città per trovare i locali vicini.",
+        "three": "Seleziona un bar, scegli il tavolo e aggiungi articoli al carrello.",
+        "four": "Controlla l'ordine, scegli il metodo di pagamento e invia."
+      },
+      "after": "Dopo aver inoltrato un ordine puoi seguire lo stato in tempo reale dalla pagina Ordini o ricevere aggiornamenti tramite notifiche."
+    },
+    "account": {
+      "title": "Gestione del tuo account",
+      "profile": "Aggiorna i dati del profilo, il numero di telefono e la password dalla pagina <a href=\"/profile\">Profilo</a>.",
+      "wallet": "Ricarica i crediti, consulta le transazioni e scarica le ricevute nel <a href=\"/wallet\">Portafoglio</a>.",
+      "notifications": "Controlla i messaggi non letti dello staff o degli amministratori in <a href=\"/notifications\">Notifiche</a>."
+    },
+    "support": {
+      "title": "Serve altro supporto?",
+      "contact": "Scrivici a <a href=\"mailto:{email}\">{email}</a>. Indica il nome del bar, il codice dell'ordine e una breve descrizione per aiutarci a rispondere rapidamente.",
+      "hours": "Rispondiamo dal lunedì al venerdì, 9:00-18:00 CET."
+    }
   }
 }

--- a/templates/help_center.html
+++ b/templates/help_center.html
@@ -1,30 +1,30 @@
 {% extends "layout.html" %}
 {% block content %}
 <article class="static-page">
-  <h1>Help Center</h1>
-  <p>Find answers to the most common questions about browsing bars, placing orders, and managing your account. These guides apply to both the web app and the mobile experience.</p>
+  <h1>{{ _('help_center.title', default='Help Center') }}</h1>
+  <p>{{ _('help_center.intro', default='Find answers to the most common questions about browsing bars, placing orders, and managing your account. These guides apply to both the web app and the mobile experience.') }}</p>
   <section>
-    <h2>Getting started</h2>
+    <h2>{{ _('help_center.getting_started.title', default='Getting started') }}</h2>
     <ol>
-      <li>Create an account or log in with your existing credentials.</li>
-      <li>Share your location or search for a city to find nearby venues.</li>
-      <li>Select a bar, pick your table, and add items to the cart.</li>
-      <li>Review your order, choose a payment method, and submit.</li>
+      <li>{{ _('help_center.getting_started.steps.one', default='Create an account or log in with your existing credentials.') }}</li>
+      <li>{{ _('help_center.getting_started.steps.two', default='Share your location or search for a city to find nearby venues.') }}</li>
+      <li>{{ _('help_center.getting_started.steps.three', default='Select a bar, pick your table, and add items to the cart.') }}</li>
+      <li>{{ _('help_center.getting_started.steps.four', default='Review your order, choose a payment method, and submit.') }}</li>
     </ol>
-    <p>After placing an order you can track the live status from the Orders page or receive updates via notifications.</p>
+    <p>{{ _('help_center.getting_started.after', default='After placing an order you can track the live status from the Orders page or receive updates via notifications.') }}</p>
   </section>
   <section>
-    <h2>Managing your account</h2>
+    <h2>{{ _('help_center.account.title', default='Managing your account') }}</h2>
     <ul>
-      <li>Update profile details, phone number, and password from the <a href="/profile">Profile</a> page.</li>
-      <li>Top up credits, review transactions, and download receipts in the <a href="/wallet">Wallet</a>.</li>
-      <li>Check unread messages from bar staff or administrators in <a href="/notifications">Notifications</a>.</li>
+      <li>{{ _('help_center.account.profile', default='Update profile details, phone number, and password from the <a href="/profile">Profile</a> page.')|safe }}</li>
+      <li>{{ _('help_center.account.wallet', default='Top up credits, review transactions, and download receipts in the <a href="/wallet">Wallet</a>.')|safe }}</li>
+      <li>{{ _('help_center.account.notifications', default='Check unread messages from bar staff or administrators in <a href="/notifications">Notifications</a>.')|safe }}</li>
     </ul>
   </section>
   <section>
-    <h2>Need more help?</h2>
-    <p>Send us a note at <a href="mailto:{{ SUPPORT_EMAIL }}">{{ SUPPORT_EMAIL }}</a>. Include the bar name, order code, and a short description so we can assist quickly.</p>
-    <p>We respond Monday through Friday, 9:00-18:00 CET.</p>
+    <h2>{{ _('help_center.support.title', default='Need more help?') }}</h2>
+    <p>{{ _('help_center.support.contact', email=SUPPORT_EMAIL, default='Send us a note at <a href="mailto:{email}">{email}</a>. Include the bar name, order code, and a short description so we can assist quickly.')|safe }}</p>
+    <p>{{ _('help_center.support.hours', default='We respond Monday through Friday, 9:00-18:00 CET.') }}</p>
   </section>
 </article>
 {% endblock %}


### PR DESCRIPTION
## Summary
- localize the Help Center static page template to use translation strings
- add Help Center copy to the English and Italian translation files
- note the new translation namespace in AGENTS.md

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c980000f1c83208b08b4dee0495709