### PR TITLE
Translate login and registration pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -371,3 +371,8 @@
 - About page strings live under the `about` namespace in `app/i18n/translations/*.json`; `templates/about.html` pulls from these keys.
 - Help Center page strings live under the `help_center` namespace in `app/i18n/translations/*.json`; `templates/help_center.html` pulls from these keys.
 - "For Bars", "Terms", and "Wallet" pages localize through `for_bars`, `terms`, and `wallet` namespaces inside `app/i18n/translations/*.json`.
+
+- Login page strings live under the `login` namespace in `app/i18n/translations/*.json`; `templates/login.html` pulls from these keys.
+- Registration step one page strings live under the `register_step1` namespace in `app/i18n/translations/*.json`; `templates/register_step1.html` pulls from these keys.
+- Registration details page strings live under the `register` namespace in `app/i18n/translations/*.json`; `templates/register.html` pulls from these keys.
+- Shared authentication UI strings (password toggles, caps lock warning) live under the `auth` namespace in `app/i18n/translations/*.json`.

--- a/app/i18n/translations/en.json
+++ b/app/i18n/translations/en.json
@@ -259,5 +259,75 @@
       "cancelled": "Cancelled",
       "failed": "Failed"
     }
+  },
+  "auth": {
+    "password_toggle": {
+      "show": "Show password",
+      "hide": "Hide password"
+    },
+    "caps_warning": "Caps Lock is on",
+    "password_mismatch": "Passwords must match"
+  },
+  "login": {
+    "title": "Login",
+    "fields": {
+      "email": {
+        "label": "Email"
+      },
+      "password": {
+        "label": "Password"
+      }
+    },
+    "actions": {
+      "submit": "Login",
+      "register_prompt": "Not registered yet? <a href=\"/register\">Register</a>"
+    }
+  },
+  "register_step1": {
+    "title": "Register",
+    "fields": {
+      "email": {
+        "label": "Email",
+        "title": "Email must be in the format text@text.text"
+      },
+      "password": {
+        "label": "Password",
+        "title": "Password must be between 8 and 128 characters"
+      },
+      "confirm_password": {
+        "label": "Confirm Password"
+      }
+    },
+    "disclaimer": "By registering you accept our <a href=\"/terms\">Terms of Service</a>.",
+    "actions": {
+      "submit": "Next",
+      "login_prompt": "Already registered? <a href=\"/login\">Log in</a>"
+    }
+  },
+  "register": {
+    "title": "Complete Registration",
+    "fields": {
+      "username": {
+        "label": "Username",
+        "title": "3–24 characters, lowercase letters, numbers, dot, hyphen or underscore. No spaces."
+      },
+      "prefix": {
+        "label": "Phone Prefix"
+      },
+      "phone": {
+        "label": "Phone Number",
+        "title": "Phone number must be 9 to 10 digits"
+      }
+    },
+    "options": {
+      "ch": "+41 (Switzerland)",
+      "it": "+39 (Italy)",
+      "de": "+49 (Germany)",
+      "fr": "+33 (France)"
+    },
+    "disclaimer": "By finishing your registration you accept our <a href=\"/terms\">Terms of Service</a>.",
+    "actions": {
+      "submit": "Finish"
+    }
   }
 }

--- a/app/i18n/translations/it.json
+++ b/app/i18n/translations/it.json
@@ -259,5 +259,75 @@
       "cancelled": "Annullato",
       "failed": "Non riuscito"
     }
+  },
+  "auth": {
+    "password_toggle": {
+      "show": "Mostra password",
+      "hide": "Nascondi password"
+    },
+    "caps_warning": "Bloc Maiusc attivo",
+    "password_mismatch": "Le password devono coincidere"
+  },
+  "login": {
+    "title": "Accedi",
+    "fields": {
+      "email": {
+        "label": "Email"
+      },
+      "password": {
+        "label": "Password"
+      }
+    },
+    "actions": {
+      "submit": "Accedi",
+      "register_prompt": "Non sei ancora registrato? <a href=\"/register\">Registrati</a>"
+    }
+  },
+  "register_step1": {
+    "title": "Registrati",
+    "fields": {
+      "email": {
+        "label": "Email",
+        "title": "L'email deve avere il formato testo@testo.testo"
+      },
+      "password": {
+        "label": "Password",
+        "title": "La password deve contenere tra 8 e 128 caratteri"
+      },
+      "confirm_password": {
+        "label": "Conferma password"
+      }
+    },
+    "disclaimer": "Registrandoti accetti i nostri <a href=\"/terms\">Termini di servizio</a>.",
+    "actions": {
+      "submit": "Avanti",
+      "login_prompt": "Già registrato? <a href=\"/login\">Accedi</a>"
+    }
+  },
+  "register": {
+    "title": "Completa la registrazione",
+    "fields": {
+      "username": {
+        "label": "Nome utente",
+        "title": "3-24 caratteri, lettere minuscole, numeri, punto, trattino o underscore. Niente spazi."
+      },
+      "prefix": {
+        "label": "Prefisso telefonico"
+      },
+      "phone": {
+        "label": "Numero di telefono",
+        "title": "Phone number must be 9 to 10 digits"
+      }
+    },
+    "options": {
+      "ch": "+41 (Svizzera)",
+      "it": "+39 (Italia)",
+      "de": "+49 (Germania)",
+      "fr": "+33 (Francia)"
+    },
+    "disclaimer": "Completando la registrazione accetti i nostri <a href=\"/terms\">Termini di servizio</a>.",
+    "actions": {
+      "submit": "Completa"
+    }
   }
 }

--- a/static/js/password.js
+++ b/static/js/password.js
@@ -4,10 +4,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const toggle = wrapper.querySelector('.toggle-password');
     const warning = wrapper.parentElement.querySelector('.caps-warning');
     if (toggle && input) {
+      const showLabel = toggle.dataset.showLabel || 'Show password';
+      const hideLabel = toggle.dataset.hideLabel || 'Hide password';
       toggle.addEventListener('click', () => {
         const isPassword = input.type === 'password';
         input.type = isPassword ? 'text' : 'password';
-        toggle.setAttribute('aria-label', isPassword ? 'Hide password' : 'Show password');
+        toggle.setAttribute('aria-label', isPassword ? hideLabel : showLabel);
       });
       input.addEventListener('keyup', e => {
         if (warning) warning.hidden = !e.getModifierState('CapsLock');
@@ -20,8 +22,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const password = document.getElementById('password');
   const confirm = document.getElementById('confirm_password');
   if (password && confirm) {
+    const mismatchMessage = confirm.dataset.mismatchMessage || 'Passwords must match';
     const validate = () => {
-      confirm.setCustomValidity(confirm.value !== password.value ? 'Passwords must match' : '');
+      confirm.setCustomValidity(confirm.value !== password.value ? mismatchMessage : '');
     };
     password.addEventListener('input', validate);
     confirm.addEventListener('input', validate);

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,24 +1,24 @@
 {% extends "layout.html" %}
 {% block content %}
 <div class="auth-card">
-  <h1>Login</h1>
+  <h1>{{ _('login.title', default='Login') }}</h1>
   {% if error %}<p class="alert">{{ error }}</p>{% endif %}
   <form method="post" action="/login">
-    <label for="email">Email
+    <label for="email">{{ _('login.fields.email.label', default='Email') }}
       <input id="email" type="email" name="email" required autocomplete="email" inputmode="email" enterkeyhint="next">
     </label>
-    <label for="password">Password
+    <label for="password">{{ _('login.fields.password.label', default='Password') }}
       <div class="password-wrapper">
         <input id="password" type="password" name="password" required autocomplete="current-password" enterkeyhint="done" maxlength="128">
-        <button type="button" class="toggle-password" aria-label="Show password"><i class="bi bi-eye"></i></button>
+        <button type="button" class="toggle-password" aria-label="{{ _('auth.password_toggle.show', default='Show password') }}" data-show-label="{{ _('auth.password_toggle.show', default='Show password') }}" data-hide-label="{{ _('auth.password_toggle.hide', default='Hide password') }}"><i class="bi bi-eye"></i></button>
       </div>
-      <span id="capsWarning" class="caps-warning" hidden>Caps Lock is on</span>
+      <span id="capsWarning" class="caps-warning" hidden>{{ _('auth.caps_warning', default='Caps Lock is on') }}</span>
     </label>
     <input type="hidden" name="latitude" id="latitude">
     <input type="hidden" name="longitude" id="longitude">
-    <button class="btn btn--primary" type="submit">Login</button>
+    <button class="btn btn--primary" type="submit">{{ _('login.actions.submit', default='Login') }}</button>
   </form>
-  <p style="align-self:center">Not registered yet? <a href="/register">Register</a></p>
+  <p style="align-self:center">{{ _('login.actions.register_prompt', default="Not registered yet? <a href=\"/register\">Register</a>")|safe }}</p>
 </div>
 {% endblock %}
 

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,25 +1,25 @@
 {% extends "layout.html" %}
 {% block content %}
 <div class="auth-card">
-  <h1>Complete Registration</h1>
+  <h1>{{ _('register.title', default='Complete Registration') }}</h1>
   {% if error %}<p class="alert">{{ error }}</p>{% endif %}
   <form method="post" action="/register/details">
-    <label for="username">Username
-      <input id="username" type="text" name="username" required autocomplete="username" inputmode="text" enterkeyhint="next" minlength="3" maxlength="24" pattern="(?![._-])(?!.*[._-]{2})(?!.*[._-]$)[a-z0-9._-]{3,24}" title="3–24 characters, lowercase letters, numbers, dot, hyphen or underscore. No spaces." value="{{ username|default('') }}">
+    <label for="username">{{ _('register.fields.username.label', default='Username') }}
+      <input id="username" type="text" name="username" required autocomplete="username" inputmode="text" enterkeyhint="next" minlength="3" maxlength="24" pattern="(?![._-])(?!.*[._-]{2})(?!.*[._-]$)[a-z0-9._-]{3,24}" title="{{ _('register.fields.username.title', default='3–24 characters, lowercase letters, numbers, dot, hyphen or underscore. No spaces.') }}" value="{{ username|default('') }}">
     </label>
-    <label for="prefix">Phone Prefix
+    <label for="prefix">{{ _('register.fields.prefix.label', default='Phone Prefix') }}
       <select id="prefix" name="prefix" required autocomplete="tel-country-code">
-        <option value="+41" {% if prefix == "+41" %}selected{% endif %}>+41 (Switzerland)</option>
-        <option value="+39" {% if prefix == "+39" %}selected{% endif %}>+39 (Italy)</option>
-        <option value="+49" {% if prefix == "+49" %}selected{% endif %}>+49 (Germany)</option>
-        <option value="+33" {% if prefix == "+33" %}selected{% endif %}>+33 (France)</option>
+        <option value="+41" {% if prefix == "+41" %}selected{% endif %}>{{ _('register.options.ch', default='+41 (Switzerland)') }}</option>
+        <option value="+39" {% if prefix == "+39" %}selected{% endif %}>{{ _('register.options.it', default='+39 (Italy)') }}</option>
+        <option value="+49" {% if prefix == "+49" %}selected{% endif %}>{{ _('register.options.de', default='+49 (Germany)') }}</option>
+        <option value="+33" {% if prefix == "+33" %}selected{% endif %}>{{ _('register.options.fr', default='+33 (France)') }}</option>
       </select>
     </label>
-    <label for="phone">Phone Number
-      <input id="phone" type="tel" name="phone" required autocomplete="tel-national" inputmode="tel" enterkeyhint="done" pattern="[0-9]{9,10}" minlength="9" maxlength="10" title="Phone number must be 9 to 10 digits" value="{{ phone|default('') }}">
+    <label for="phone">{{ _('register.fields.phone.label', default='Phone Number') }}
+      <input id="phone" type="tel" name="phone" required autocomplete="tel-national" inputmode="tel" enterkeyhint="done" pattern="[0-9]{9,10}" minlength="9" maxlength="10" title="{{ _('register.fields.phone.title', default='Phone number must be 9 to 10 digits') }}" value="{{ phone|default('') }}">
     </label>
-    <p class="auth-card__disclaimer">By finishing your registration you accept our <a href="/terms">Terms of Service</a>.</p>
-    <button class="btn btn--primary" type="submit">Finish</button>
+    <p class="auth-card__disclaimer">{{ _('register.disclaimer', default="By finishing your registration you accept our <a href=\"/terms\">Terms of Service</a>.")|safe }}</p>
+    <button class="btn btn--primary" type="submit">{{ _('register.actions.submit', default='Finish') }}</button>
   </form>
 </div>
 {% endblock %}

--- a/templates/register_step1.html
+++ b/templates/register_step1.html
@@ -1,30 +1,30 @@
 {% extends "layout.html" %}
 {% block content %}
 <div class="auth-card">
-  <h1>Register</h1>
+  <h1>{{ _('register_step1.title', default='Register') }}</h1>
   {% if error %}<p class="alert">{{ error }}</p>{% endif %}
   <form method="post" action="/register">
-    <label for="email">Email
-      <input id="email" type="email" name="email" required autocomplete="email" inputmode="email" enterkeyhint="next" pattern="[^@]+@[^@]+\.[^@]+" title="Email must be in the format text@text.text" value="{{ email|default('') }}">
+    <label for="email">{{ _('register_step1.fields.email.label', default='Email') }}
+      <input id="email" type="email" name="email" required autocomplete="email" inputmode="email" enterkeyhint="next" pattern="[^@]+@[^@]+\.[^@]+" title="{{ _('register_step1.fields.email.title', default='Email must be in the format text@text.text') }}" value="{{ email|default('') }}">
     </label>
-    <label for="password">Password
+    <label for="password">{{ _('register_step1.fields.password.label', default='Password') }}
       <div class="password-wrapper">
-        <input id="password" type="password" name="password" required autocomplete="new-password" enterkeyhint="next" minlength="8" maxlength="128" title="Password must be between 8 and 128 characters">
-        <button type="button" class="toggle-password" aria-label="Show password"><i class="bi bi-eye"></i></button>
+        <input id="password" type="password" name="password" required autocomplete="new-password" enterkeyhint="next" minlength="8" maxlength="128" title="{{ _('register_step1.fields.password.title', default='Password must be between 8 and 128 characters') }}">
+        <button type="button" class="toggle-password" aria-label="{{ _('auth.password_toggle.show', default='Show password') }}" data-show-label="{{ _('auth.password_toggle.show', default='Show password') }}" data-hide-label="{{ _('auth.password_toggle.hide', default='Hide password') }}"><i class="bi bi-eye"></i></button>
       </div>
-      <span id="capsWarning" class="caps-warning" hidden>Caps Lock is on</span>
+      <span id="capsWarning" class="caps-warning" hidden>{{ _('auth.caps_warning', default='Caps Lock is on') }}</span>
     </label>
-    <label for="confirm_password">Confirm Password
+    <label for="confirm_password">{{ _('register_step1.fields.confirm_password.label', default='Confirm Password') }}
       <div class="password-wrapper">
-        <input id="confirm_password" type="password" name="confirm_password" required autocomplete="new-password" enterkeyhint="done" minlength="8" maxlength="128" title="Passwords must match">
-        <button type="button" class="toggle-password" aria-label="Show password"><i class="bi bi-eye"></i></button>
+        <input id="confirm_password" type="password" name="confirm_password" required autocomplete="new-password" enterkeyhint="done" minlength="8" maxlength="128" title="{{ _('auth.password_mismatch', default='Passwords must match') }}" data-mismatch-message="{{ _('auth.password_mismatch', default='Passwords must match') }}">
+        <button type="button" class="toggle-password" aria-label="{{ _('auth.password_toggle.show', default='Show password') }}" data-show-label="{{ _('auth.password_toggle.show', default='Show password') }}" data-hide-label="{{ _('auth.password_toggle.hide', default='Hide password') }}"><i class="bi bi-eye"></i></button>
       </div>
-      <span id="capsWarningConfirm" class="caps-warning" hidden>Caps Lock is on</span>
+      <span id="capsWarningConfirm" class="caps-warning" hidden>{{ _('auth.caps_warning', default='Caps Lock is on') }}</span>
     </label>
-    <p class="auth-card__disclaimer">By registering you accept our <a href="/terms">Terms of Service</a>.</p>
-    <button class="btn btn--primary" type="submit">Next</button>
+    <p class="auth-card__disclaimer">{{ _('register_step1.disclaimer', default="By registering you accept our <a href=\"/terms\">Terms of Service</a>.")|safe }}</p>
+    <button class="btn btn--primary" type="submit">{{ _('register_step1.actions.submit', default='Next') }}</button>
   </form>
-  <p style="align-self:center">Already registered? <a href="/login">Log in</a></p>
+  <p style="align-self:center">{{ _('register_step1.actions.login_prompt', default="Already registered? <a href=\"/login\">Log in</a>")|safe }}</p>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- localize the login, registration step one, and registration detail templates with translation helpers
- add English and Italian copy for the new auth namespaces and shared UI strings
- update the password toggle script to use localized labels and reuse translated mismatch messaging
- document the new translation namespaces in AGENTS.md for future work

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9b70745288320a6bcb2897f1cc0e3