### PR TITLE
Localize profile and password pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -376,3 +376,6 @@
 - Registration step one page strings live under the `register_step1` namespace in `app/i18n/translations/*.json`; `templates/register_step1.html` pulls from these keys.
 - Registration details page strings live under the `register` namespace in `app/i18n/translations/*.json`; `templates/register.html` pulls from these keys.
 - Shared authentication UI strings (password toggles, caps lock warning) live under the `auth` namespace in `app/i18n/translations/*.json`.
+- Profile page strings live under the `profile` namespace in `app/i18n/translations/*.json`; `templates/profile.html` pulls from these keys and reuses the registration phone prefix options.
+- Change Password page strings live under the `change_password` namespace in `app/i18n/translations/*.json`; `templates/change_password.html` also uses shared `auth` password toggle labels.
+- Order confirmation copy in `templates/order_success.html` localises through the `order_success` namespace in `app/i18n/translations/*.json`.

--- a/app/i18n/translations/en.json
+++ b/app/i18n/translations/en.json
@@ -329,5 +329,82 @@
     "actions": {
       "submit": "Finish"
     }
+  },
+  "profile": {
+    "title": "Profile",
+    "subtitle": "Manage your account, security, and phone number.",
+    "alerts": {
+      "success": "Profile updated successfully."
+    },
+    "fields": {
+      "username": {
+        "label": "Username",
+        "title": "3–24 characters, lowercase letters, numbers, dot, hyphen or underscore. No spaces."
+      },
+      "email": {
+        "label": "Email",
+        "title": "Email must be in the format text@text.text"
+      },
+      "prefix": {
+        "label": "Phone Prefix"
+      },
+      "phone": {
+        "label": "Phone Number",
+        "title": "Phone number must be 9 to 10 digits"
+      }
+    },
+    "help": {
+      "phone": "Use mobile format for your country."
+    },
+    "actions": {
+      "change_password": "Change Password",
+      "save": "Save"
+    },
+    "aria": {
+      "edit_username": "Edit username",
+      "edit_email": "Edit email",
+      "edit_prefix": "Edit phone prefix",
+      "edit_phone": "Edit phone number"
+    }
+  },
+  "change_password": {
+    "title": "Change Password",
+    "subtitle": "Update your account password.",
+    "alerts": {
+      "success": "Password updated successfully."
+    },
+    "fields": {
+      "current_password": {
+        "label": "Current Password",
+        "title": "Password must be between 8 and 128 characters"
+      },
+      "new_password": {
+        "label": "New Password",
+        "title": "Password must be between 8 and 128 characters"
+      },
+      "confirm_password": {
+        "label": "Confirm Password",
+        "title": "Passwords must match"
+      }
+    },
+    "help": {
+      "strength": "Use 8+ characters with letters & numbers."
+    },
+    "actions": {
+      "save": "Save"
+    }
+  },
+  "order_success": {
+    "title": "Order Placed",
+    "body": {
+      "success": "Your order has been placed successfully!",
+      "total": "Total paid: CHF {total}",
+      "payment_method": "Payment method: {method}",
+      "remaining": "Remaining credit: CHF {remaining}",
+      "thanks": "Thank you for ordering with SiplyGo."
+    },
+    "actions": {
+      "home": "Return to home"
+    }
   }
 }

--- a/app/i18n/translations/it.json
+++ b/app/i18n/translations/it.json
@@ -329,5 +329,82 @@
     "actions": {
       "submit": "Completa"
     }
+  },
+  "profile": {
+    "title": "Profilo",
+    "subtitle": "Gestisci il tuo account, la sicurezza e il numero di telefono.",
+    "alerts": {
+      "success": "Profilo aggiornato con successo."
+    },
+    "fields": {
+      "username": {
+        "label": "Nome utente",
+        "title": "3-24 caratteri, lettere minuscole, numeri, punto, trattino o underscore. Niente spazi."
+      },
+      "email": {
+        "label": "Email",
+        "title": "L'email deve avere il formato testo@testo.testo"
+      },
+      "prefix": {
+        "label": "Prefisso telefonico"
+      },
+      "phone": {
+        "label": "Numero di telefono",
+        "title": "Il numero di telefono deve contenere da 9 a 10 cifre."
+      }
+    },
+    "help": {
+      "phone": "Usa il formato mobile del tuo paese."
+    },
+    "actions": {
+      "change_password": "Cambia password",
+      "save": "Salva"
+    },
+    "aria": {
+      "edit_username": "Modifica nome utente",
+      "edit_email": "Modifica email",
+      "edit_prefix": "Modifica prefisso telefonico",
+      "edit_phone": "Modifica numero di telefono"
+    }
+  },
+  "change_password": {
+    "title": "Cambia password",
+    "subtitle": "Aggiorna la password del tuo account.",
+    "alerts": {
+      "success": "Password aggiornata con successo."
+    },
+    "fields": {
+      "current_password": {
+        "label": "Password attuale",
+        "title": "La password deve contenere tra 8 e 128 caratteri"
+      },
+      "new_password": {
+        "label": "Nuova password",
+        "title": "La password deve contenere tra 8 e 128 caratteri"
+      },
+      "confirm_password": {
+        "label": "Conferma password",
+        "title": "Le password devono coincidere"
+      }
+    },
+    "help": {
+      "strength": "Usa almeno 8 caratteri con lettere e numeri."
+    },
+    "actions": {
+      "save": "Salva"
+    }
+  },
+  "order_success": {
+    "title": "Ordine inviato",
+    "body": {
+      "success": "Il tuo ordine è stato inviato con successo!",
+      "total": "Totale pagato: CHF {total}",
+      "payment_method": "Metodo di pagamento: {method}",
+      "remaining": "Credito residuo: CHF {remaining}",
+      "thanks": "Grazie per aver ordinato con SiplyGo."
+    },
+    "actions": {
+      "home": "Torna alla home"
+    }
   }
 }

--- a/templates/change_password.html
+++ b/templates/change_password.html
@@ -3,41 +3,41 @@
 <section class="profile-page change-password-page">
   <div class="profile-card">
     <div class="profile-head">
-      <h1 class="profile-title">Change Password</h1>
-      <p class="profile-subtitle">Update your account password.</p>
+      <h1 class="profile-title">{{ _('change_password.title', default='Change Password') }}</h1>
+      <p class="profile-subtitle">{{ _('change_password.subtitle', default='Update your account password.') }}</p>
     </div>
-    {% if success %}<p class="alert alert-success">Password updated successfully.</p>{% endif %}
+    {% if success %}<p class="alert alert-success">{{ _('change_password.alerts.success', default='Password updated successfully.') }}</p>{% endif %}
     {% if error %}<p class="alert alert-danger">{{ error }}</p>{% endif %}
     <form method="post" action="/profile/password" class="profile-form">
       <div class="form-grid">
         <div class="field" data-name="current-password">
-          <label for="current_password" class="block-label">Current Password</label>
+          <label for="current_password" class="block-label">{{ _('change_password.fields.current_password.label', default='Current Password') }}</label>
           <div class="password-wrapper input-with-icon">
-            <input id="current_password" type="password" name="current_password" autocomplete="current-password" enterkeyhint="next" minlength="8" maxlength="128" title="Password must be between 8 and 128 characters">
-            <button type="button" class="toggle-password icon" aria-label="Show password"><i class="bi bi-eye"></i></button>
+            <input id="current_password" type="password" name="current_password" autocomplete="current-password" enterkeyhint="next" minlength="8" maxlength="128" title="{{ _('change_password.fields.current_password.title', default='Password must be between 8 and 128 characters') }}">
+            <button type="button" class="toggle-password icon" aria-label="{{ _('auth.password_toggle.show', default='Show password') }}" data-show-label="{{ _('auth.password_toggle.show', default='Show password') }}" data-hide-label="{{ _('auth.password_toggle.hide', default='Hide password') }}"><i class="bi bi-eye"></i></button>
           </div>
-          <span id="capsWarningCurrent" class="caps-warning" hidden>Caps Lock is on</span>
+          <span id="capsWarningCurrent" class="caps-warning" hidden>{{ _('auth.caps_warning', default='Caps Lock is on') }}</span>
         </div>
         <div class="field" data-name="new-password">
-          <label for="password" class="block-label">New Password</label>
+          <label for="password" class="block-label">{{ _('change_password.fields.new_password.label', default='New Password') }}</label>
           <div class="password-wrapper input-with-icon">
-            <input id="password" type="password" name="password" autocomplete="new-password" enterkeyhint="next" minlength="8" maxlength="128" title="Password must be between 8 and 128 characters">
-            <button type="button" class="toggle-password icon" aria-label="Show password"><i class="bi bi-eye"></i></button>
+            <input id="password" type="password" name="password" autocomplete="new-password" enterkeyhint="next" minlength="8" maxlength="128" title="{{ _('change_password.fields.new_password.title', default='Password must be between 8 and 128 characters') }}">
+            <button type="button" class="toggle-password icon" aria-label="{{ _('auth.password_toggle.show', default='Show password') }}" data-show-label="{{ _('auth.password_toggle.show', default='Show password') }}" data-hide-label="{{ _('auth.password_toggle.hide', default='Hide password') }}"><i class="bi bi-eye"></i></button>
           </div>
-          <span id="capsWarning" class="caps-warning" hidden>Caps Lock is on</span>
-          <small class="help">Use 8+ characters with letters &amp; numbers.</small>
+          <span id="capsWarning" class="caps-warning" hidden>{{ _('auth.caps_warning', default='Caps Lock is on') }}</span>
+          <small class="help">{{ _('change_password.help.strength', default='Use 8+ characters with letters & numbers.') }}</small>
         </div>
         <div class="field" data-name="confirm-password">
-          <label for="confirm_password" class="block-label">Confirm Password</label>
+          <label for="confirm_password" class="block-label">{{ _('change_password.fields.confirm_password.label', default='Confirm Password') }}</label>
           <div class="password-wrapper input-with-icon">
-            <input id="confirm_password" type="password" name="confirm_password" autocomplete="new-password" enterkeyhint="done" minlength="8" maxlength="128" title="Passwords must match">
-            <button type="button" class="toggle-password icon" aria-label="Show password"><i class="bi bi-eye"></i></button>
+            <input id="confirm_password" type="password" name="confirm_password" autocomplete="new-password" enterkeyhint="done" minlength="8" maxlength="128" title="{{ _('change_password.fields.confirm_password.title', default='Passwords must match') }}" data-mismatch-message="{{ _('auth.password_mismatch', default='Passwords must match') }}">
+            <button type="button" class="toggle-password icon" aria-label="{{ _('auth.password_toggle.show', default='Show password') }}" data-show-label="{{ _('auth.password_toggle.show', default='Show password') }}" data-hide-label="{{ _('auth.password_toggle.hide', default='Hide password') }}"><i class="bi bi-eye"></i></button>
           </div>
-          <span id="capsWarningConfirm" class="caps-warning" hidden>Caps Lock is on</span>
+          <span id="capsWarningConfirm" class="caps-warning" hidden>{{ _('auth.caps_warning', default='Caps Lock is on') }}</span>
         </div>
       </div>
       <div class="sticky-actions">
-        <button class="btn btn--primary" type="submit">Save</button>
+        <button class="btn btn--primary" type="submit">{{ _('change_password.actions.save', default='Save') }}</button>
       </div>
     </form>
   </div>

--- a/templates/order_success.html
+++ b/templates/order_success.html
@@ -1,14 +1,17 @@
 {% extends "layout.html" %}
 {% block content %}
 <div class="text-center">
-  <h1>Order Placed</h1>
-  <p>Your order has been placed successfully!</p>
-  <p>Total paid: CHF {{ "%.2f"|format(total) }}</p>
-  <p>Payment method: {{ payment_method.replace('_', ' ')|title }}</p>
+  {% set formatted_total = "%.2f"|format(total) %}
+  {% set method_label = payment_method.replace('_', ' ')|title %}
+  <h1>{{ _('order_success.title', default='Order Placed') }}</h1>
+  <p>{{ _('order_success.body.success', default='Your order has been placed successfully!') }}</p>
+  <p>{{ _('order_success.body.total', total=formatted_total, default='Total paid: CHF {total}') }}</p>
+  <p>{{ _('order_success.body.payment_method', method=method_label, default='Payment method: {method}') }}</p>
   {% if payment_method == 'wallet' %}
-  <p>Remaining credit: CHF {{ "%.2f"|format(remaining) }}</p>
+  {% set formatted_remaining = "%.2f"|format(remaining) %}
+  <p>{{ _('order_success.body.remaining', remaining=formatted_remaining, default='Remaining credit: CHF {remaining}') }}</p>
   {% endif %}
-  <p>Thank you for ordering with SiplyGo.</p>
-  <a class="btn btn--primary" href="/">Return to home</a>
+  <p>{{ _('order_success.body.thanks', default='Thank you for ordering with SiplyGo.') }}</p>
+  <a class="btn btn--primary" href="/">{{ _('order_success.actions.home', default='Return to home') }}</a>
 </div>
 {% endblock %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -3,51 +3,51 @@
 <section class="profile-page">
   <div class="profile-card">
     <div class="profile-head">
-      <h1 class="profile-title">Profile</h1>
-      <p class="profile-subtitle">Manage your account, security, and phone number.</p>
+      <h1 class="profile-title">{{ _('profile.title', default='Profile') }}</h1>
+      <p class="profile-subtitle">{{ _('profile.subtitle', default='Manage your account, security, and phone number.') }}</p>
     </div>
-    {% if success %}<p class="alert alert-success">Profile updated successfully.</p>{% endif %}
+    {% if success %}<p class="alert alert-success">{{ _('profile.alerts.success', default='Profile updated successfully.') }}</p>{% endif %}
     {% if error %}<p class="alert alert-danger">{{ error }}</p>{% endif %}
     <form method="post" action="/profile" id="profile-form" class="profile-form">
       <div class="form-grid">
         <div class="field" data-name="username">
-          <label for="username" class="block-label">Username</label>
+          <label for="username" class="block-label">{{ _('profile.fields.username.label', default='Username') }}</label>
           <div class="input-with-icon">
-            <input id="username" type="text" name="username" required autocomplete="username" inputmode="text" enterkeyhint="next" minlength="3" maxlength="24" pattern="(?![._-])(?!.*[._-]{2})(?!.*[._-]$)[a-z0-9._-]{3,24}" title="3–24 characters, lowercase letters, numbers, dot, hyphen or underscore. No spaces." value="{{ username|default(user.username) }}" disabled>
-            <button type="button" class="edit-btn icon" aria-label="Edit username"><i class="bi bi-pencil-square"></i></button>
+            <input id="username" type="text" name="username" required autocomplete="username" inputmode="text" enterkeyhint="next" minlength="3" maxlength="24" pattern="(?![._-])(?!.*[._-]{2})(?!.*[._-]$)[a-z0-9._-]{3,24}" title="{{ _('profile.fields.username.title', default='3–24 characters, lowercase letters, numbers, dot, hyphen or underscore. No spaces.') }}" value="{{ username|default(user.username) }}" disabled>
+            <button type="button" class="edit-btn icon" aria-label="{{ _('profile.aria.edit_username', default='Edit username') }}"><i class="bi bi-pencil-square"></i></button>
           </div>
         </div>
         <div class="field" data-name="email">
-          <label for="email" class="block-label">Email</label>
+          <label for="email" class="block-label">{{ _('profile.fields.email.label', default='Email') }}</label>
           <div class="input-with-icon">
-            <input id="email" type="email" name="email" required autocomplete="email" inputmode="email" enterkeyhint="next" pattern="[^@]+@[^@]+\.[^@]+" title="Email must be in the format text@text.text" value="{{ email|default(user.email) }}" disabled>
-            <button type="button" class="edit-btn icon" aria-label="Edit email"><i class="bi bi-pencil-square"></i></button>
+            <input id="email" type="email" name="email" required autocomplete="email" inputmode="email" enterkeyhint="next" pattern="[^@]+@[^@]+\.[^@]+" title="{{ _('profile.fields.email.title', default='Email must be in the format text@text.text') }}" value="{{ email|default(user.email) }}" disabled>
+            <button type="button" class="edit-btn icon" aria-label="{{ _('profile.aria.edit_email', default='Edit email') }}"><i class="bi bi-pencil-square"></i></button>
           </div>
         </div>
         <div class="field" data-name="prefix">
-          <label for="prefix" class="block-label">Phone Prefix</label>
+          <label for="prefix" class="block-label">{{ _('profile.fields.prefix.label', default='Phone Prefix') }}</label>
           <div class="input-with-icon">
             <select id="prefix" name="prefix" required autocomplete="tel-country-code" disabled>
-              <option value="+41" {% if (prefix|default(user.prefix)) == "+41" %}selected{% endif %}>+41 (Switzerland)</option>
-              <option value="+39" {% if (prefix|default(user.prefix)) == "+39" %}selected{% endif %}>+39 (Italy)</option>
-              <option value="+49" {% if (prefix|default(user.prefix)) == "+49" %}selected{% endif %}>+49 (Germany)</option>
-              <option value="+33" {% if (prefix|default(user.prefix)) == "+33" %}selected{% endif %}>+33 (France)</option>
+              <option value="+41" {% if (prefix|default(user.prefix)) == "+41" %}selected{% endif %}>{{ _('register.options.ch', default='+41 (Switzerland)') }}</option>
+              <option value="+39" {% if (prefix|default(user.prefix)) == "+39" %}selected{% endif %}>{{ _('register.options.it', default='+39 (Italy)') }}</option>
+              <option value="+49" {% if (prefix|default(user.prefix)) == "+49" %}selected{% endif %}>{{ _('register.options.de', default='+49 (Germany)') }}</option>
+              <option value="+33" {% if (prefix|default(user.prefix)) == "+33" %}selected{% endif %}>{{ _('register.options.fr', default='+33 (France)') }}</option>
             </select>
-            <button type="button" class="edit-btn icon" aria-label="Edit phone prefix"><i class="bi bi-pencil-square"></i></button>
+            <button type="button" class="edit-btn icon" aria-label="{{ _('profile.aria.edit_prefix', default='Edit phone prefix') }}"><i class="bi bi-pencil-square"></i></button>
           </div>
         </div>
         <div class="field" data-name="phone">
-          <label for="phone" class="block-label">Phone Number</label>
+          <label for="phone" class="block-label">{{ _('profile.fields.phone.label', default='Phone Number') }}</label>
           <div class="input-with-icon">
-            <input id="phone" type="tel" name="phone" required autocomplete="tel-national" inputmode="tel" enterkeyhint="done" pattern="[0-9]{9,10}" minlength="9" maxlength="10" title="Phone number must be 9 to 10 digits" value="{{ phone|default(user.phone) }}" disabled>
-            <button type="button" class="edit-btn icon" aria-label="Edit phone number"><i class="bi bi-pencil-square"></i></button>
+            <input id="phone" type="tel" name="phone" required autocomplete="tel-national" inputmode="tel" enterkeyhint="done" pattern="[0-9]{9,10}" minlength="9" maxlength="10" title="{{ _('profile.fields.phone.title', default='Phone number must be 9 to 10 digits') }}" value="{{ phone|default(user.phone) }}" disabled>
+            <button type="button" class="edit-btn icon" aria-label="{{ _('profile.aria.edit_phone', default='Edit phone number') }}"><i class="bi bi-pencil-square"></i></button>
           </div>
-          <small class="help">Use mobile format for your country.</small>
-          <a class="btn btn--secondary change-password" href="/profile/password">Change Password</a>
+          <small class="help">{{ _('profile.help.phone', default='Use mobile format for your country.') }}</small>
+          <a class="btn btn--secondary change-password" href="/profile/password">{{ _('profile.actions.change_password', default='Change Password') }}</a>
         </div>
       </div>
       <div class="form-actions">
-        <button class="btn btn--primary" type="submit">Save</button>
+        <button class="btn btn--primary" type="submit">{{ _('profile.actions.save', default='Save') }}</button>
       </div>
     </form>
   </div>


### PR DESCRIPTION
## Summary
- localize the profile, change password, and order success templates so they pull strings from the translator helpers
- add English and Italian translation keys for the profile, change_password, and order_success namespaces
- note the new translation namespaces in AGENTS.md for future updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9bacf90f88320883c80ec5b67dc50