### PR TITLE
Localize For Bars, Terms, and Wallet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -370,3 +370,4 @@
   `Accept-Language` header before falling back to English.
 - About page strings live under the `about` namespace in `app/i18n/translations/*.json`; `templates/about.html` pulls from these keys.
 - Help Center page strings live under the `help_center` namespace in `app/i18n/translations/*.json`; `templates/help_center.html` pulls from these keys.
+- "For Bars", "Terms", and "Wallet" pages localize through `for_bars`, `terms`, and `wallet` namespaces inside `app/i18n/translations/*.json`.

--- a/app/i18n/translations/en.json
+++ b/app/i18n/translations/en.json
@@ -155,5 +155,109 @@
       "contact": "Send us a note at <a href=\"mailto:{email}\">{email}</a>. Include the bar name, order code, and a short description so we can assist quickly.",
       "hours": "We respond Monday through Friday, 9:00-18:00 CET."
     }
+  },
+  "for_bars": {
+    "title": "For Bars",
+    "intro": "SiplyGo helps venues deliver quicker service, increase order value, and give staff clearer visibility into what guests need next.",
+    "why": {
+      "title": "Why venues choose SiplyGo",
+      "items": {
+        "menus": "<strong>Digital menus that stay fresh</strong> – highlight specials, mark items out of stock, and share allergen details instantly.",
+        "fulfilment": "<strong>Faster fulfilment</strong> – bar dashboards show incoming orders, prep status, and ready times in one place.",
+        "payments": "<strong>Flexible payments</strong> – accept wallet credit, cards, or pay-at-bar while keeping transaction fees predictable.",
+        "insights": "<strong>Insights that matter</strong> – track nightly revenue, payouts, and repeat guests without spreadsheets."
+      }
+    },
+    "onboarding": {
+      "title": "How onboarding works",
+      "steps": {
+        "one": "We map your menu, categories, and pricing in a shared workspace.",
+        "two": "Staff receive a walkthrough covering live orders, notifications, and service best practices.",
+        "three": "Go live with marketing assets, QR codes, and support resources tailored to your bar."
+      }
+    },
+    "requirements": {
+      "title": "What you need",
+      "items": {
+        "device": "A tablet or laptop behind the bar to monitor orders.",
+        "wifi": "Reliable Wi-Fi for staff devices and optional guest QR scanning.",
+        "contact": "A point of contact to manage payouts and menu updates."
+      }
+    },
+    "demo": {
+      "title": "Schedule a demo",
+      "cta": "Email <a href=\"mailto:{email}\">{email}</a> or call {phone} to learn how SiplyGo can support your service model."
+    }
+  },
+  "terms": {
+    "title": "Terms of Use",
+    "meta": "Version {version} · Effective {effective} · Next review {next_review}",
+    "intro": "These terms explain how SiplyGo provides services to guests and bar partners. By creating an account or placing an order you agree to the rules below.",
+    "sections": {
+      "eligibility": {
+        "title": "1. Eligibility and accounts",
+        "items": {
+          "age": "You must be at least 18 years old and able to form a binding agreement.",
+          "credentials": "Keep your login credentials secure and notify us immediately if you suspect unauthorized access.",
+          "suspend": "We may suspend or close accounts that violate these terms or local regulations."
+        }
+      },
+      "ordering": {
+        "title": "2. Ordering and payments",
+        "items": {
+          "fulfilment": "Orders placed through SiplyGo are fulfilled directly by the bar you select.",
+          "pricing": "Displayed prices include any applicable taxes or service fees. The final receipt will be available in your wallet history.",
+          "refunds": "Refunds for cancellations or order issues are managed jointly by SiplyGo and the venue."
+        }
+      },
+      "use": {
+        "title": "3. Acceptable use",
+        "items": {
+          "responsible": "Use the platform responsibly and avoid activities that disrupt service, attempt fraud, or harm other guests and staff.",
+          "content": "Content you submit, such as order notes, must be respectful and accurate.",
+          "monitoring": "We monitor usage to keep the experience safe and may remove content or limit access when necessary."
+        }
+      }
+    },
+    "contact": {
+      "title": "4. Contact",
+      "body": "For questions about these terms or to report an issue, email <a href=\"mailto:{email}\">{email}</a> or call <a href=\"tel:{phone_tel}\">{phone}</a>.",
+      "update": "We update this page whenever policies change. Continued use of SiplyGo after updates means you accept the revised terms."
+    }
+  },
+  "wallet": {
+    "title": "Wallet",
+    "subtitle": "Manage your balance, top up instantly, and review your recent activity.",
+    "balance": {
+      "label": "Current balance",
+      "available": "Available"
+    },
+    "actions": {
+      "top_up": "Top Up"
+    },
+    "activity": {
+      "title": "Recent Activity"
+    },
+    "tx": {
+      "topup": "Top up",
+      "refund": "Refund",
+      "refund_with_order": "Refund · Order #{order_id}",
+      "order": "Order placed",
+      "order_with_bar": "Order placed · {bar}"
+    },
+    "empty": {
+      "title": "No transactions yet",
+      "body": "Your top ups and payments will appear here.",
+      "cta": "Make your first top up"
+    },
+    "status": {
+      "completed": "Completed",
+      "processing": "Processing",
+      "pending": "Pending",
+      "refunded": "Refunded",
+      "canceled": "Canceled",
+      "cancelled": "Cancelled",
+      "failed": "Failed"
+    }
   }
 }

--- a/app/i18n/translations/it.json
+++ b/app/i18n/translations/it.json
@@ -155,5 +155,109 @@
       "contact": "Scrivici a <a href=\"mailto:{email}\">{email}</a>. Indica il nome del bar, il codice dell'ordine e una breve descrizione per aiutarci a rispondere rapidamente.",
       "hours": "Rispondiamo dal lunedì al venerdì, 9:00-18:00 CET."
     }
+  },
+  "for_bars": {
+    "title": "Per i bar",
+    "intro": "SiplyGo aiuta i locali a offrire un servizio più rapido, aumentare il valore degli ordini e fornire allo staff una visibilità più chiara su ciò di cui gli ospiti hanno bisogno.",
+    "why": {
+      "title": "Perché i locali scelgono SiplyGo",
+      "items": {
+        "menus": "<strong>Menu digitali sempre aggiornati</strong> – metti in evidenza le specialità, segnala gli articoli non disponibili e condividi subito le informazioni sugli allergeni.",
+        "fulfilment": "<strong>Evasione più rapida</strong> – le dashboard del bar mostrano ordini in arrivo, stato di preparazione e tempi di consegna in un unico posto.",
+        "payments": "<strong>Pagamenti flessibili</strong> – accetta credito del portafoglio, carte o pagamento al bancone mantenendo commissioni prevedibili.",
+        "insights": "<strong>Analisi utili</strong> – monitora incassi serali, pagamenti e clienti abituali senza fogli di calcolo."
+      }
+    },
+    "onboarding": {
+      "title": "Come funziona l'onboarding",
+      "steps": {
+        "one": "Mappiamo il tuo menù, le categorie e i prezzi in uno spazio di lavoro condiviso.",
+        "two": "Il personale riceve una sessione guidata su ordini live, notifiche e buone pratiche di servizio.",
+        "three": "Vai online con materiali marketing, codici QR e risorse di supporto su misura per il tuo locale."
+      }
+    },
+    "requirements": {
+      "title": "Cosa ti serve",
+      "items": {
+        "device": "Un tablet o laptop al bancone per monitorare gli ordini.",
+        "wifi": "Una connessione Wi-Fi affidabile per i dispositivi dello staff e per la scansione facoltativa dei QR dei clienti.",
+        "contact": "Un referente che gestisca pagamenti e aggiornamenti del menù."
+      }
+    },
+    "demo": {
+      "title": "Prenota una demo",
+      "cta": "Scrivici a <a href=\"mailto:{email}\">{email}</a> o chiama {phone} per scoprire come SiplyGo può supportare il tuo modello di servizio."
+    }
+  },
+  "terms": {
+    "title": "Termini d'uso",
+    "meta": "Versione {version} · In vigore dal {effective} · Prossima revisione {next_review}",
+    "intro": "Questi termini spiegano come SiplyGo offre i servizi a ospiti e partner. Creando un account o effettuando un ordine accetti le regole riportate di seguito.",
+    "sections": {
+      "eligibility": {
+        "title": "1. Requisiti e account",
+        "items": {
+          "age": "Devi avere almeno 18 anni e la capacità di stipulare un accordo vincolante.",
+          "credentials": "Mantieni le credenziali di accesso al sicuro e avvisaci subito se sospetti accessi non autorizzati.",
+          "suspend": "Possiamo sospendere o chiudere gli account che violano questi termini o le normative locali."
+        }
+      },
+      "ordering": {
+        "title": "2. Ordini e pagamenti",
+        "items": {
+          "fulfilment": "Gli ordini effettuati tramite SiplyGo sono evasi direttamente dal bar che scegli.",
+          "pricing": "I prezzi mostrati includono tasse o eventuali commissioni di servizio applicabili. La ricevuta finale sarà disponibile nello storico del tuo portafoglio.",
+          "refunds": "I rimborsi per cancellazioni o problemi con l'ordine sono gestiti congiuntamente da SiplyGo e dal locale."
+        }
+      },
+      "use": {
+        "title": "3. Uso consentito",
+        "items": {
+          "responsible": "Usa la piattaforma in modo responsabile ed evita attività che interrompono il servizio, tentano frodi o danneggiano ospiti e staff.",
+          "content": "I contenuti che invii, come le note agli ordini, devono essere rispettosi e accurati.",
+          "monitoring": "Monitoriamo l'utilizzo per mantenere l'esperienza sicura e possiamo rimuovere contenuti o limitare l'accesso quando necessario."
+        }
+      }
+    },
+    "contact": {
+      "title": "4. Contatti",
+      "body": "Per domande su questi termini o per segnalare un problema, scrivici a <a href=\"mailto:{email}\">{email}</a> o chiama <a href=\"tel:{phone_tel}\">{phone}</a>.",
+      "update": "Aggiorniamo questa pagina ogni volta che le policy cambiano. Continuando a utilizzare SiplyGo dopo gli aggiornamenti accetti i termini rivisti."
+    }
+  },
+  "wallet": {
+    "title": "Portafoglio",
+    "subtitle": "Gestisci il tuo saldo, ricarica all'istante e rivedi le attività recenti.",
+    "balance": {
+      "label": "Saldo attuale",
+      "available": "Disponibile"
+    },
+    "actions": {
+      "top_up": "Ricarica"
+    },
+    "activity": {
+      "title": "Attività recenti"
+    },
+    "tx": {
+      "topup": "Ricarica",
+      "refund": "Rimborso",
+      "refund_with_order": "Rimborso · Ordine n. {order_id}",
+      "order": "Ordine effettuato",
+      "order_with_bar": "Ordine effettuato · {bar}"
+    },
+    "empty": {
+      "title": "Nessuna transazione",
+      "body": "Le tue ricariche e i tuoi pagamenti appariranno qui.",
+      "cta": "Effettua la tua prima ricarica"
+    },
+    "status": {
+      "completed": "Completato",
+      "processing": "In elaborazione",
+      "pending": "In attesa",
+      "refunded": "Rimborsato",
+      "canceled": "Annullato",
+      "cancelled": "Annullato",
+      "failed": "Non riuscito"
+    }
   }
 }

--- a/templates/for_bars.html
+++ b/templates/for_bars.html
@@ -1,36 +1,36 @@
 {% extends "layout.html" %}
 {% block content %}
 <article class="static-page">
-  <h1>For Bars</h1>
-  <p>SiplyGo helps venues deliver quicker service, increase order value, and give staff clearer visibility into what guests need next.</p>
+  <h1>{{ _('for_bars.title', default='For Bars') }}</h1>
+  <p>{{ _('for_bars.intro', default='SiplyGo helps venues deliver quicker service, increase order value, and give staff clearer visibility into what guests need next.') }}</p>
   <section>
-    <h2>Why venues choose SiplyGo</h2>
+    <h2>{{ _('for_bars.why.title', default='Why venues choose SiplyGo') }}</h2>
     <ul>
-      <li><strong>Digital menus that stay fresh</strong> – highlight specials, mark items out of stock, and share allergen details instantly.</li>
-      <li><strong>Faster fulfilment</strong> – bar dashboards show incoming orders, prep status, and ready times in one place.</li>
-      <li><strong>Flexible payments</strong> – accept wallet credit, cards, or pay-at-bar while keeping transaction fees predictable.</li>
-      <li><strong>Insights that matter</strong> – track nightly revenue, payouts, and repeat guests without spreadsheets.</li>
+      <li>{{ _('for_bars.why.items.menus', default='<strong>Digital menus that stay fresh</strong> – highlight specials, mark items out of stock, and share allergen details instantly.')|safe }}</li>
+      <li>{{ _('for_bars.why.items.fulfilment', default='<strong>Faster fulfilment</strong> – bar dashboards show incoming orders, prep status, and ready times in one place.')|safe }}</li>
+      <li>{{ _('for_bars.why.items.payments', default='<strong>Flexible payments</strong> – accept wallet credit, cards, or pay-at-bar while keeping transaction fees predictable.')|safe }}</li>
+      <li>{{ _('for_bars.why.items.insights', default='<strong>Insights that matter</strong> – track nightly revenue, payouts, and repeat guests without spreadsheets.')|safe }}</li>
     </ul>
   </section>
   <section>
-    <h2>How onboarding works</h2>
+    <h2>{{ _('for_bars.onboarding.title', default='How onboarding works') }}</h2>
     <ol>
-      <li>We map your menu, categories, and pricing in a shared workspace.</li>
-      <li>Staff receive a walkthrough covering live orders, notifications, and service best practices.</li>
-      <li>Go live with marketing assets, QR codes, and support resources tailored to your bar.</li>
+      <li>{{ _('for_bars.onboarding.steps.one', default='We map your menu, categories, and pricing in a shared workspace.') }}</li>
+      <li>{{ _('for_bars.onboarding.steps.two', default='Staff receive a walkthrough covering live orders, notifications, and service best practices.') }}</li>
+      <li>{{ _('for_bars.onboarding.steps.three', default='Go live with marketing assets, QR codes, and support resources tailored to your bar.') }}</li>
     </ol>
   </section>
   <section>
-    <h2>What you need</h2>
+    <h2>{{ _('for_bars.requirements.title', default='What you need') }}</h2>
     <ul>
-      <li>A tablet or laptop behind the bar to monitor orders.</li>
-      <li>Reliable Wi-Fi for staff devices and optional guest QR scanning.</li>
-      <li>A point of contact to manage payouts and menu updates.</li>
+      <li>{{ _('for_bars.requirements.items.device', default='A tablet or laptop behind the bar to monitor orders.') }}</li>
+      <li>{{ _('for_bars.requirements.items.wifi', default='Reliable Wi-Fi for staff devices and optional guest QR scanning.') }}</li>
+      <li>{{ _('for_bars.requirements.items.contact', default='A point of contact to manage payouts and menu updates.') }}</li>
     </ul>
   </section>
   <section>
-    <h2>Schedule a demo</h2>
-    <p>Email <a href="mailto:{{ SUPPORT_EMAIL }}">{{ SUPPORT_EMAIL }}</a> or call {{ SUPPORT_NUMBER }} to learn how SiplyGo can support your service model.</p>
+    <h2>{{ _('for_bars.demo.title', default='Schedule a demo') }}</h2>
+    <p>{{ _('for_bars.demo.cta', email=SUPPORT_EMAIL, phone=SUPPORT_NUMBER, default='Email <a href="mailto:{email}">{email}</a> or call {phone} to learn how SiplyGo can support your service model.')|safe }}</p>
   </section>
 </article>
 {% endblock %}

--- a/templates/terms.html
+++ b/templates/terms.html
@@ -1,43 +1,39 @@
 {% extends "layout.html" %}
 {% block content %}
 <article class="static-page">
-  <h1>Terms of Use</h1>
+  <h1>{{ _('terms.title', default='Terms of Use') }}</h1>
   <p class="terms-meta">
-    Version {{ TERMS_VERSION }} · Effective {{ TERMS_EFFECTIVE_DATE }} · Next review {{ TERMS_NEXT_REVIEW_DATE }}
+    {{ _('terms.meta', version=TERMS_VERSION, effective=TERMS_EFFECTIVE_DATE, next_review=TERMS_NEXT_REVIEW_DATE, default='Version {version} · Effective {effective} · Next review {next_review}') }}
   </p>
-  <p>These terms explain how SiplyGo provides services to guests and bar partners. By creating an account or placing an order you agree to the rules below.</p>
+  <p>{{ _('terms.intro', default='These terms explain how SiplyGo provides services to guests and bar partners. By creating an account or placing an order you agree to the rules below.') }}</p>
   <section>
-    <h2>1. Eligibility and accounts</h2>
+    <h2>{{ _('terms.sections.eligibility.title', default='1. Eligibility and accounts') }}</h2>
     <ul>
-      <li>You must be at least 18 years old and able to form a binding agreement.</li>
-      <li>Keep your login credentials secure and notify us immediately if you suspect unauthorized access.</li>
-      <li>We may suspend or close accounts that violate these terms or local regulations.</li>
+      <li>{{ _('terms.sections.eligibility.items.age', default='You must be at least 18 years old and able to form a binding agreement.') }}</li>
+      <li>{{ _('terms.sections.eligibility.items.credentials', default='Keep your login credentials secure and notify us immediately if you suspect unauthorized access.') }}</li>
+      <li>{{ _('terms.sections.eligibility.items.suspend', default='We may suspend or close accounts that violate these terms or local regulations.') }}</li>
     </ul>
   </section>
   <section>
-    <h2>2. Ordering and payments</h2>
+    <h2>{{ _('terms.sections.ordering.title', default='2. Ordering and payments') }}</h2>
     <ul>
-      <li>Orders placed through SiplyGo are fulfilled directly by the bar you select.</li>
-      <li>Displayed prices include any applicable taxes or service fees. The final receipt will be available in your wallet history.</li>
-      <li>Refunds for cancellations or order issues are managed jointly by SiplyGo and the venue.</li>
+      <li>{{ _('terms.sections.ordering.items.fulfilment', default='Orders placed through SiplyGo are fulfilled directly by the bar you select.') }}</li>
+      <li>{{ _('terms.sections.ordering.items.pricing', default='Displayed prices include any applicable taxes or service fees. The final receipt will be available in your wallet history.') }}</li>
+      <li>{{ _('terms.sections.ordering.items.refunds', default='Refunds for cancellations or order issues are managed jointly by SiplyGo and the venue.') }}</li>
     </ul>
   </section>
   <section>
-    <h2>3. Acceptable use</h2>
+    <h2>{{ _('terms.sections.use.title', default='3. Acceptable use') }}</h2>
     <ul>
-      <li>Use the platform responsibly and avoid activities that disrupt service, attempt fraud, or harm other guests and staff.</li>
-      <li>Content you submit, such as order notes, must be respectful and accurate.</li>
-      <li>We monitor usage to keep the experience safe and may remove content or limit access when necessary.</li>
+      <li>{{ _('terms.sections.use.items.responsible', default='Use the platform responsibly and avoid activities that disrupt service, attempt fraud, or harm other guests and staff.') }}</li>
+      <li>{{ _('terms.sections.use.items.content', default='Content you submit, such as order notes, must be respectful and accurate.') }}</li>
+      <li>{{ _('terms.sections.use.items.monitoring', default='We monitor usage to keep the experience safe and may remove content or limit access when necessary.') }}</li>
     </ul>
   </section>
   <section>
-    <h2>4. Contact</h2>
-    <p>
-      For questions about these terms or to report an issue, email
-      <a href="mailto:{{ SUPPORT_EMAIL }}">{{ SUPPORT_EMAIL }}</a>
-      or call <a href="tel:{{ SUPPORT_NUMBER_TEL }}">{{ SUPPORT_NUMBER }}</a>.
-    </p>
-    <p>We update this page whenever policies change. Continued use of SiplyGo after updates means you accept the revised terms.</p>
+    <h2>{{ _('terms.contact.title', default='4. Contact') }}</h2>
+    <p>{{ _('terms.contact.body', email=SUPPORT_EMAIL, phone=SUPPORT_NUMBER, phone_tel=SUPPORT_NUMBER_TEL, default='For questions about these terms or to report an issue, email <a href="mailto:{email}">{email}</a> or call <a href="tel:{phone_tel}">{phone}</a>.')|safe }}</p>
+    <p>{{ _('terms.contact.update', default='We update this page whenever policies change. Continued use of SiplyGo after updates means you accept the revised terms.') }}</p>
   </section>
 </article>
 {% endblock %}

--- a/templates/wallet.html
+++ b/templates/wallet.html
@@ -2,24 +2,24 @@
 {% block content %}
 <section class="wallet-page">
   <div class="wallet-head">
-    <h1 class="wallet-title">Wallet</h1>
-    <p class="wallet-subtitle">Manage your balance, top up instantly, and review your recent activity.</p>
+    <h1 class="wallet-title">{{ _('wallet.title', default='Wallet') }}</h1>
+    <p class="wallet-subtitle">{{ _('wallet.subtitle', default='Manage your balance, top up instantly, and review your recent activity.') }}</p>
   </div>
 
   <div class="balance-card card">
     <div class="balance-left">
-      <span class="label">Current balance</span>
+      <span class="label">{{ _('wallet.balance.label', default='Current balance') }}</span>
       <div class="amount">CHF {{ "%.2f"|format(user.credit) }}</div>
-      <div class="meta"><span class="badge success">Available</span></div>
+      <div class="meta"><span class="badge success">{{ _('wallet.balance.available', default='Available') }}</span></div>
     </div>
   <div class="balance-right wallet-actions">
-      <a href="/topup" class="btn-primary">Top Up</a>
+      <a href="/topup" class="btn-primary">{{ _('wallet.actions.top_up', default='Top Up') }}</a>
   </div>
   </div>
 
   <div class="card tx-feed">
     <div class="tx-head">
-      <h2 class="section-title">Recent Activity</h2>
+      <h2 class="section-title">{{ _('wallet.activity.title', default='Recent Activity') }}</h2>
     </div>
 
     {% if transactions %}
@@ -32,11 +32,19 @@
             <div class="tx-main">
               <div class="tx-title">
                 {% if ttype == 'topup' %}
-                  Top up
+                  {{ _('wallet.tx.topup', default='Top up') }}
                 {% elif ttype == 'refund' %}
-                  Refund{% if tx.order_id is defined %} · Order #{{ tx.order_id }}{% endif %}
+                  {% if tx.order_id is defined %}
+                    {{ _('wallet.tx.refund_with_order', order_id=tx.order_id, default='Refund · Order #{order_id}') }}
+                  {% else %}
+                    {{ _('wallet.tx.refund', default='Refund') }}
+                  {% endif %}
                 {% else %}
-                  Order placed{% if tx.bar_name is defined %} · {{ tx.bar_name }}{% endif %}
+                  {% if tx.bar_name is defined %}
+                    {{ _('wallet.tx.order_with_bar', bar=tx.bar_name, default='Order placed · {bar}') }}
+                  {% else %}
+                    {{ _('wallet.tx.order', default='Order placed') }}
+                  {% endif %}
                 {% endif %}
               </div>
               <div class="tx-sub">
@@ -55,7 +63,7 @@
                 {% if ttype == 'payment' %}-{% else %}+{% endif %} CHF {{ "%.2f"|format(tx.total) }}
               </div>
               {% set status = tx.status if tx.status is defined else 'COMPLETED' %}
-              <span class="pill {% if status|lower in ['processing','pending'] %}pending{% elif status|lower == 'refunded' %}refunded{% elif status|lower in ['canceled','cancelled','failed'] %}canceled{% else %}success{% endif %}">{{ status|replace('_',' ')|title }}</span>
+              <span class="pill {% if status|lower in ['processing','pending'] %}pending{% elif status|lower == 'refunded' %}refunded{% elif status|lower in ['canceled','cancelled','failed'] %}canceled{% else %}success{% endif %}">{{ _('wallet.status.' ~ status|lower, default=status.replace('_',' ')|title) }}</span>
             </div>
           </div>
         </li>
@@ -64,9 +72,9 @@
     </div>
     {% else %}
     <div class="empty" aria-live="polite">
-      <h3>No transactions yet</h3>
-      <p>Your top ups and payments will appear here.</p>
-      <a class="btn-primary" href="/topup">Make your first top up</a>
+      <h3>{{ _('wallet.empty.title', default='No transactions yet') }}</h3>
+      <p>{{ _('wallet.empty.body', default='Your top ups and payments will appear here.') }}</p>
+      <a class="btn-primary" href="/topup">{{ _('wallet.empty.cta', default='Make your first top up') }}</a>
     </div>
     {% endif %}
 


### PR DESCRIPTION
## Summary
- internationalize the For Bars, Terms, and Wallet templates so they render localized copy via the translation helper
- add English and Italian resources for the new `for_bars`, `terms`, and `wallet` namespaces
- note the new namespaces in `AGENTS.md` for future translators

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9936d531483208971476906ebf5cc