### PR TITLE
Localize next three pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -383,3 +383,5 @@
 - Notifications list strings use the `notifications` namespace in `app/i18n/translations/*.json`; `templates/notifications.html` references them.
 - Notification detail view strings use the `notification_detail` namespace in `app/i18n/translations/*.json`; `templates/notification_detail.html` uses these keys.
 - Cart, Search, and bar detail pages use the `cart`, `search`, and `bar_detail` namespaces in `app/i18n/translations/*.json` and their respective templates.
+- The "All bars" directory view localises via the `all_bars` namespace in `app/i18n/translations/*.json`; strings surface in `templates/all_bars.html` and supporting scripts.
+- Bartender dashboard copy pulls from the `bartender_dashboard` namespace, and bartender order management strings use the `bartender_orders` namespace.

--- a/app/i18n/translations/en.json
+++ b/app/i18n/translations/en.json
@@ -531,6 +531,52 @@
     "add_to_cart": "Add to Cart",
     "login_to_order": "Login to order"
   },
+  "all_bars": {
+    "title": "All bars",
+    "filters": {
+      "toggle_show": "Show filters",
+      "toggle_hide": "Hide filters",
+      "name": {
+        "label": "Bar name",
+        "placeholder": "e.g. Central Bar"
+      },
+      "city": {
+        "label": "City",
+        "placeholder": "e.g. Bellinzona"
+      },
+      "distance": {
+        "label": "Max distance (km)"
+      },
+      "rating": {
+        "label": "Minimum rating",
+        "help": "Show only bars with rating ≥ selected value"
+      },
+      "categories": {
+        "label": "Categories"
+      },
+      "clear": "Clear filters"
+    }
+  },
+  "bartender_dashboard": {
+    "title": "Bartender Dashboard",
+    "sections": {
+      "bars": {
+        "title": "Your Bars",
+        "aria": "Bars"
+      }
+    },
+    "empty": "No bar assigned."
+  },
+  "bartender_orders": {
+    "title": "{bar} Orders",
+    "pause": "Pause ordering",
+    "sections": {
+      "incoming": "Incoming Orders",
+      "preparing": "Preparing",
+      "ready": "Ready",
+      "completed": "Completed"
+    }
+  },
   "order_success": {
     "title": "Order Placed",
     "body": {

--- a/app/i18n/translations/it.json
+++ b/app/i18n/translations/it.json
@@ -531,6 +531,52 @@
     "add_to_cart": "Aggiungi al carrello",
     "login_to_order": "Accedi per ordinare"
   },
+  "all_bars": {
+    "title": "Tutti i locali",
+    "filters": {
+      "toggle_show": "Mostra filtri",
+      "toggle_hide": "Nascondi filtri",
+      "name": {
+        "label": "Nome locale",
+        "placeholder": "es. Central Bar"
+      },
+      "city": {
+        "label": "Città",
+        "placeholder": "es. Bellinzona"
+      },
+      "distance": {
+        "label": "Distanza massima (km)"
+      },
+      "rating": {
+        "label": "Valutazione minima",
+        "help": "Mostra solo i locali con valutazione ≥ valore selezionato"
+      },
+      "categories": {
+        "label": "Categorie"
+      },
+      "clear": "Azzera filtri"
+    }
+  },
+  "bartender_dashboard": {
+    "title": "Dashboard bartender",
+    "sections": {
+      "bars": {
+        "title": "I tuoi locali",
+        "aria": "Locali"
+      }
+    },
+    "empty": "Nessun locale assegnato."
+  },
+  "bartender_orders": {
+    "title": "Ordini {bar}",
+    "pause": "Metti in pausa gli ordini",
+    "sections": {
+      "incoming": "Ordini in arrivo",
+      "preparing": "In preparazione",
+      "ready": "Pronti",
+      "completed": "Completati"
+    }
+  },
   "order_success": {
     "title": "Ordine inviato",
     "body": {

--- a/static/js/view-all.js
+++ b/static/js/view-all.js
@@ -83,6 +83,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const filterLabel = filtersToggle?.querySelector('.label');
   const distanceValue = document.getElementById('distanceValue');
   const activeCategories = new Set();
+  const labelShow = filterLabel?.dataset.showLabel || 'Show filters';
+  const labelHide = filterLabel?.dataset.hideLabel || 'Hide filters';
 
   if (distInput) {
     distInput.value = distInput.max || '30';
@@ -115,11 +117,11 @@ document.addEventListener('DOMContentLoaded', () => {
     if (open) {
       filterPanel.removeAttribute('hidden');
       filtersToggle.setAttribute('aria-expanded', 'true');
-      filterLabel.textContent = 'Hide filters';
+      filterLabel.textContent = labelHide;
     } else {
       filterPanel.setAttribute('hidden', '');
       filtersToggle.setAttribute('aria-expanded', 'false');
-      filterLabel.textContent = 'Show filters';
+      filterLabel.textContent = labelShow;
     }
     localStorage.setItem('isOpen', String(open));
   }

--- a/templates/all_bars.html
+++ b/templates/all_bars.html
@@ -4,12 +4,13 @@
 <section class="bar-section">
     <div class="section-track">
       <div class="section-head">
-        <h2>All bars</h2>
+        <h2>{{ _('all_bars.title', default='All bars') }}</h2>
       </div>
       <div class="filters-toolbar">
         <button type="button" id="filters-toggle" class="btn-filter" aria-expanded="false" aria-controls="filters-panel">
           <i class="bi bi-sliders" aria-hidden="true"></i>
-          <span class="label">Show filters</span>
+          {% set show_label = _('all_bars.filters.toggle_show', default='Show filters') %}
+          <span class="label" data-show-label="{{ show_label }}" data-hide-label="{{ _('all_bars.filters.toggle_hide', default='Hide filters') }}">{{ show_label }}</span>
           <span class="badge" hidden>0</span>
           <i class="bi bi-chevron-down chevron" aria-hidden="true"></i>
         </button>
@@ -17,21 +18,21 @@
       <div class="bar-filters" id="filters-panel" hidden>
         <div class="filter-grid">
           <div class="filter-group">
-            <label for="searchName">Bar name</label>
+            <label for="searchName">{{ _('all_bars.filters.name.label', default='Bar name') }}</label>
             <div class="input-wrap">
               <i class="bi bi-search" aria-hidden="true"></i>
-                <input type="search" id="searchName" placeholder="e.g. Central Bar">
+                <input type="search" id="searchName" placeholder="{{ _('all_bars.filters.name.placeholder', default='e.g. Central Bar') }}">
             </div>
           </div>
           <div class="filter-group">
-            <label for="searchCity">City</label>
+            <label for="searchCity">{{ _('all_bars.filters.city.label', default='City') }}</label>
             <div class="input-wrap">
               <i class="bi bi-geo-alt" aria-hidden="true"></i>
-                <input type="search" id="searchCity" placeholder="e.g. Bellinzona">
+                <input type="search" id="searchCity" placeholder="{{ _('all_bars.filters.city.placeholder', default='e.g. Bellinzona') }}">
             </div>
           </div>
           <div class="filter-group">
-            <label for="filterDistance">Max distance (km)</label>
+            <label for="filterDistance">{{ _('all_bars.filters.distance.label', default='Max distance (km)') }}</label>
             <div class="range-wrap">
               <input type="range" id="filterDistance" min="0" max="30" step="1" list="distTicks" aria-live="polite">
               <datalist id="distTicks">
@@ -47,21 +48,21 @@
             </div>
           </div>
           <div class="filter-group rating-group">
-              <label for="filterRating">Minimum rating <i class="bi bi-info-circle" title="Show only bars with rating ≥ selected value" aria-hidden="true"></i></label>
+              <label for="filterRating">{{ _('all_bars.filters.rating.label', default='Minimum rating') }} <i class="bi bi-info-circle" title="{{ _('all_bars.filters.rating.help', default='Show only bars with rating ≥ selected value') }}" aria-hidden="true"></i></label>
             <div class="rating-stars" id="ratingStars" tabindex="0" role="slider" aria-valuemin="0" aria-valuemax="5" aria-valuenow="0"></div>
             <span class="value" id="ratingValue"></span>
             <input type="hidden" id="filterRating">
           </div>
           <div class="filter-group check-group">
-            <label><input type="checkbox" id="filterOpen"> Open now</label>
-            <label><input type="checkbox" id="filterClosed"> Closed now</label>
+            <label><input type="checkbox" id="filterOpen"> {{ _('home.bar_card.status_open', default='Open now') }}</label>
+            <label><input type="checkbox" id="filterClosed"> {{ _('home.bar_card.status_closed', default='Closed now') }}</label>
           </div>
           <div class="filter-group categories">
-            <label>Categories</label>
+            <label>{{ _('all_bars.filters.categories.label', default='Categories') }}</label>
             <div class="chips" id="categoryChips"></div>
           </div>
           <div class="actions">
-            <button type="button" id="clearFilters" class="btn-link">Clear filters</button>
+            <button type="button" id="clearFilters" class="btn-link">{{ _('all_bars.filters.clear', default='Clear filters') }}</button>
           </div>
         </div>
       </div>
@@ -69,7 +70,7 @@
       <ul class="bars all-bars" id="allBarList">
         {% for bar in bars %}
         <li>
-        <a class="bar-card{% if bar.is_open_now %} is-open{% endif %}" href="/bars/{{ bar.id }}" aria-label="Open {{ bar.name }}" data-name="{{ bar.name|lower }}" data-address="{{ bar.address|lower }}" data-city="{{ bar.city|lower }}" data-state="{{ bar.state|lower }}" data-latitude="{{ bar.latitude }}" data-longitude="{{ bar.longitude }}" data-rating="{{ bar.rating or '' }}" data-distance_km="{{ bar.distance_km or '' }}" data-open="{{ 'true' if bar.is_open_now else 'false' }}" data-categories="{{ bar.bar_categories|lower if bar.bar_categories else '' }}" itemscope itemtype="https://schema.org/BarOrPub">
+        <a class="bar-card{% if bar.is_open_now %} is-open{% endif %}" href="/bars/{{ bar.id }}" aria-label="{{ _('home.bar_card.open_label', bar_name=bar.name, default='Open {bar_name}') }}" data-name="{{ bar.name|lower }}" data-address="{{ bar.address|lower }}" data-city="{{ bar.city|lower }}" data-state="{{ bar.state|lower }}" data-latitude="{{ bar.latitude }}" data-longitude="{{ bar.longitude }}" data-rating="{{ bar.rating or '' }}" data-distance_km="{{ bar.distance_km or '' }}" data-open="{{ 'true' if bar.is_open_now else 'false' }}" data-categories="{{ bar.bar_categories|lower if bar.bar_categories else '' }}" itemscope itemtype="https://schema.org/BarOrPub">
           <div class="thumb-wrapper">
             {% if bar.photo_url %}
             <img class="thumb" src="{{ bar.photo_url }}" alt="{{ bar.name }} photo" itemprop="image" loading="lazy" decoding="async" width="400" height="225" srcset="{{ bar.photo_url }} 400w, {{ bar.photo_url }} 800w" sizes="(max-width: 600px) 100vw, 400px" onerror="this.src='{{ fallback_img }}';this.onerror=null;">
@@ -78,9 +79,9 @@
             {% endif %}
           </div>
           {% if bar.is_open_now %}
-          <span class="status status-open">Open now</span>
+          <span class="status status-open">{{ _('home.bar_card.status_open', default='Open now') }}</span>
           {% else %}
-          <span class="status status-closed">Closed now</span>
+          <span class="status status-closed">{{ _('home.bar_card.status_closed', default='Closed now') }}</span>
           {% endif %}
           <h3 class="title" itemprop="name">{{ bar.name }}</h3>
           <div class="bar-meta">

--- a/templates/bartender_dashboard.html
+++ b/templates/bartender_dashboard.html
@@ -2,7 +2,7 @@
 {% block content %}
 <section class="admin-dashboard editbar">
   <header class="admin-header">
-    <h1>Bartender Dashboard</h1>
+    <h1>{{ _('bartender_dashboard.title', default='Bartender Dashboard') }}</h1>
     <div class="admin-identity card">
       <div class="identity-row">
         <span class="identity-name">{{ user.username }}</span>
@@ -12,8 +12,8 @@
     </div>
   </header>
   {% if bars %}
-  <section class="admin-section" aria-label="Bars">
-    <h2 class="section-title"><i class="bi bi-shop"></i> Your Bars</h2>
+  <section class="admin-section" aria-label="{{ _('bartender_dashboard.sections.bars.aria', default='Bars') }}">
+    <h2 class="section-title"><i class="bi bi-shop"></i> {{ _('bartender_dashboard.sections.bars.title', default='Your Bars') }}</h2>
     <ul class="bars">
       {% for bar in bars %}
       <li>
@@ -32,7 +32,7 @@
     </ul>
   </section>
   {% else %}
-  <p>No bar assigned.</p>
+  <p>{{ _('bartender_dashboard.empty', default='No bar assigned.') }}</p>
   {% endif %}
 </section>
 {% endblock %}

--- a/templates/bartender_orders.html
+++ b/templates/bartender_orders.html
@@ -2,27 +2,27 @@
 {% block content %}
 <section class="orders-page">
   <header class="orders-head">
-    <h1 class="orders-title">{{ bar.name }} Orders</h1>
-    <label><input type="checkbox" id="pause-ordering" {% if bar.ordering_paused %}checked{% endif %}> Pause ordering</label>
+    <h1 class="orders-title">{{ _('bartender_orders.title', bar=bar.name, default='{bar} Orders') }}</h1>
+    <label><input type="checkbox" id="pause-ordering" {% if bar.ordering_paused %}checked{% endif %}> {{ _('bartender_orders.pause', default='Pause ordering') }}</label>
   </header>
 
   <section class="orders-section">
-    <div class="section-head"><h2>Incoming Orders</h2></div>
+    <div class="section-head"><h2>{{ _('bartender_orders.sections.incoming', default='Incoming Orders') }}</h2></div>
     <div id="incoming-orders" class="orders-grid order-list"></div>
   </section>
 
   <section class="orders-section">
-    <div class="section-head"><h2>Preparing</h2></div>
+    <div class="section-head"><h2>{{ _('bartender_orders.sections.preparing', default='Preparing') }}</h2></div>
     <div id="preparing-orders" class="orders-grid order-list"></div>
   </section>
 
   <section class="orders-section">
-    <div class="section-head"><h2>Ready</h2></div>
+    <div class="section-head"><h2>{{ _('bartender_orders.sections.ready', default='Ready') }}</h2></div>
     <div id="ready-orders" class="orders-grid order-list"></div>
   </section>
 
   <section class="orders-section">
-    <div class="section-head"><h2>Completed</h2></div>
+    <div class="section-head"><h2>{{ _('bartender_orders.sections.completed', default='Completed') }}</h2></div>
     <div id="completed-orders" class="orders-grid order-list"></div>
   </section>
 </section>


### PR DESCRIPTION
## Summary
- localize the All Bars directory template and hook it up to new translation keys
- translate bartender dashboard and orders pages via new `bartender_dashboard` and `bartender_orders` namespaces
- teach the filter toggle script to reuse localized "show/hide filters" labels and document the new namespaces in AGENTS

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca475027548320a48c55ebd21bbb17