### PR TITLE
Localize bar admin and menu management pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -388,3 +388,7 @@
 - Bar admin dashboard strings live under the `bar_admin_dashboard` namespace in `app/i18n/translations/*.json`; `templates/bar_admin_dashboard.html` references them.
 - Bartender confirmation strings live under the `bartender_confirm` namespace in `app/i18n/translations/*.json`; `templates/bartender_confirm.html` references them.
 - Display orders screen strings live under the `display_orders` namespace in `app/i18n/translations/*.json`; `templates/display_orders.html` references them.
+- Bar admin revenue history pages use the `bar_admin_history` namespace in `app/i18n/translations/*.json`; `templates/bar_admin_month_history.html`, `templates/bar_admin_order_history.html`, and `templates/bar_admin_order_history_view.html` reference these keys.
+- Bar admin live orders strings live under the `bar_admin_orders` namespace in `app/i18n/translations/*.json`; `templates/bar_admin_orders.html` pulls from these keys.
+- Bar category management pages use the `bar_categories` namespace in `app/i18n/translations/*.json`; see `templates/bar_manage_categories.html`, `templates/bar_new_category.html`, and `templates/bar_edit_category.html`.
+- Bar product management pages use the `bar_products` namespace in `app/i18n/translations/*.json`; `templates/bar_category_products.html`, `templates/bar_new_product.html`, and `templates/bar_edit_product.html` reference them.

--- a/app/i18n/translations/en.json
+++ b/app/i18n/translations/en.json
@@ -602,6 +602,112 @@
       "ready": "Ready"
     }
   },
+  "bar_admin_history": {
+    "title": "{bar} - Order History & Revenue",
+    "month_title": "{bar} - {month}",
+    "orders_title": "{bar} - Orders for {date}",
+    "actions": {
+      "view": "View",
+      "confirm": "Confirm Payment"
+    },
+    "metrics": {
+      "total_collected": "Total collected",
+      "total_earned": "Total earned",
+      "commission": "Siplygo commission (5%)",
+      "payout": "Amount to pay to bar"
+    },
+    "breakdown": {
+      "title": "Payment breakdown:"
+    },
+    "empty": {
+      "history": "No order history yet.",
+      "orders": "No orders."
+    }
+  },
+  "bar_admin_orders": {
+    "title": "{bar} Orders",
+    "actions": {
+      "history": "Order History & Revenue"
+    }
+  },
+  "bar_categories": {
+    "manage": {
+      "title": "Manage Categories for {bar}",
+      "subtitle": "Create, edit and organize menu categories for this venue.",
+      "search": {
+        "aria": "Search categories",
+        "placeholder": "Search categories…",
+        "input_aria": "Search categories by name",
+        "clear": "Clear search"
+      },
+      "actions": {
+        "add": "Add Category",
+        "products": "Products",
+        "edit": "Edit",
+        "delete": "Delete"
+      },
+      "table": {
+        "headers": {
+          "name": "Name",
+          "description": "Description",
+          "actions": "Actions"
+        }
+      },
+      "confirm_delete": "Are you sure you want to delete this category?",
+      "empty": "No categories yet."
+    },
+    "form": {
+      "name": "Name",
+      "description": "Description",
+      "display_order": "Display Order",
+      "create": "Create",
+      "save": "Save"
+    },
+    "new": {
+      "title": "Add Category for {bar}"
+    },
+    "edit": {
+      "title": "Edit Category for {bar}"
+    }
+  },
+  "bar_products": {
+    "edit": {
+      "title": "Edit Product {product}"
+    },
+    "new": {
+      "title": "Add Product to {category}"
+    },
+    "form": {
+      "name": "Name",
+      "price": "Price (CHF)",
+      "description": "Description",
+      "display_order": "Display Order",
+      "photo": "Photo",
+      "create": "Create",
+      "update": "Update"
+    },
+    "manage": {
+      "title": "Products in {category} for {bar}",
+      "subtitle": "Add, edit and organize products for this category.",
+      "actions": {
+        "add": "Add Product",
+        "edit": "Edit",
+        "delete": "Delete"
+      },
+      "table": {
+        "headers": {
+          "order": "Order",
+          "photo": "Photo",
+          "name": "Name",
+          "description": "Description",
+          "price": "Price (CHF)",
+          "actions": "Actions"
+        }
+      },
+      "confirm_delete": "Are you sure you want to delete this product?",
+      "empty": "No products in this category."
+    }
+  },
   "order_success": {
     "title": "Order Placed",
     "body": {

--- a/app/i18n/translations/it.json
+++ b/app/i18n/translations/it.json
@@ -602,6 +602,112 @@
       "ready": "Pronti"
     }
   },
+  "bar_admin_history": {
+    "title": "{bar} - Storico ordini e incassi",
+    "month_title": "{bar} - {month}",
+    "orders_title": "{bar} - Ordini per {date}",
+    "actions": {
+      "view": "Visualizza",
+      "confirm": "Conferma pagamento"
+    },
+    "metrics": {
+      "total_collected": "Totale incassato",
+      "total_earned": "Totale guadagnato",
+      "commission": "Commissione Siplygo (5%)",
+      "payout": "Importo da versare al locale"
+    },
+    "breakdown": {
+      "title": "Dettaglio pagamenti:"
+    },
+    "empty": {
+      "history": "Nessuno storico ordini.",
+      "orders": "Nessun ordine."
+    }
+  },
+  "bar_admin_orders": {
+    "title": "{bar} - Ordini",
+    "actions": {
+      "history": "Storico ordini e incassi"
+    }
+  },
+  "bar_categories": {
+    "manage": {
+      "title": "Gestisci categorie per {bar}",
+      "subtitle": "Crea, modifica e organizza le categorie del menu per questo locale.",
+      "search": {
+        "aria": "Cerca categorie",
+        "placeholder": "Cerca categorie…",
+        "input_aria": "Cerca categorie per nome",
+        "clear": "Pulisci ricerca"
+      },
+      "actions": {
+        "add": "Aggiungi categoria",
+        "products": "Prodotti",
+        "edit": "Modifica",
+        "delete": "Elimina"
+      },
+      "table": {
+        "headers": {
+          "name": "Nome",
+          "description": "Descrizione",
+          "actions": "Azioni"
+        }
+      },
+      "confirm_delete": "Sei sicuro di voler eliminare questa categoria?",
+      "empty": "Nessuna categoria al momento."
+    },
+    "form": {
+      "name": "Nome",
+      "description": "Descrizione",
+      "display_order": "Ordine di visualizzazione",
+      "create": "Crea",
+      "save": "Salva"
+    },
+    "new": {
+      "title": "Aggiungi categoria per {bar}"
+    },
+    "edit": {
+      "title": "Modifica categoria per {bar}"
+    }
+  },
+  "bar_products": {
+    "edit": {
+      "title": "Modifica prodotto {product}"
+    },
+    "new": {
+      "title": "Aggiungi prodotto a {category}"
+    },
+    "form": {
+      "name": "Nome",
+      "price": "Prezzo (CHF)",
+      "description": "Descrizione",
+      "display_order": "Ordine di visualizzazione",
+      "photo": "Foto",
+      "create": "Crea",
+      "update": "Aggiorna"
+    },
+    "manage": {
+      "title": "Prodotti in {category} per {bar}",
+      "subtitle": "Aggiungi, modifica e organizza i prodotti per questa categoria.",
+      "actions": {
+        "add": "Aggiungi prodotto",
+        "edit": "Modifica",
+        "delete": "Elimina"
+      },
+      "table": {
+        "headers": {
+          "order": "Ordine",
+          "photo": "Foto",
+          "name": "Nome",
+          "description": "Descrizione",
+          "price": "Prezzo (CHF)",
+          "actions": "Azioni"
+        }
+      },
+      "confirm_delete": "Sei sicuro di voler eliminare questo prodotto?",
+      "empty": "Nessun prodotto in questa categoria."
+    }
+  },
   "order_success": {
     "title": "Ordine inviato",
     "body": {

--- a/templates/bar_admin_month_history.html
+++ b/templates/bar_admin_month_history.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1>{{ bar.name }} - {{ month_label }}</h1>
+<h1>{{ _('bar_admin_history.month_title', bar=bar.name, month=month_label, default='{bar} - {month}') }}</h1>
 {% if closings %}
 <ul class="closing-list">
   {% for closing in closings %}
@@ -9,31 +9,31 @@
       <div class="revenue-card rc">
         <div class="rc-header">
           <h3 class="rc-title">{{ closing.closed_at|format_time }}</h3>
-          <a class="rc-view" href="/dashboard/bar/{{ bar.id }}/orders/history/{{ closing.id }}">View</a>
+          <a class="rc-view" href="/dashboard/bar/{{ bar.id }}/orders/history/{{ closing.id }}">{{ _('bar_admin_history.actions.view', default='View') }}</a>
         </div>
 
         <div class="rc-kpis">
           <div class="rc-kpi">
-            <span class="label">Total collected</span>
+            <span class="label">{{ _('bar_admin_history.metrics.total_collected', default='Total collected') }}</span>
             <span class="value">CHF {{ "%.2f"|format(closing.total_revenue) }}</span>
           </div>
           <div class="rc-kpi">
-            <span class="label">Total earned</span>
+            <span class="label">{{ _('bar_admin_history.metrics.total_earned', default='Total earned') }}</span>
             <span class="value">CHF {{ "%.2f"|format(closing.total_earned) }}</span>
           </div>
           <div class="rc-kpi">
-            <span class="label">Siplygo commission (5%)</span>
+            <span class="label">{{ _('bar_admin_history.metrics.commission', default='Siplygo commission (5%)') }}</span>
             <span class="value rc-negative">CHF {{ "%.2f"|format(closing.siplygo_commission) }}</span>
           </div>
           <div class="rc-kpi rc-emph">
-            <span class="label">Amount to pay to bar</span>
+            <span class="label">{{ _('bar_admin_history.metrics.payout', default='Amount to pay to bar') }}</span>
             <span class="value">CHF {{ "%.2f"|format(closing.bar_payout) }}</span>
           </div>
         </div>
 
         {% if closing.payment_totals %}
         <div class="rc-breakdown">
-          <h4 class="rc-subtitle">Payment breakdown:</h4>
+          <h4 class="rc-subtitle">{{ _('bar_admin_history.breakdown.title', default='Payment breakdown:') }}</h4>
           <ul class="rc-list">
             {% for method, amount in closing.payment_totals.items() %}
             <li><span class="item">{{ method }}</span><span class="amount">CHF {{ '%.2f'|format(amount) }}</span></li>
@@ -47,6 +47,6 @@
   {% endfor %}
 </ul>
 {% else %}
-<p>No order history yet.</p>
+<p>{{ _('bar_admin_history.empty.history', default='No order history yet.') }}</p>
 {% endif %}
 {% endblock %}

--- a/templates/bar_admin_order_history.html
+++ b/templates/bar_admin_order_history.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1>{{ bar.name }} - Order History &amp; Revenue</h1>
+<h1>{{ _('bar_admin_history.title', bar=bar.name, default='{bar} - Order History & Revenue') }}</h1>
 {% if monthly %}
 <ul class="closing-list">
   {% for m in monthly %}
@@ -9,31 +9,31 @@
       <div class="revenue-card rc">
         <div class="rc-header">
           <h3 class="rc-title">{{ m.label }}</h3>
-          <a class="rc-view" href="/dashboard/bar/{{ bar.id }}/orders/history/{{ m.year }}/{{ m.month }}">View</a>
+          <a class="rc-view" href="/dashboard/bar/{{ bar.id }}/orders/history/{{ m.year }}/{{ m.month }}">{{ _('bar_admin_history.actions.view', default='View') }}</a>
         </div>
 
         <div class="rc-kpis">
           <div class="rc-kpi">
-            <span class="label">Total collected</span>
+            <span class="label">{{ _('bar_admin_history.metrics.total_collected', default='Total collected') }}</span>
             <span class="value">CHF {{ "%.2f"|format(m.total_revenue) }}</span>
           </div>
           <div class="rc-kpi">
-            <span class="label">Total earned</span>
+            <span class="label">{{ _('bar_admin_history.metrics.total_earned', default='Total earned') }}</span>
             <span class="value">CHF {{ "%.2f"|format(m.total_earned) }}</span>
           </div>
           <div class="rc-kpi">
-            <span class="label">Siplygo commission (5%)</span>
+            <span class="label">{{ _('bar_admin_history.metrics.commission', default='Siplygo commission (5%)') }}</span>
             <span class="value rc-negative">CHF {{ "%.2f"|format(m.siplygo_commission) }}</span>
           </div>
           <div class="rc-kpi rc-emph">
-            <span class="label">Amount to pay to bar</span>
+            <span class="label">{{ _('bar_admin_history.metrics.payout', default='Amount to pay to bar') }}</span>
             <span class="value">CHF {{ "%.2f"|format(m.bar_payout) }}</span>
           </div>
         </div>
 
         {% if m.payment_totals %}
         <div class="rc-breakdown">
-          <h4 class="rc-subtitle">Payment breakdown:</h4>
+          <h4 class="rc-subtitle">{{ _('bar_admin_history.breakdown.title', default='Payment breakdown:') }}</h4>
           <ul class="rc-list">
             {% for method, amount in m.payment_totals.items() %}
             <li><span class="item">{{ method }}</span><span class="amount">CHF {{ '%.2f'|format(amount) }}</span></li>
@@ -44,7 +44,7 @@
       </div>
       {% if m.is_past and not m.confirmed and user.is_super_admin %}
       <form method="post" action="/dashboard/bar/{{ bar.id }}/orders/history/{{ m.year }}/{{ m.month }}/confirm">
-        <button class="btn btn--primary" type="submit">Confirm Payment</button>
+        <button class="btn btn--primary" type="submit">{{ _('bar_admin_history.actions.confirm', default='Confirm Payment') }}</button>
       </form>
       {% endif %}
     </div>
@@ -52,6 +52,6 @@
   {% endfor %}
 </ul>
 {% else %}
-<p>No order history yet.</p>
+<p>{{ _('bar_admin_history.empty.history', default='No order history yet.') }}</p>
 {% endif %}
 {% endblock %}

--- a/templates/bar_admin_order_history_view.html
+++ b/templates/bar_admin_order_history_view.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1>{{ bar.name }} - Orders for {{ closing.closed_at|format_time }}</h1>
+<h1>{{ _('bar_admin_history.orders_title', bar=bar.name, date=closing.closed_at|format_time, default='{bar} - Orders for {date}') }}</h1>
 <div class="revenue-card rc">
   <div class="rc-header">
     <h3 class="rc-title">{{ closing.closed_at|format_time }}</h3>
@@ -8,26 +8,26 @@
 
   <div class="rc-kpis">
     <div class="rc-kpi">
-      <span class="label">Total collected</span>
+      <span class="label">{{ _('bar_admin_history.metrics.total_collected', default='Total collected') }}</span>
       <span class="value">CHF {{ "%.2f"|format(closing.total_revenue) }}</span>
     </div>
     <div class="rc-kpi">
-      <span class="label">Total earned</span>
+      <span class="label">{{ _('bar_admin_history.metrics.total_earned', default='Total earned') }}</span>
       <span class="value">CHF {{ "%.2f"|format(closing.total_earned) }}</span>
     </div>
     <div class="rc-kpi">
-      <span class="label">Siplygo commission (5%)</span>
+      <span class="label">{{ _('bar_admin_history.metrics.commission', default='Siplygo commission (5%)') }}</span>
       <span class="value rc-negative">CHF {{ "%.2f"|format(closing.siplygo_commission) }}</span>
     </div>
     <div class="rc-kpi rc-emph">
-      <span class="label">Amount to pay to bar</span>
+      <span class="label">{{ _('bar_admin_history.metrics.payout', default='Amount to pay to bar') }}</span>
       <span class="value">CHF {{ "%.2f"|format(bar_payout) }}</span>
     </div>
   </div>
 
   {% if payment_totals %}
   <div class="rc-breakdown">
-    <h4 class="rc-subtitle">Payment breakdown:</h4>
+    <h4 class="rc-subtitle">{{ _('bar_admin_history.breakdown.title', default='Payment breakdown:') }}</h4>
     <ul class="rc-list">
       {% for method, amount in payment_totals.items() %}
       <li><span class="item">{{ method }}</span><span class="amount">CHF {{ '%.2f'|format(amount) }}</span></li>
@@ -40,34 +40,39 @@
   {% for order in orders %}
   <article class="order-card card card--{{ order.status|lower }}" role="article" aria-labelledby="order-{{ order.id }}-title" data-status="{{ order.status }}">
     <header class="order-card__header">
-      <h3 id="order-{{ order.id }}-title">Order {{ order.public_order_code or ('#' ~ order.id) }}</h3>
-      <span class="order-status chip status status-{{ order.status|lower }}" aria-label="Order status: {{ order.status|replace('_', ' ')|title }}">{{ order.status|replace('_', ' ')|title }}</span>
+      {% set order_code = order.public_order_code or ('#' ~ order.id) %}
+      {% set status_label = order.status|replace('_', ' ')|title %}
+      <h3 id="order-{{ order.id }}-title">{{ _('order_history.card.title', code=order_code, default='Order {code}') }}</h3>
+      <span class="order-status chip status status-{{ order.status|lower }}" aria-label="{{ _('order_history.card.status_aria', status=status_label, default='Order status: {status}') }}">{{ _('order_history.card.status_label', status=status_label, default=status_label) }}</span>
     </header>
     <div class="order-card__divider"></div>
     <section class="order-card__meta">
       <dl class="order-kv">
-        <div><dt>Total</dt><dd class="num nowrap">CHF {{ "%.2f"|format(order.total) }}</dd></div>
-        <div><dt>Placed</dt><dd class="num nowrap">{{ order.created_at|format_time }}</dd></div>
+        <div><dt>{{ _('order_history.card.fields.total', default='Total') }}</dt><dd class="num nowrap">CHF {{ "%.2f"|format(order.total) }}</dd></div>
+        <div><dt>{{ _('order_history.card.fields.placed', default='Placed') }}</dt><dd class="num nowrap">{{ order.created_at|format_time }}</dd></div>
 
-        <div><dt>Customer</dt><dd>{{ order.customer_name or 'Unknown' }} <a href="tel:{{ (order.customer_prefix or '')|replace(' ', '') }}{{ (order.customer_phone or '')|replace(' ', '') }}">({{ order.customer_prefix or '' }} {{ order.customer_phone or '' }})</a></dd></div>
+        <div><dt>{{ _('order_history.card.fields.customer', default='Customer') }}</dt><dd>{{ order.customer_name or _('order_history.card.unknown_customer', default='Unknown') }} <a href="tel:{{ (order.customer_prefix or '')|replace(' ', '') }}{{ (order.customer_phone or '')|replace(' ', '') }}">({{ order.customer_prefix or '' }} {{ order.customer_phone or '' }})</a></dd></div>
 
-        <div><dt>Table</dt><dd>{{ order.table_name or '' }}</dd></div>
-        <div><dt>Payment</dt><dd>{{ order.payment_method.replace('_', ' ')|title if order.payment_method else '' }}</dd></div>
+        <div><dt>{{ _('order_history.card.fields.table', default='Table') }}</dt><dd>{{ order.table_name or '' }}</dd></div>
+        <div><dt>{{ _('order_history.card.fields.payment', default='Payment') }}</dt><dd>{{ order.payment_method.replace('_', ' ')|title if order.payment_method else '' }}</dd></div>
 
-        {% if order.ready_at %}<div><dt>Prep time</dt><dd class="num">{{ ((order.ready_at - order.created_at).total_seconds() // 60)|int }} min</dd></div>{% endif %}
+        {% if order.ready_at %}
+        {% set prep_minutes = ((order.ready_at - order.created_at).total_seconds() // 60)|int %}
+        <div><dt>{{ _('order_history.card.fields.prep_time', default='Prep time') }}</dt><dd class="num">{{ _('order_history.card.prep_minutes', minutes=prep_minutes, default='{minutes} min') }}</dd></div>
+        {% endif %}
       </dl>
     </section>
     <div class="order-card__divider"></div>
     <section class="order-card__items">
       <ul class="order-items">
         {% for item in order.items %}
-        <li><span class="qty">{{ item.qty }}×</span><span class="name">{{ item.menu_item_name or 'Unknown item' }}</span></li>
+        <li><span class="qty">{{ item.qty }}×</span><span class="name">{{ item.menu_item_name or _('order_history.card.unknown_item', default='Unknown item') }}</span></li>
         {% endfor %}
       </ul>
     </section>
   </article>
   {% else %}
-  <p>No orders.</p>
+  <p>{{ _('bar_admin_history.empty.orders', default='No orders.') }}</p>
   {% endfor %}
 </div>
 {% endblock %}

--- a/templates/bar_admin_orders.html
+++ b/templates/bar_admin_orders.html
@@ -2,29 +2,29 @@
 {% block content %}
 <section class="orders-page">
   <header class="orders-head">
-    <h1 class="orders-title">{{ bar.name }} Orders</h1>
+    <h1 class="orders-title">{{ _('bar_admin_orders.title', bar=bar.name, default='{bar} Orders') }}</h1>
     <div class="orders-controls">
-      <a class="btn" href="/dashboard/bar/{{ bar.id }}/orders/history">Order History &amp; Revenue</a>
+      <a class="btn" href="/dashboard/bar/{{ bar.id }}/orders/history">{{ _('bar_admin_orders.actions.history', default='Order History & Revenue') }}</a>
     </div>
   </header>
 
   <section class="orders-section">
-    <div class="section-head"><h2>Incoming Orders</h2></div>
+    <div class="section-head"><h2>{{ _('bartender_orders.sections.incoming', default='Incoming Orders') }}</h2></div>
     <div id="incoming-orders" class="orders-grid order-list"></div>
   </section>
 
   <section class="orders-section">
-    <div class="section-head"><h2>Preparing</h2></div>
+    <div class="section-head"><h2>{{ _('bartender_orders.sections.preparing', default='Preparing') }}</h2></div>
     <div id="preparing-orders" class="orders-grid order-list"></div>
   </section>
 
   <section class="orders-section">
-    <div class="section-head"><h2>Ready</h2></div>
+    <div class="section-head"><h2>{{ _('bartender_orders.sections.ready', default='Ready') }}</h2></div>
     <div id="ready-orders" class="orders-grid order-list"></div>
   </section>
 
   <section class="orders-section">
-    <div class="section-head"><h2>Completed</h2></div>
+    <div class="section-head"><h2>{{ _('bartender_orders.sections.completed', default='Completed') }}</h2></div>
     <div id="completed-orders" class="orders-grid order-list"></div>
   </section>
 </section>

--- a/templates/bar_category_products.html
+++ b/templates/bar_category_products.html
@@ -4,11 +4,11 @@
 <section class="menu-page">
   <header class="menu-toolbar">
     <div class="title-wrap">
-      <h1>Products in {{ category.name }} for {{ bar.name }}</h1>
-      <p class="subtitle">Add, edit and organize products for this category.</p>
+      <h1>{{ _('bar_products.manage.title', category=category.name, bar=bar.name, default='Products in {category} for {bar}') }}</h1>
+      <p class="subtitle">{{ _('bar_products.manage.subtitle', default='Add, edit and organize products for this category.') }}</p>
     </div>
     <div class="toolbar-actions">
-      <a class="btn btn--primary" href="/bar/{{ bar.id }}/categories/{{ category.id }}/products/new">Add Product</a>
+      <a class="btn btn--primary" href="/bar/{{ bar.id }}/categories/{{ category.id }}/products/new">{{ _('bar_products.manage.actions.add', default='Add Product') }}</a>
     </div>
   </header>
 
@@ -17,12 +17,12 @@
     <table class="menu-table">
       <thead>
         <tr>
-          <th>Order</th>
-          <th>Photo</th>
-          <th>Name</th>
-          <th>Description</th>
-          <th>Price (CHF)</th>
-          <th class="actions">Actions</th>
+          <th>{{ _('bar_products.manage.table.headers.order', default='Order') }}</th>
+          <th>{{ _('bar_products.manage.table.headers.photo', default='Photo') }}</th>
+          <th>{{ _('bar_products.manage.table.headers.name', default='Name') }}</th>
+          <th>{{ _('bar_products.manage.table.headers.description', default='Description') }}</th>
+          <th>{{ _('bar_products.manage.table.headers.price', default='Price (CHF)') }}</th>
+          <th class="actions">{{ _('bar_products.manage.table.headers.actions', default='Actions') }}</th>
         </tr>
       </thead>
       <tbody>
@@ -37,10 +37,10 @@
           <td>{{ "%.2f"|format(product.price) }}</td>
           <td class="actions">
             <div class="actions-group">
-              <a class="btn-outline" href="/bar/{{ bar.id }}/categories/{{ category.id }}/products/{{ product.id }}/edit">Edit</a>
-              <button type="submit" form="delete_{{ product.id }}" class="btn-danger-soft">Delete</button>
+              <a class="btn-outline" href="/bar/{{ bar.id }}/categories/{{ category.id }}/products/{{ product.id }}/edit">{{ _('bar_products.manage.actions.edit', default='Edit') }}</a>
+              <button type="submit" form="delete_{{ product.id }}" class="btn-danger-soft">{{ _('bar_products.manage.actions.delete', default='Delete') }}</button>
             </div>
-            <form id="delete_{{ product.id }}" method="post" action="/bar/{{ bar.id }}/categories/{{ category.id }}/products/{{ product.id }}/delete" style="display:none" onsubmit="return confirm('Are you sure you want to delete this product?');"></form>
+            <form id="delete_{{ product.id }}" method="post" action="/bar/{{ bar.id }}/categories/{{ category.id }}/products/{{ product.id }}/delete" style="display:none" onsubmit="return confirm(&quot;{{ _('bar_products.manage.confirm_delete', default='Are you sure you want to delete this product?')|replace('"', '\\"') }}&quot;);"></form>
           </td>
         </tr>
         {% endfor %}
@@ -48,7 +48,7 @@
     </table>
   </div>
   {% else %}
-  <p>No products in this category.</p>
+  <p>{{ _('bar_products.manage.empty', default='No products in this category.') }}</p>
   {% endif %}
 </section>
 

--- a/templates/bar_edit_category.html
+++ b/templates/bar_edit_category.html
@@ -1,16 +1,16 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1>Edit Category for {{ bar.name }}</h1>
+<h1>{{ _('bar_categories.edit.title', bar=bar.name, default='Edit Category for {bar}') }}</h1>
 <form class="form" method="post">
-  <label for="name">Name
+  <label for="name">{{ _('bar_categories.form.name', default='Name') }}
     <input id="name" name="name" value="{{ category.name }}" required>
   </label>
-  <label for="description">Description
+  <label for="description">{{ _('bar_categories.form.description', default='Description') }}
     <textarea id="description" name="description" required>{{ category.description }}</textarea>
   </label>
-  <label for="display_order">Display Order
+  <label for="display_order">{{ _('bar_categories.form.display_order', default='Display Order') }}
     <input id="display_order" type="number" name="display_order" value="{{ category.display_order }}">
   </label>
-  <button class="btn btn--primary" type="submit">Save</button>
+  <button class="btn btn--primary" type="submit">{{ _('bar_categories.form.save', default='Save') }}</button>
 </form>
 {% endblock %}

--- a/templates/bar_edit_product.html
+++ b/templates/bar_edit_product.html
@@ -1,24 +1,24 @@
 {% extends "layout.html" %}
 {% block content %}
 {% set fallback_img = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCA0MDAgMjI1Jz48cmVjdCB3aWR0aD0nNDAwJyBoZWlnaHQ9JzIyNScgZmlsbD0nJTIzZjFmM2Y1Jy8+PC9zdmc+" %}
-<h1>Edit Product {{ product.name }}</h1>
+<h1>{{ _('bar_products.edit.title', product=product.name, default='Edit Product {product}') }}</h1>
 <form class="form" method="post" enctype="multipart/form-data">
-  <label for="name">Name
+  <label for="name">{{ _('bar_products.form.name', default='Name') }}
     <input id="name" name="name" value="{{ product.name }}" required>
   </label>
-  <label for="price">Price (CHF)
+  <label for="price">{{ _('bar_products.form.price', default='Price (CHF)') }}
     <input id="price" type="number" step="0.01" name="price" value="{{ '%.2f'|format(product.price) }}" required>
   </label>
-  <label for="description">Description
+  <label for="description">{{ _('bar_products.form.description', default='Description') }}
     <textarea id="description" name="description" maxlength="190" required>{{ product.description }}</textarea>
   </label>
-  <label for="display_order">Display Order
+  <label for="display_order">{{ _('bar_products.form.display_order', default='Display Order') }}
     <input id="display_order" type="number" name="display_order" value="{{ product.display_order }}">
   </label>
   <img src="{{ product.photo_url }}" alt="{{ product.name }} photo" style="max-width:200px;" loading="lazy" decoding="async" onerror="this.src='{{ fallback_img }}';this.onerror=null;" width="400" height="225" />
-  <label for="photo">Photo
+  <label for="photo">{{ _('bar_products.form.photo', default='Photo') }}
     <input id="photo" type="file" name="photo" accept="image/*">
   </label>
-  <button class="btn btn--primary" type="submit">Update</button>
+  <button class="btn btn--primary" type="submit">{{ _('bar_products.form.update', default='Update') }}</button>
 </form>
 {% endblock %}

--- a/templates/bar_manage_categories.html
+++ b/templates/bar_manage_categories.html
@@ -3,18 +3,18 @@
 <section class="menu-page">
   <header class="menu-toolbar">
     <div class="title-wrap">
-      <h1>Manage Categories for {{ bar.name }}</h1>
-      <p class="subtitle">Create, edit and organize menu categories for this venue.</p>
+      <h1>{{ _('bar_categories.manage.title', bar=bar.name, default='Manage Categories for {bar}') }}</h1>
+      <p class="subtitle">{{ _('bar_categories.manage.subtitle', default='Create, edit and organize menu categories for this venue.') }}</p>
     </div>
     <div class="toolbar-actions">
-      <form class="menu-search" role="search" aria-label="Search categories" onsubmit="return false">
+      <form class="menu-search" role="search" aria-label="{{ _('bar_categories.manage.search.aria', default='Search categories') }}" onsubmit="return false">
         <i class="bi bi-search" aria-hidden="true"></i>
-        <input id="categorySearch" type="search" inputmode="search" autocomplete="off" placeholder="Search categories…" aria-label="Search categories by name">
-        <button class="clear" type="button" aria-label="Clear search">
+        <input id="categorySearch" type="search" inputmode="search" autocomplete="off" placeholder="{{ _('bar_categories.manage.search.placeholder', default='Search categories…') }}" aria-label="{{ _('bar_categories.manage.search.input_aria', default='Search categories by name') }}">
+        <button class="clear" type="button" aria-label="{{ _('bar_categories.manage.search.clear', default='Clear search') }}">
           <i class="bi bi-x-circle" aria-hidden="true"></i>
         </button>
       </form>
-      <a href="/bar/{{ bar.id }}/categories/new" class="btn btn--primary">Add Category</a>
+      <a href="/bar/{{ bar.id }}/categories/new" class="btn btn--primary">{{ _('bar_categories.manage.actions.add', default='Add Category') }}</a>
     </div>
   </header>
 
@@ -24,9 +24,9 @@
       <thead>
         <tr>
           <th style="width:56px">#</th>
-          <th>Name</th>
-          <th>Description</th>
-          <th class="actions">Actions</th>
+          <th>{{ _('bar_categories.manage.table.headers.name', default='Name') }}</th>
+          <th>{{ _('bar_categories.manage.table.headers.description', default='Description') }}</th>
+          <th class="actions">{{ _('bar_categories.manage.table.headers.actions', default='Actions') }}</th>
         </tr>
       </thead>
       <tbody>
@@ -37,11 +37,11 @@
           <td>{{ category.description }}</td>
           <td class="actions">
             <div class="actions-group">
-              <a href="/bar/{{ bar.id }}/categories/{{ category.id }}/products" class="btn-outline">Products</a>
-              <a href="/bar/{{ bar.id }}/categories/{{ category.id }}/edit" class="btn-outline">Edit</a>
-              <button type="submit" form="delete_{{ category.id }}" class="btn-danger-soft">Delete</button>
+              <a href="/bar/{{ bar.id }}/categories/{{ category.id }}/products" class="btn-outline">{{ _('bar_categories.manage.actions.products', default='Products') }}</a>
+              <a href="/bar/{{ bar.id }}/categories/{{ category.id }}/edit" class="btn-outline">{{ _('bar_categories.manage.actions.edit', default='Edit') }}</a>
+              <button type="submit" form="delete_{{ category.id }}" class="btn-danger-soft">{{ _('bar_categories.manage.actions.delete', default='Delete') }}</button>
             </div>
-            <form id="delete_{{ category.id }}" method="post" action="/bar/{{ bar.id }}/categories/{{ category.id }}/delete" style="display:none" onsubmit="return confirm('Are you sure you want to delete this category?');"></form>
+            <form id="delete_{{ category.id }}" method="post" action="/bar/{{ bar.id }}/categories/{{ category.id }}/delete" style="display:none" onsubmit="return confirm(&quot;{{ _('bar_categories.manage.confirm_delete', default='Are you sure you want to delete this category?')|replace('"', '\\"') }}&quot;);"></form>
           </td>
         </tr>
         {% endfor %}
@@ -49,7 +49,7 @@
     </table>
   </div>
   {% else %}
-  <p>No categories yet.</p>
+  <p>{{ _('bar_categories.manage.empty', default='No categories yet.') }}</p>
   {% endif %}
 </section>
 

--- a/templates/bar_new_category.html
+++ b/templates/bar_new_category.html
@@ -1,17 +1,17 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1>Add Category for {{ bar.name }}</h1>
+<h1>{{ _('bar_categories.new.title', bar=bar.name, default='Add Category for {bar}') }}</h1>
 {% if error %}<p class="error">{{ error }}</p>{% endif %}
 <form class="form" method="post">
-  <label for="name">Name
+  <label for="name">{{ _('bar_categories.form.name', default='Name') }}
     <input id="name" name="name" required>
   </label>
-  <label for="description">Description
+  <label for="description">{{ _('bar_categories.form.description', default='Description') }}
     <textarea id="description" name="description" required></textarea>
   </label>
-  <label for="display_order">Display Order
+  <label for="display_order">{{ _('bar_categories.form.display_order', default='Display Order') }}
     <input id="display_order" type="number" name="display_order" value="0">
   </label>
-  <button class="btn btn--primary" type="submit">Create</button>
+  <button class="btn btn--primary" type="submit">{{ _('bar_categories.form.create', default='Create') }}</button>
 </form>
 {% endblock %}

--- a/templates/bar_new_product.html
+++ b/templates/bar_new_product.html
@@ -1,24 +1,24 @@
 {% extends "layout.html" %}
 {% block content %}
-<h1>Add Product to {{ category.name }}</h1>
+<h1>{{ _('bar_products.new.title', category=category.name, default='Add Product to {category}') }}</h1>
 {% if error %}<p class="error">{{ error }}</p>{% endif %}
 <form class="form" method="post" enctype="multipart/form-data">
-  <label for="name">Name
+  <label for="name">{{ _('bar_products.form.name', default='Name') }}
     <input id="name" name="name" required>
   </label>
-  <label for="price">Price (CHF)
+  <label for="price">{{ _('bar_products.form.price', default='Price (CHF)') }}
     <input id="price" type="number" step="0.01" name="price" required>
   </label>
-  <label for="description">Description
+  <label for="description">{{ _('bar_products.form.description', default='Description') }}
     <textarea id="description" name="description" maxlength="190" required></textarea>
   </label>
-  <label for="display_order">Display Order
+  <label for="display_order">{{ _('bar_products.form.display_order', default='Display Order') }}
     <input id="display_order" type="number" name="display_order" value="0">
   </label>
-  <label for="photo">Photo
+  <label for="photo">{{ _('bar_products.form.photo', default='Photo') }}
     <input id="photo" type="file" name="photo">
   </label>
-  <button class="btn btn--primary" type="submit">Create</button>
+  <button class="btn btn--primary" type="submit">{{ _('bar_products.form.create', default='Create') }}</button>
 </form>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- localize bar admin revenue history and live orders templates to use new translation keys
- translate bar category and product management pages and forms, including delete confirmations
- add English and Italian strings plus AGENTS guidance for the new namespaces

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ca4c320c0c83208117cc2fcfe1d86e