### PR TITLE
Localize more admin pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -395,3 +395,7 @@
 - Admin analytics, audit logs, table management, bar user management, admin bar listings, admin change password, admin dashboard, and admin user edit pages localise through the `admin_analytics`, `admin_audit_logs`, `admin_tables`, `admin_bar_users`, `admin_bars`, `admin_change_user_password`, `admin_dashboard`, and `admin_edit_user` namespaces in `app/i18n/translations/*.json`.
 - Admin users, profile summary, bar option chooser, notifications list, bar creation, welcome message editor, notification detail, and admin user overview pages localise through the `admin_users`, `admin_profile`, `admin_edit_bar_options`, `admin_notifications`, `admin_new_bar`, `admin_edit_welcome`, `admin_notification_view`, and `admin_view_user` namespaces in `app/i18n/translations/*.json`.
 - The `/topup` standalone page uses the `topup` namespace for headings, form labels, and alerts.
+- Admin bar editing and notification workflows use new namespaces in `app/i18n/translations/*.json`:
+  - `admin_edit_bar` covers the bar info form, including category chips and opening hours labels.
+  - `admin_new_notification` drives the broadcast form, search controls, and selection prompts.
+  - `admin_payments` defines the payouts list header, search inputs, and action buttons.

--- a/app/i18n/translations/en.json
+++ b/app/i18n/translations/en.json
@@ -965,6 +965,55 @@
       "phone": "Phone:"
     }
   },
+  "admin_edit_bar": {
+    "title": "Edit Bar",
+    "cards": {
+      "details": {
+        "title": "Details"
+      },
+      "media": {
+        "title": "Media &amp; Hours"
+      }
+    },
+    "fields": {
+      "name": "Name",
+      "address": "Address",
+      "city": "City",
+      "state": "Canton",
+      "description": "Description",
+      "categories": "Categories",
+      "photo": "Photo",
+      "rating": "Rating",
+      "manual_closed": "Close bar manually"
+    },
+    "help": {
+      "description": "Short, clear description. Links will be ignored.",
+      "categories": "Click to select/deselect. Selected items are highlighted."
+    },
+    "categories": {
+      "count": "{selected}/{max} selected"
+    },
+    "media": {
+      "photo_alt": "{bar} photo"
+    },
+    "days": {
+      "monday": "Monday",
+      "tuesday": "Tuesday",
+      "wednesday": "Wednesday",
+      "thursday": "Thursday",
+      "friday": "Friday",
+      "saturday": "Saturday",
+      "sunday": "Sunday"
+    },
+    "hours": {
+      "day": "Day",
+      "open": "Open",
+      "close": "Close"
+    },
+    "actions": {
+      "save": "Save"
+    }
+  },
   "admin_edit_bar_options": {
     "back": "Back to Bars",
     "title": "Edit {bar}",
@@ -1022,6 +1071,68 @@
       "prompt": "Are you sure you want to delete this notification?",
       "cancel": "Cancel",
       "confirm": "Delete"
+    }
+  },
+  "admin_new_notification": {
+    "title": "New Notification",
+    "subtitle": "Send a message to users.",
+    "form": {
+      "target": {
+        "label": "Target",
+        "options": {
+          "all": "All Users",
+          "user": "Specific User",
+          "bar": "Users of Bar"
+        }
+      },
+      "subject": "Subject",
+      "message": "Message",
+      "link_url": "Link URL",
+      "image": "Image",
+      "attachment": "Attachment",
+      "submit": "Send"
+    },
+    "user_section": {
+      "title": "Select User",
+      "search": {
+        "aria": "Search users",
+        "placeholder": "Search users…",
+        "input_aria": "Search users",
+        "clear": "Clear search"
+      },
+      "table": {
+        "headers": {
+          "id": "ID",
+          "username": "Username",
+          "email": "Email",
+          "actions": "Actions"
+        }
+      }
+    },
+    "bar_section": {
+      "title": "Select Bar",
+      "search": {
+        "aria": "Search bars",
+        "placeholder": "Search bars…",
+        "input_aria": "Search bars",
+        "clear": "Clear search"
+      },
+      "table": {
+        "headers": {
+          "id": "ID",
+          "name": "Name",
+          "city": "City",
+          "actions": "Actions"
+        }
+      }
+    },
+    "actions": {
+      "select": "Select",
+      "selected": "Selected"
+    },
+    "alerts": {
+      "select_user": "Please select a user.",
+      "select_bar": "Please select a bar."
     }
   },
   "admin_new_bar": {
@@ -1088,6 +1199,27 @@
       },
       "read_yes": "Yes",
       "read_no": "No"
+    }
+  },
+  "admin_payments": {
+    "title": "Payments",
+    "subtitle": "Review bar revenue and closings.",
+    "search": {
+      "aria": "Search bars",
+      "placeholder": "Search bars by name…",
+      "input_aria": "Search bars by name",
+      "clear": "Clear search"
+    },
+    "table": {
+      "headers": {
+        "name": "Name",
+        "actions": "Actions"
+      }
+    },
+    "actions": {
+      "view": "View",
+      "add_test": "Add Test Closing",
+      "delete_test": "Delete Test Closing"
     }
   },
   "admin_view_user": {

--- a/app/i18n/translations/it.json
+++ b/app/i18n/translations/it.json
@@ -965,6 +965,55 @@
       "phone": "Telefono:"
     }
   },
+  "admin_edit_bar": {
+    "title": "Modifica locale",
+    "cards": {
+      "details": {
+        "title": "Dettagli"
+      },
+      "media": {
+        "title": "Media e orari"
+      }
+    },
+    "fields": {
+      "name": "Nome",
+      "address": "Indirizzo",
+      "city": "Città",
+      "state": "Cantone",
+      "description": "Descrizione",
+      "categories": "Categorie",
+      "photo": "Foto",
+      "rating": "Valutazione",
+      "manual_closed": "Chiudi il locale manualmente"
+    },
+    "help": {
+      "description": "Descrizione breve e chiara. I link verranno ignorati.",
+      "categories": "Clicca per selezionare/deselezionare. Gli elementi selezionati sono evidenziati."
+    },
+    "categories": {
+      "count": "{selected}/{max} selezionate"
+    },
+    "media": {
+      "photo_alt": "Foto di {bar}"
+    },
+    "days": {
+      "monday": "Lunedì",
+      "tuesday": "Martedì",
+      "wednesday": "Mercoledì",
+      "thursday": "Giovedì",
+      "friday": "Venerdì",
+      "saturday": "Sabato",
+      "sunday": "Domenica"
+    },
+    "hours": {
+      "day": "Giorno",
+      "open": "Apertura",
+      "close": "Chiusura"
+    },
+    "actions": {
+      "save": "Salva"
+    }
+  },
   "admin_edit_bar_options": {
     "back": "Torna ai locali",
     "title": "Modifica {bar}",
@@ -1022,6 +1071,68 @@
       "prompt": "Sei sicuro di voler eliminare questa notifica?",
       "cancel": "Annulla",
       "confirm": "Elimina"
+    }
+  },
+  "admin_new_notification": {
+    "title": "Nuova notifica",
+    "subtitle": "Invia un messaggio agli utenti.",
+    "form": {
+      "target": {
+        "label": "Destinatari",
+        "options": {
+          "all": "Tutti gli utenti",
+          "user": "Utente specifico",
+          "bar": "Utenti del locale"
+        }
+      },
+      "subject": "Oggetto",
+      "message": "Messaggio",
+      "link_url": "URL del collegamento",
+      "image": "Immagine",
+      "attachment": "Allegato",
+      "submit": "Invia"
+    },
+    "user_section": {
+      "title": "Seleziona utente",
+      "search": {
+        "aria": "Cerca utenti",
+        "placeholder": "Cerca utenti…",
+        "input_aria": "Cerca utenti",
+        "clear": "Cancella ricerca"
+      },
+      "table": {
+        "headers": {
+          "id": "ID",
+          "username": "Nome utente",
+          "email": "Email",
+          "actions": "Azioni"
+        }
+      }
+    },
+    "bar_section": {
+      "title": "Seleziona locale",
+      "search": {
+        "aria": "Cerca locali",
+        "placeholder": "Cerca locali…",
+        "input_aria": "Cerca locali",
+        "clear": "Cancella ricerca"
+      },
+      "table": {
+        "headers": {
+          "id": "ID",
+          "name": "Nome",
+          "city": "Città",
+          "actions": "Azioni"
+        }
+      }
+    },
+    "actions": {
+      "select": "Seleziona",
+      "selected": "Selezionato"
+    },
+    "alerts": {
+      "select_user": "Seleziona un utente.",
+      "select_bar": "Seleziona un locale."
     }
   },
   "admin_new_bar": {
@@ -1088,6 +1199,27 @@
       },
       "read_yes": "Sì",
       "read_no": "No"
+    }
+  },
+  "admin_payments": {
+    "title": "Pagamenti",
+    "subtitle": "Controlla ricavi e chiusure dei locali.",
+    "search": {
+      "aria": "Cerca locali",
+      "placeholder": "Cerca locali per nome…",
+      "input_aria": "Cerca locali per nome",
+      "clear": "Cancella ricerca"
+    },
+    "table": {
+      "headers": {
+        "name": "Nome",
+        "actions": "Azioni"
+      }
+    },
+    "actions": {
+      "view": "Visualizza",
+      "add_test": "Aggiungi chiusura di test",
+      "delete_test": "Elimina chiusura di test"
     }
   },
   "admin_view_user": {

--- a/templates/admin_edit_bar.html
+++ b/templates/admin_edit_bar.html
@@ -2,7 +2,7 @@
 {% block content %}
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
 <section class="editbar">
-  <h1>Edit Bar</h1>
+  <h1>{{ _('admin_edit_bar.title', default='Edit Bar') }}</h1>
   {% if error %}<p class="error">{{ error }}</p>{% endif %}
 
   <div class="card map-card">
@@ -13,41 +13,50 @@
     <div class="grid-2">
 
       <div class="card form-card">
-        <h2 class="card-title"><i class="bi bi-geo-alt"></i> Details</h2>
+        <h2 class="card-title"><i class="bi bi-geo-alt"></i> {{ _('admin_edit_bar.cards.details.title', default='Details') }}</h2>
 
         <div class="field-group">
-          <label for="name">Name</label>
+          <label for="name">{{ _('admin_edit_bar.fields.name', default='Name') }}</label>
           <input id="name" name="name" class="input-pill" value="{{ bar.name }}">
         </div>
 
         <div class="field-group">
-          <label for="address">Address</label>
+          <label for="address">{{ _('admin_edit_bar.fields.address', default='Address') }}</label>
           <input id="address" name="address" class="input-pill" value="{{ bar.address }}">
         </div>
 
         <div class="field-row">
           <div class="field-group">
-              <label for="city">City</label>
+              <label for="city">{{ _('admin_edit_bar.fields.city', default='City') }}</label>
               <input id="city" name="city" class="input-pill" value="{{ bar.city }}">
           </div>
           <div class="field-group">
-              <label for="state">Canton</label>
+              <label for="state">{{ _('admin_edit_bar.fields.state', default='Canton') }}</label>
               <input id="state" name="state" class="input-pill" value="{{ bar.state }}">
           </div>
         </div>
 
         <div class="field-group">
-          <label for="description">Description</label>
+          <label for="description">{{ _('admin_edit_bar.fields.description', default='Description') }}</label>
           <textarea id="description" name="description" maxlength="120">{{ bar.description }}</textarea>
-          <small class="help">Short, clear description. Links will be ignored.</small>
+          <small class="help">{{ _('admin_edit_bar.help.description', default='Short, clear description. Links will be ignored.') }}</small>
         </div>
 
         <div class="field-group">
-          <label>Categories</label>
+          <label>{{ _('admin_edit_bar.fields.categories', default='Categories') }}</label>
           <div id="categoriesChips" class="chips-grid" aria-describedby="catHelp"></div>
           <div class="chips-meta">
-            <small id="catCount" class="count">0/5 selected</small>
-            <small id="catHelp">Click to select/deselect. Selected items are highlighted.</small>
+            {% set max_categories = 5 %}
+            {% set selected_count = selected_categories|length if selected_categories else 0 %}
+            <small
+              id="catCount"
+              class="count"
+              data-template="{{ _('admin_edit_bar.categories.count', default='{selected}/{max} selected') }}"
+              data-max="{{ max_categories }}"
+            >
+              {{ _('admin_edit_bar.categories.count', default='{selected}/{max} selected', selected=selected_count, max=max_categories) }}
+            </small>
+            <small id="catHelp">{{ _('admin_edit_bar.help.categories', default='Click to select/deselect. Selected items are highlighted.') }}</small>
           </div>
           <select id="categoriesNative" name="categories" multiple hidden>
             {% for c in bar_categories %}
@@ -58,37 +67,49 @@
       </div>
 
       <div class="card form-card">
-        <h2 class="card-title"><i class="bi bi-card-image"></i> Media &amp; Hours</h2>
+        <h2 class="card-title"><i class="bi bi-card-image"></i> {{ _('admin_edit_bar.cards.media.title', default='Media &amp; Hours')|safe }}</h2>
 
         {% if bar.photo_url %}
         <div class="field-group">
-          <img src="{{ bar.photo_url }}" alt="{{ bar.name }} photo" style="max-width:200px;"/>
+          <img src="{{ bar.photo_url }}" alt="{{ _('admin_edit_bar.media.photo_alt', bar=bar.name, default='{bar} photo') }}" style="max-width:200px;"/>
         </div>
         {% endif %}
 
         <div class="field-group">
-          <label for="photo">Photo</label>
+          <label for="photo">{{ _('admin_edit_bar.fields.photo', default='Photo') }}</label>
           <input id="photo" name="photo" type="file">
         </div>
 
         {% if user.is_super_admin %}
         <div class="field-group">
-          <label for="rating">Rating</label>
+          <label for="rating">{{ _('admin_edit_bar.fields.rating', default='Rating') }}</label>
           <input id="rating" name="rating" class="input-pill" type="number" min="0" max="5" step="0.1" value="{{ bar.rating or 0 }}">
         </div>
         {% endif %}
 
         <div class="field-group">
           <label class="switch-label">
-            <input id="manual_closed" name="manual_closed" type="checkbox" {% if bar.manual_closed %}checked{% endif %}> Close bar manually
+            <input id="manual_closed" name="manual_closed" type="checkbox" {% if bar.manual_closed %}checked{% endif %}> {{ _('admin_edit_bar.fields.manual_closed', default='Close bar manually') }}
           </label>
         </div>
 
         <div class="field-group hours-table-wrap">
-          {% set days = ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday'] %}
+          {% set days = [
+            _('admin_edit_bar.days.monday', default='Monday'),
+            _('admin_edit_bar.days.tuesday', default='Tuesday'),
+            _('admin_edit_bar.days.wednesday', default='Wednesday'),
+            _('admin_edit_bar.days.thursday', default='Thursday'),
+            _('admin_edit_bar.days.friday', default='Friday'),
+            _('admin_edit_bar.days.saturday', default='Saturday'),
+            _('admin_edit_bar.days.sunday', default='Sunday')
+          ] %}
           <table class="hours-table">
             <thead>
-              <tr><th>Day</th><th>Open</th><th>Close</th></tr>
+              <tr>
+                <th>{{ _('admin_edit_bar.hours.day', default='Day') }}</th>
+                <th>{{ _('admin_edit_bar.hours.open', default='Open') }}</th>
+                <th>{{ _('admin_edit_bar.hours.close', default='Close') }}</th>
+              </tr>
             </thead>
             <tbody>
             {% for day in days %}
@@ -113,7 +134,7 @@
     <input type="hidden" name="tags" value="">
 
     <div class="form-actions save-inline">
-      <button type="submit" class="btn btn--primary">Save</button>
+      <button type="submit" class="btn btn--primary">{{ _('admin_edit_bar.actions.save', default='Save') }}</button>
     </div>
   </form>
 </section>
@@ -141,8 +162,10 @@
   const select = document.getElementById('categoriesNative');
   const mount  = document.getElementById('categoriesChips');
   const countEl= document.getElementById('catCount');
+  const countTemplate = countEl?.dataset.template || '{selected}/{max}';
+  const countMax = Number(countEl?.dataset.max || 5);
   if(select && mount){
-    const MAX = 5;
+    const MAX = countMax || 5;
     const all = Array.from(select.options).map(o=>({ value:o.value, label:o.text, selected:o.selected }));
     const selectedCount = ()=> all.filter(i=>i.selected).length;
 
@@ -155,7 +178,7 @@
     function render(){
       mount.innerHTML = '';
       const cnt = selectedCount();
-      if(countEl) countEl.textContent = `${cnt}/${MAX} selected`;
+      if(countEl) countEl.textContent = countTemplate.replace('{selected}', cnt).replace('{max}', MAX);
       const limitReached = cnt >= MAX;
 
       all.forEach(item=>{

--- a/templates/admin_new_notification.html
+++ b/templates/admin_new_notification.html
@@ -3,28 +3,28 @@
 <section class="users-page">
   <header class="users-toolbar">
     <div class="title-wrap">
-      <h1>New Notification</h1>
-      <p class="subtitle">Send a message to users.</p>
+      <h1>{{ _('admin_new_notification.title', default='New Notification') }}</h1>
+      <p class="subtitle">{{ _('admin_new_notification.subtitle', default='Send a message to users.') }}</p>
     </div>
   </header>
   {% if error %}
   <p class="alert-danger">{{ error }}</p>
   {% endif %}
   <form class="form" method="post" action="/admin/notifications" enctype="multipart/form-data">
-    <label>Target
+    <label>{{ _('admin_new_notification.form.target.label', default='Target') }}
       <select name="target" id="target" required>
-        <option value="all">All Users</option>
-        <option value="user">Specific User</option>
-        <option value="bar">Users of Bar</option>
+        <option value="all">{{ _('admin_new_notification.form.target.options.all', default='All Users') }}</option>
+        <option value="user">{{ _('admin_new_notification.form.target.options.user', default='Specific User') }}</option>
+        <option value="bar">{{ _('admin_new_notification.form.target.options.bar', default='Users of Bar') }}</option>
       </select>
     </label>
 
     <section id="userSection" hidden>
-      <h2>Select User</h2>
-      <div class="users-search" role="search" aria-label="Search users" onsubmit="return false">
+      <h2>{{ _('admin_new_notification.user_section.title', default='Select User') }}</h2>
+      <div class="users-search" role="search" aria-label="{{ _('admin_new_notification.user_section.search.aria', default='Search users') }}" onsubmit="return false">
         <i class="bi bi-search" aria-hidden="true"></i>
-        <input id="userSearch" type="search" inputmode="search" autocomplete="off" placeholder="Search users…" aria-label="Search users">
-        <button class="clear" type="button" aria-label="Clear search">
+        <input id="userSearch" type="search" inputmode="search" autocomplete="off" placeholder="{{ _('admin_new_notification.user_section.search.placeholder', default='Search users…') }}" aria-label="{{ _('admin_new_notification.user_section.search.input_aria', default='Search users') }}">
+        <button class="clear" type="button" aria-label="{{ _('admin_new_notification.user_section.search.clear', default='Clear search') }}">
           <i class="bi bi-x-circle" aria-hidden="true"></i>
         </button>
       </div>
@@ -32,10 +32,10 @@
         <table class="users-table">
           <thead>
             <tr>
-              <th>ID</th>
-              <th>Username</th>
-              <th>Email</th>
-              <th class="actions">Actions</th>
+              <th>{{ _('admin_new_notification.user_section.table.headers.id', default='ID') }}</th>
+              <th>{{ _('admin_new_notification.user_section.table.headers.username', default='Username') }}</th>
+              <th>{{ _('admin_new_notification.user_section.table.headers.email', default='Email') }}</th>
+              <th class="actions">{{ _('admin_new_notification.user_section.table.headers.actions', default='Actions') }}</th>
             </tr>
           </thead>
           <tbody id="userRows">
@@ -45,7 +45,7 @@
               <td>{{ u.username }}</td>
               <td>{{ u.email }}</td>
               <td class="actions">
-                <button type="button" class="btn-outline js-pick-user" data-user-id="{{ u.id }}">Select</button>
+                <button type="button" class="btn-outline js-pick-user" data-user-id="{{ u.id }}">{{ _('admin_new_notification.actions.select', default='Select') }}</button>
               </td>
             </tr>
             {% endfor %}
@@ -56,11 +56,11 @@
     </section>
 
     <section id="barSection" hidden>
-      <h2>Select Bar</h2>
-      <div class="bars-search" role="search" aria-label="Search bars" onsubmit="return false">
+      <h2>{{ _('admin_new_notification.bar_section.title', default='Select Bar') }}</h2>
+      <div class="bars-search" role="search" aria-label="{{ _('admin_new_notification.bar_section.search.aria', default='Search bars') }}" onsubmit="return false">
         <i class="bi bi-search" aria-hidden="true"></i>
-        <input id="barSearch" type="search" inputmode="search" autocomplete="off" placeholder="Search bars…" aria-label="Search bars">
-        <button class="clear" type="button" aria-label="Clear search">
+        <input id="barSearch" type="search" inputmode="search" autocomplete="off" placeholder="{{ _('admin_new_notification.bar_section.search.placeholder', default='Search bars…') }}" aria-label="{{ _('admin_new_notification.bar_section.search.input_aria', default='Search bars') }}">
+        <button class="clear" type="button" aria-label="{{ _('admin_new_notification.bar_section.search.clear', default='Clear search') }}">
           <i class="bi bi-x-circle" aria-hidden="true"></i>
         </button>
       </div>
@@ -68,10 +68,10 @@
         <table class="bars-table">
           <thead>
             <tr>
-              <th>ID</th>
-              <th>Name</th>
-              <th>City</th>
-              <th class="actions">Actions</th>
+              <th>{{ _('admin_new_notification.bar_section.table.headers.id', default='ID') }}</th>
+              <th>{{ _('admin_new_notification.bar_section.table.headers.name', default='Name') }}</th>
+              <th>{{ _('admin_new_notification.bar_section.table.headers.city', default='City') }}</th>
+              <th class="actions">{{ _('admin_new_notification.bar_section.table.headers.actions', default='Actions') }}</th>
             </tr>
           </thead>
           <tbody id="barRows">
@@ -81,7 +81,7 @@
               <td>{{ b.name }}</td>
               <td>{{ b.city }}</td>
               <td class="actions">
-                <button type="button" class="btn-outline js-pick-bar" data-bar-id="{{ b.id }}">Select</button>
+                <button type="button" class="btn-outline js-pick-bar" data-bar-id="{{ b.id }}">{{ _('admin_new_notification.actions.select', default='Select') }}</button>
               </td>
             </tr>
             {% endfor %}
@@ -91,22 +91,22 @@
       <input type="hidden" name="bar_id" id="bar_id">
     </section>
 
-    <label>Subject
+    <label>{{ _('admin_new_notification.form.subject', default='Subject') }}
       <input type="text" name="subject" maxlength="30">
     </label>
-    <label>Message
+    <label>{{ _('admin_new_notification.form.message', default='Message') }}
       <textarea name="body" rows="4"></textarea>
     </label>
-    <label>Link URL
+    <label>{{ _('admin_new_notification.form.link_url', default='Link URL') }}
       <input type="url" name="link_url">
     </label>
-    <label>Image
+    <label>{{ _('admin_new_notification.form.image', default='Image') }}
       <input type="file" name="image" accept="image/*">
     </label>
-    <label>Attachment
+    <label>{{ _('admin_new_notification.form.attachment', default='Attachment') }}
       <input type="file" name="attachment">
     </label>
-    <button class="btn btn--primary" type="submit">Send</button>
+    <button class="btn btn--primary" type="submit">{{ _('admin_new_notification.form.submit', default='Send') }}</button>
   </form>
 </section>
 
@@ -118,6 +118,12 @@
   const userInput = document.getElementById('user_id');
   const barInput = document.getElementById('bar_id');
   const form = document.querySelector('form');
+  const texts = {{ {
+    'select_user': _('admin_new_notification.alerts.select_user', default='Please select a user.'),
+    'select_bar': _('admin_new_notification.alerts.select_bar', default='Please select a bar.'),
+    'select': _('admin_new_notification.actions.select', default='Select'),
+    'selected': _('admin_new_notification.actions.selected', default='Selected')
+  }|tojson }};
   function updateTarget(){
     const val = target.value;
     userSection.hidden = val !== 'user';
@@ -133,7 +139,7 @@
     const val = target.value;
     if((val === 'user' && !userInput.value) || (val === 'bar' && !barInput.value)){
       e.preventDefault();
-      alert('Please select a ' + (val === 'user' ? 'user' : 'bar'));
+      alert(val === 'user' ? texts.select_user : texts.select_bar);
     }
   });
   const norm = s => (s||'').toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g,'').trim();
@@ -159,16 +165,16 @@
     if(!btn) return;
     e.preventDefault();
     userInput.value = btn.dataset.userId;
-    document.querySelectorAll('.js-pick-user').forEach(b=>b.textContent='Select');
-    btn.textContent='Selected';
+    document.querySelectorAll('.js-pick-user').forEach(b=>b.textContent=texts.select);
+    btn.textContent=texts.selected;
   });
   document.getElementById('barRows')?.addEventListener('click', e => {
     const btn = e.target.closest('.js-pick-bar');
     if(!btn) return;
     e.preventDefault();
     barInput.value = btn.dataset.barId;
-    document.querySelectorAll('.js-pick-bar').forEach(b=>b.textContent='Select');
-    btn.textContent='Selected';
+    document.querySelectorAll('.js-pick-bar').forEach(b=>b.textContent=texts.select);
+    btn.textContent=texts.selected;
   });
 })();
 </script>

--- a/templates/admin_payments.html
+++ b/templates/admin_payments.html
@@ -3,21 +3,21 @@
 <section class="payments-page users-page">
   <header class="payments-toolbar users-toolbar">
     <div class="title-wrap">
-      <h1>Payments</h1>
-      <p class="subtitle">Review bar revenue and closings.</p>
+      <h1>{{ _('admin_payments.title', default='Payments') }}</h1>
+      <p class="subtitle">{{ _('admin_payments.subtitle', default='Review bar revenue and closings.') }}</p>
     </div>
     <div class="toolbar-actions">
-      <form class="payments-search users-search" role="search" aria-label="Search bars" onsubmit="return false">
+      <form class="payments-search users-search" role="search" aria-label="{{ _('admin_payments.search.aria', default='Search bars') }}" onsubmit="return false">
         <i class="bi bi-search" aria-hidden="true"></i>
         <input
           id="paymentsSearch"
           type="search"
           inputmode="search"
           autocomplete="off"
-          placeholder="Search bars by name…"
-          aria-label="Search bars by name"
+          placeholder="{{ _('admin_payments.search.placeholder', default='Search bars by name…') }}"
+          aria-label="{{ _('admin_payments.search.input_aria', default='Search bars by name') }}"
         >
-        <button class="clear" type="button" aria-label="Clear search">
+        <button class="clear" type="button" aria-label="{{ _('admin_payments.search.clear', default='Clear search') }}">
           <i class="bi bi-x-circle" aria-hidden="true"></i>
         </button>
       </form>
@@ -28,8 +28,8 @@
     <table class="payments-table users-table">
       <thead>
         <tr>
-          <th>Name</th>
-          <th class="actions">Actions</th>
+          <th>{{ _('admin_payments.table.headers.name', default='Name') }}</th>
+          <th class="actions">{{ _('admin_payments.table.headers.actions', default='Actions') }}</th>
         </tr>
       </thead>
       <tbody>
@@ -38,9 +38,9 @@
           <td>{{ bar.name }}</td>
           <td class="actions">
             <div class="actions-group">
-              <a class="btn-outline" href="/dashboard/bar/{{ bar.id }}/orders">View</a>
-              <button type="submit" form="add_test_{{ bar.id }}" class="btn-outline">Add Test Closing</button>
-              <button type="submit" form="delete_test_{{ bar.id }}" class="btn-danger-soft">Delete Test Closing</button>
+              <a class="btn-outline" href="/dashboard/bar/{{ bar.id }}/orders">{{ _('admin_payments.actions.view', default='View') }}</a>
+              <button type="submit" form="add_test_{{ bar.id }}" class="btn-outline">{{ _('admin_payments.actions.add_test', default='Add Test Closing') }}</button>
+              <button type="submit" form="delete_test_{{ bar.id }}" class="btn-danger-soft">{{ _('admin_payments.actions.delete_test', default='Delete Test Closing') }}</button>
             </div>
             <form id="add_test_{{ bar.id }}" method="post" action="/admin/payments/{{ bar.id }}/test_closing" style="display:none"></form>
             <form id="delete_test_{{ bar.id }}" method="post" action="/admin/payments/{{ bar.id }}/test_closing/delete" style="display:none"></form>


### PR DESCRIPTION
## Summary
- localize the admin bar edit form, including category chip counter strings
- translate the admin notification composer and selection flows
- translate the admin payments list and document the new namespaces

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca5b2f462083208f5117a9e1bb138a