### PR TITLE
Localize cart/search/bar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -382,3 +382,4 @@
 - Order history UI strings live under the `order_history` namespace in `app/i18n/translations/*.json`; `templates/order_history.html` pulls from these keys.
 - Notifications list strings use the `notifications` namespace in `app/i18n/translations/*.json`; `templates/notifications.html` references them.
 - Notification detail view strings use the `notification_detail` namespace in `app/i18n/translations/*.json`; `templates/notification_detail.html` uses these keys.
+- Cart, Search, and bar detail pages use the `cart`, `search`, and `bar_detail` namespaces in `app/i18n/translations/*.json` and their respective templates.

--- a/app/i18n/translations/en.json
+++ b/app/i18n/translations/en.json
@@ -450,6 +450,87 @@
     "download": "Download attachment",
     "image_alt": "Notification image"
   },
+  "cart": {
+    "title": "Your Cart",
+    "subtitle": "Review your order, choose your table, and confirm payment.",
+    "wallet": {
+      "label": "Wallet:",
+      "add_funds": "Add funds"
+    },
+    "table": {
+      "headers": {
+        "item": "Item",
+        "quantity": "Quantity",
+        "price": "Price",
+        "total": "Total",
+        "actions": "Actions"
+      },
+      "update": "Update",
+      "remove": "Remove"
+    },
+    "form": {
+      "table": {
+        "label": "Table",
+        "placeholder": "Select table"
+      },
+      "notes": {
+        "label": "Message to bartender",
+        "placeholder": "Add a note for the bartender"
+      }
+    },
+    "payment": {
+      "title": "Payment Method",
+      "options": {
+        "card": {
+          "title": "Credit Card",
+          "note": "Pay now with card"
+        },
+        "wallet": {
+          "title": "Wallet Credit",
+          "note": "Use your credit"
+        },
+        "bar": {
+          "title": "Pay at Bar",
+          "note": "Pay at the counter"
+        }
+      }
+    },
+    "summary": {
+      "title": "Order Summary",
+      "subtotal": "Subtotal",
+      "fees": "Fees",
+      "total": "Total",
+      "submit": "Place Order",
+      "fee_note": "Orders under CHF 10 include a CHF 0.20 fee.",
+      "secure": "Your payment will be processed securely."
+    },
+    "empty": {
+      "message": "Your cart is empty."
+    }
+  },
+  "search": {
+    "view_all": "View all",
+    "view_all_recent_aria": "View all: Recently visited bars",
+    "sections": {
+      "recent": "Recently visited bars",
+      "nearby": "Closest to you",
+      "top": "Top rated",
+      "popular": "Recommended"
+    },
+    "empty": "No bars found."
+  },
+  "bar_detail": {
+    "status": {
+      "open": "Open now",
+      "closed": "Closed now"
+    },
+    "hours": {
+      "title": "Opening hours",
+      "closed": "Closed"
+    },
+    "add_to_cart": "Add to Cart",
+    "login_to_order": "Login to order"
+  },
   "order_success": {
     "title": "Order Placed",
     "body": {

--- a/app/i18n/translations/it.json
+++ b/app/i18n/translations/it.json
@@ -450,6 +450,87 @@
     "download": "Scarica allegato",
     "image_alt": "Immagine della notifica"
   },
+  "cart": {
+    "title": "Il tuo carrello",
+    "subtitle": "Controlla il tuo ordine, scegli il tavolo e conferma il pagamento.",
+    "wallet": {
+      "label": "Portafoglio:",
+      "add_funds": "Ricarica"
+    },
+    "table": {
+      "headers": {
+        "item": "Articolo",
+        "quantity": "Quantità",
+        "price": "Prezzo",
+        "total": "Totale",
+        "actions": "Azioni"
+      },
+      "update": "Aggiorna",
+      "remove": "Rimuovi"
+    },
+    "form": {
+      "table": {
+        "label": "Tavolo",
+        "placeholder": "Seleziona il tavolo"
+      },
+      "notes": {
+        "label": "Messaggio al barista",
+        "placeholder": "Aggiungi una nota per il barista"
+      }
+    },
+    "payment": {
+      "title": "Metodo di pagamento",
+      "options": {
+        "card": {
+          "title": "Carta di credito",
+          "note": "Paga ora con carta"
+        },
+        "wallet": {
+          "title": "Credito portafoglio",
+          "note": "Usa il tuo credito"
+        },
+        "bar": {
+          "title": "Paga al bancone",
+          "note": "Paga direttamente al bancone"
+        }
+      }
+    },
+    "summary": {
+      "title": "Riepilogo ordine",
+      "subtotal": "Subtotale",
+      "fees": "Commissioni",
+      "total": "Totale",
+      "submit": "Invia ordine",
+      "fee_note": "Gli ordini inferiori a 10 CHF includono una commissione di 0,20 CHF.",
+      "secure": "Il tuo pagamento sarà elaborato in modo sicuro."
+    },
+    "empty": {
+      "message": "Il tuo carrello è vuoto."
+    }
+  },
+  "search": {
+    "view_all": "Vedi tutto",
+    "view_all_recent_aria": "Vedi tutto: Bar visitati di recente",
+    "sections": {
+      "recent": "Bar visitati di recente",
+      "nearby": "Più vicini a te",
+      "top": "Più votati",
+      "popular": "Consigliati"
+    },
+    "empty": "Nessun bar trovato."
+  },
+  "bar_detail": {
+    "status": {
+      "open": "Aperto ora",
+      "closed": "Chiuso ora"
+    },
+    "hours": {
+      "title": "Orari di apertura",
+      "closed": "Chiuso"
+    },
+    "add_to_cart": "Aggiungi al carrello",
+    "login_to_order": "Accedi per ordinare"
+  },
   "order_success": {
     "title": "Ordine inviato",
     "body": {

--- a/templates/bar_detail.html
+++ b/templates/bar_detail.html
@@ -12,7 +12,7 @@
   <h1 class="bar-title" itemprop="name">{{ bar.name }}</h1>
   <div class="bar-meta">
     <span class="bar-status">
-      <span class="status {% if bar.is_open_now %}status-open{% else %}status-closed{% endif %}">{% if bar.is_open_now %}Open now{% else %}Closed now{% endif %}</span>
+      <span class="status {% if bar.is_open_now %}status-open{% else %}status-closed{% endif %}">{% if bar.is_open_now %}{{ _('bar_detail.status.open', default='Open now') }}{% else %}{{ _('bar_detail.status.closed', default='Closed now') }}{% endif %}</span>
     </span>
     {% if bar.rating %}<span class="bar-rating"><i class="bi bi-star-fill" aria-hidden="true"></i> {{ '%.1f'|format(bar.rating) }}</span>{% endif %}
     <span class="bar-distance" data-has-distance="true" hidden><i class="bi bi-geo-alt" aria-hidden="true"></i> <span class="distance-value"></span></span>
@@ -21,13 +21,13 @@
   <p class="bar-desc clamp" itemprop="description">{{ bar.description }}</p>
   {% if opening_hours %}
   <section class="bar-hours-card">
-    <h2 class="bar-hours-title">Opening hours</h2>
+    <h2 class="bar-hours-title">{{ _('bar_detail.hours.title', default='Opening hours') }}</h2>
     <div class="hours">
       <div class="hours-col">
         {% for h in opening_hours[:4] %}
         <div class="hour-row">
           <span>{{ h.day }}</span>
-          <span>{% if h.open and h.close %}{{ h.open }} - {{ h.close }}{% else %}Closed{% endif %}</span>
+          <span>{% if h.open and h.close %}{{ h.open }} - {{ h.close }}{% else %}{{ _('bar_detail.hours.closed', default='Closed') }}{% endif %}</span>
         </div>
         {% endfor %}
       </div>
@@ -35,7 +35,7 @@
         {% for h in opening_hours[4:] %}
         <div class="hour-row">
           <span>{{ h.day }}</span>
-          <span>{% if h.open and h.close %}{{ h.open }} - {{ h.close }}{% else %}Closed{% endif %}</span>
+          <span>{% if h.open and h.close %}{{ h.open }} - {{ h.close }}{% else %}{{ _('bar_detail.hours.closed', default='Closed') }}{% endif %}</span>
         </div>
         {% endfor %}
       </div>
@@ -51,8 +51,8 @@
     <div class="section-head">
       <h2>{{ category.name }}</h2>
       <div class="scroller-nav">
-        <button class="scroll-btn prev" aria-label="Previous">‹</button>
-        <button class="scroll-btn next" aria-label="Next">›</button>
+        <button class="scroll-btn prev" aria-label="{{ _('common.previous', default='Previous') }}">‹</button>
+        <button class="scroll-btn next" aria-label="{{ _('common.next', default='Next') }}">›</button>
       </div>
     </div>
     <p>{{ category.description }}</p>
@@ -70,11 +70,11 @@
             {% if user %}
             <form class="form form--inline add-to-cart-form" method="post" action="/bars/{{ bar.id }}/add_to_cart">
               <input type="hidden" name="product_id" value="{{ product.id }}">
-              <button class="btn btn--primary btn--small add-to-cart" type="submit">Add to Cart</button>
-            </form>
-            {% else %}
-            <a class="btn add-to-cart" href="/login">Login to order</a>
-            {% endif %}
+        <button class="btn btn--primary btn--small add-to-cart" type="submit">{{ _('bar_detail.add_to_cart', default='Add to Cart') }}</button>
+        </form>
+        {% else %}
+        <a class="btn add-to-cart" href="/login">{{ _('bar_detail.login_to_order', default='Login to order') }}</a>
+        {% endif %}
           </div>
         </article>
       </li>

--- a/templates/cart.html
+++ b/templates/cart.html
@@ -2,22 +2,28 @@
 {% block content %}
 <section class="cart-page">
   <div class="cart-head">
-    <h1 class="cart-title">Your Cart</h1>
-    <p class="cart-subtitle">Review your order, choose your table, and confirm payment.</p>
+    <h1 class="cart-title">{{ _('cart.title', default='Your Cart') }}</h1>
+    <p class="cart-subtitle">{{ _('cart.subtitle', default='Review your order, choose your table, and confirm payment.') }}</p>
   </div>
   {% if cart.items %}
   <div class="cart-layout">
     <div class="cart-main">
       <div class="wallet-banner">
-        <span class="label">Wallet:</span>
+        <span class="label">{{ _('cart.wallet.label', default='Wallet:') }}</span>
         <strong class="amount">CHF {{ "%.2f"|format(user.credit) }}</strong>
-        <a href="/wallet" class="link-add">Add funds</a>
+        <a href="/wallet" class="link-add">{{ _('cart.wallet.add_funds', default='Add funds') }}</a>
       </div>
       <div class="card cart-table">
         <div class="table-scroll">
         <table class="menu-table">
           <thead>
-            <tr><th>Item</th><th>Quantity</th><th>Price</th><th>Total</th><th class="actions">Actions</th></tr>
+            <tr>
+              <th>{{ _('cart.table.headers.item', default='Item') }}</th>
+              <th>{{ _('cart.table.headers.quantity', default='Quantity') }}</th>
+              <th>{{ _('cart.table.headers.price', default='Price') }}</th>
+              <th>{{ _('cart.table.headers.total', default='Total') }}</th>
+              <th class="actions">{{ _('cart.table.headers.actions', default='Actions') }}</th>
+            </tr>
           </thead>
           <tbody>
             {% for item in cart.items.values() %}
@@ -28,7 +34,7 @@
                   <input type="hidden" name="product_id" value="{{ item.product.id }}">
                   <div class="qty-group">
                     <input type="number" name="quantity" min="0" value="{{ item.quantity }}" inputmode="numeric" enterkeyhint="done">
-                    <button class="btn-outline btn--small" type="submit">Update</button>
+                    <button class="btn-outline btn--small" type="submit">{{ _('cart.table.update', default='Update') }}</button>
                   </div>
                 </form>
               </td>
@@ -39,7 +45,7 @@
                   <form method="post" action="/cart/update" class="form form--inline">
                     <input type="hidden" name="product_id" value="{{ item.product.id }}">
                     <input type="hidden" name="quantity" value="0">
-                    <button class="btn-danger-soft btn--small" type="submit">Remove</button>
+                    <button class="btn-danger-soft btn--small" type="submit">{{ _('cart.table.remove', default='Remove') }}</button>
                   </form>
                 </div>
               </td>
@@ -53,9 +59,9 @@
       <form id="checkoutForm" method="post" action="/cart/checkout">
         <div class="card form-card">
           <div class="field">
-            <label for="table_id">Table</label>
+            <label for="table_id">{{ _('cart.form.table.label', default='Table') }}</label>
             <select id="table_id" name="table_id" required>
-              <option value="" disabled {% if cart.table_id is none %}selected{% endif %}>Select table</option>
+              <option value="" disabled {% if cart.table_id is none %}selected{% endif %}>{{ _('cart.form.table.placeholder', default='Select table') }}</option>
               {% for table in bar.tables.values() %}
                 <option value="{{ table.id }}" {% if cart.table_id == table.id %}selected{% endif %}>{{ table.name }}</option>
               {% endfor %}
@@ -65,32 +71,32 @@
 
         <div class="card form-card">
           <div class="field">
-            <label for="notes">Message to bartender</label>
-            <textarea id="notes" name="notes" rows="3" placeholder="Add a note for the bartender"></textarea>
+            <label for="notes">{{ _('cart.form.notes.label', default='Message to bartender') }}</label>
+            <textarea id="notes" name="notes" rows="3" placeholder="{{ _('cart.form.notes.placeholder', default='Add a note for the bartender') }}"></textarea>
           </div>
         </div>
 
         <div class="card pay-card" id="paymentMethods">
-          <h3 class="section-title">Payment Method</h3>
+          <h3 class="section-title">{{ _('cart.payment.title', default='Payment Method') }}</h3>
           <label class="pay-option">
             <input type="radio" name="payment_method" value="card" required>
             <span class="pay-content">
-              <span class="pay-title">Credit Card</span>
-              <span class="pay-note">Pay now with card</span>
+              <span class="pay-title">{{ _('cart.payment.options.card.title', default='Credit Card') }}</span>
+              <span class="pay-note">{{ _('cart.payment.options.card.note', default='Pay now with card') }}</span>
             </span>
           </label>
           <label class="pay-option">
             <input type="radio" name="payment_method" value="wallet">
             <span class="pay-content">
-              <span class="pay-title">Wallet Credit</span>
-              <span class="pay-note">Use your credit</span>
+              <span class="pay-title">{{ _('cart.payment.options.wallet.title', default='Wallet Credit') }}</span>
+              <span class="pay-note">{{ _('cart.payment.options.wallet.note', default='Use your credit') }}</span>
             </span>
           </label>
           <label class="pay-option">
             <input type="radio" name="payment_method" value="bar">
             <span class="pay-content">
-              <span class="pay-title">Pay at Bar</span>
-              <span class="pay-note">Pay at the counter</span>
+              <span class="pay-title">{{ _('cart.payment.options.bar.title', default='Pay at Bar') }}</span>
+              <span class="pay-note">{{ _('cart.payment.options.bar.note', default='Pay at the counter') }}</span>
             </span>
           </label>
         </div>
@@ -99,22 +105,22 @@
 
     <aside class="summary">
       <div class="card summary-card">
-        <h3 class="section-title">Order Summary</h3>
+        <h3 class="section-title">{{ _('cart.summary.title', default='Order Summary') }}</h3>
         <dl class="sum-rows">
-          <div class="row"><dt>Subtotal</dt><dd>CHF {{ "%.2f"|format(cart.total_price()) }}</dd></div>
-          <div class="row"><dt>Fees</dt><dd>{% if cart.small_order_fee() %}CHF {{ "%.2f"|format(cart.small_order_fee()) }}{% else %}—{% endif %}</dd></div>
-          <div class="row total"><dt>Total</dt><dd>CHF {{ "%.2f"|format(cart.total_with_fee()) }}</dd></div>
+          <div class="row"><dt>{{ _('cart.summary.subtotal', default='Subtotal') }}</dt><dd>CHF {{ "%.2f"|format(cart.total_price()) }}</dd></div>
+          <div class="row"><dt>{{ _('cart.summary.fees', default='Fees') }}</dt><dd>{% if cart.small_order_fee() %}CHF {{ "%.2f"|format(cart.small_order_fee()) }}{% else %}—{% endif %}</dd></div>
+          <div class="row total"><dt>{{ _('cart.summary.total', default='Total') }}</dt><dd>CHF {{ "%.2f"|format(cart.total_with_fee()) }}</dd></div>
         </dl>
-        <button type="submit" class="btn-primary place-order" form="checkoutForm">Place Order</button>
+        <button type="submit" class="btn-primary place-order" form="checkoutForm">{{ _('cart.summary.submit', default='Place Order') }}</button>
         {% if cart.small_order_fee() %}
-        <p class="sum-note">Orders under CHF 10 include a CHF 0.20 fee.</p>
+        <p class="sum-note">{{ _('cart.summary.fee_note', default='Orders under CHF 10 include a CHF 0.20 fee.') }}</p>
         {% endif %}
-        <p class="sum-note">Your payment will be processed securely.</p>
+        <p class="sum-note">{{ _('cart.summary.secure', default='Your payment will be processed securely.') }}</p>
       </div>
     </aside>
   </div>
   {% else %}
-  <p>Your cart is empty.</p>
+  <p>{{ _('cart.empty.message', default='Your cart is empty.') }}</p>
   {% endif %}
 </section>
 <style>

--- a/templates/search.html
+++ b/templates/search.html
@@ -3,17 +3,17 @@
 {% set fallback_img = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCA0MDAgMjI1Jz48cmVjdCB3aWR0aD0nNDAwJyBoZWlnaHQ9JzIyNScgZmlsbD0nJTIzZjFmM2Y1Jy8+PC9zdmc+" %}
 <div class="search-page">
   <div class="section-utility container">
-    <a class="btn-filter" href="/bars" aria-label="View all: Recently visited bars">
-      <span data-i18n="see_all">View all</span>
+    <a class="btn-filter" href="/bars" aria-label="{{ _('search.view_all_recent_aria', default='View all: Recently visited bars') }}">
+      <span data-i18n="see_all">{{ _('search.view_all', default='View all') }}</span>
       <i class="bi bi-arrow-right" aria-hidden="true"></i>
     </a>
   </div>
   {% if bars or recent_bars %}
     {% set sections = [
-      ('recent', 'Recently visited bars'),
-      ('nearby', 'Closest to you'),
-      ('top', 'Top rated'),
-      ('popular', 'Recommended')
+      ('recent', _('search.sections.recent', default='Recently visited bars')),
+      ('nearby', _('search.sections.nearby', default='Closest to you')),
+      ('top', _('search.sections.top', default='Top rated')),
+      ('popular', _('search.sections.popular', default='Recommended'))
     ] %}
     {% for key, title in sections %}
       {% set items =
@@ -28,13 +28,13 @@
           <div class="section-head">
             <h2>{{ title }}</h2>
             <div class="scroller-nav">
-              <button class="scroll-btn prev" aria-label="Previous">‹</button>
-              <button class="scroll-btn next" aria-label="Next">›</button>
+              <button class="scroll-btn prev" aria-label="{{ _('common.previous', default='Previous') }}">‹</button>
+              <button class="scroll-btn next" aria-label="{{ _('common.next', default='Next') }}">›</button>
             </div>
           </div>
           <div class="cards scroller" aria-label="{{ title }}" tabindex="0">
             {% for bar in items %}
-              <a class="bar-card{% if bar.is_open_now %} is-open{% endif %}" href="/bars/{{ bar.id }}" aria-label="Open {{ bar.name }}" data-name="{{ bar.name|lower }}" data-address="{{ bar.address|lower }}" data-city="{{ bar.city|lower }}" data-state="{{ bar.state|lower }}" data-latitude="{{ bar.latitude }}" data-longitude="{{ bar.longitude }}" data-rating="{{ bar.rating or '' }}" data-distance_km="{{ bar.distance_km or '' }}" data-categories="{{ bar.bar_categories|lower if bar.bar_categories else '' }}" data-open="{{ 'true' if bar.is_open_now else 'false' }}" itemscope itemtype="https://schema.org/BarOrPub">
+              <a class="bar-card{% if bar.is_open_now %} is-open{% endif %}" href="/bars/{{ bar.id }}" aria-label="{{ _('home.bar_card.open_label', bar_name=bar.name, default='Open {bar_name}') }}" data-name="{{ bar.name|lower }}" data-address="{{ bar.address|lower }}" data-city="{{ bar.city|lower }}" data-state="{{ bar.state|lower }}" data-latitude="{{ bar.latitude }}" data-longitude="{{ bar.longitude }}" data-rating="{{ bar.rating or '' }}" data-distance_km="{{ bar.distance_km or '' }}" data-categories="{{ bar.bar_categories|lower if bar.bar_categories else '' }}" data-open="{{ 'true' if bar.is_open_now else 'false' }}" itemscope itemtype="https://schema.org/BarOrPub">
           {% if bar.photo_url %}
             <div class="thumb-wrapper">
             <img src="{{ bar.photo_url }}" alt="{{ bar.name }} photo" class="thumb" loading="lazy" decoding="async" width="400" height="225" srcset="{{ bar.photo_url }} 400w, {{ bar.photo_url }} 800w" sizes="(max-width: 600px) 100vw, 400px" onerror="this.src='{{ fallback_img }}';this.onerror=null;">
@@ -45,9 +45,9 @@
             </div>
           {% endif %}
           {% if bar.is_open_now %}
-          <span class="status status-open">Open now</span>
+          <span class="status status-open">{{ _('home.bar_card.status_open', default='Open now') }}</span>
           {% else %}
-          <span class="status status-closed">Closed now</span>
+          <span class="status status-closed">{{ _('home.bar_card.status_closed', default='Closed now') }}</span>
           {% endif %}
             <h3 class="title" itemprop="name">{{ bar.name }}</h3>
             <div class="bar-meta">
@@ -63,7 +63,7 @@
               <div class="thumb-wrapper">
                 <i class="bi bi-arrow-left" aria-hidden="true"></i>
               </div>
-              <span>View all</span>
+              <span>{{ _('search.view_all', default='View all') }}</span>
             </a>
             {% endif %}
           </div>
@@ -80,7 +80,7 @@
     {% endfor %}
   {% else %}
   <div class="empty-state">
-    <p>No bars found.</p>
+    <p>{{ _('search.empty', default='No bars found.') }}</p>
   </div>
   {% endif %}
 </div>


### PR DESCRIPTION
## Summary
- localize the cart page strings through the new `cart` translation namespace
- translate search listings and bar detail views using shared and dedicated keys
- document the new namespaces in AGENTS guidance for future localization work

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca4532bf4c83209507a092b3c9a54d