### PR TITLE
Localize bar opening hours text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,10 @@
 - The display orders page stretches to the full viewport width and doubles the size of order headers for clearer visibility.
 - Display orders include 10px horizontal margins and center the order text within each card.
 
+- `common.weekdays.<day>` translations drive the opening hours day labels on bar pages. Use these keys instead of hard-coded
+  weekday names.
+- `cart.errors.other_bar` localises the warning shown when trying to order from a different bar while the cart is full.
+
 - Wallet page UI lives in `templates/wallet.html` using a `.wallet-page` wrapper and inline scoped styles. Transaction rows render inside `<ul id="txList">` as static `.tx` divs with no detail links. "Load more," "Export CSV," "Manage payment methods," and all filters have been removed; the "Top Up" button uses `text-decoration:none` to avoid an underline.
 - Transaction detail views have been removed, so there is no `/wallet/tx/{index}` route or `transaction_detail.html` template.
 - Wallet Recent Activity shows all transactions with the newest first, and wallet cards override the base mobile `max-height` so the feed length isn't capped.

--- a/app/i18n/translations/en.json
+++ b/app/i18n/translations/en.json
@@ -20,7 +20,16 @@
     "cart": "Cart",
     "previous": "Previous",
     "next": "Next",
-    "search": "Search"
+    "search": "Search",
+    "weekdays": {
+      "monday": "Monday",
+      "tuesday": "Tuesday",
+      "wednesday": "Wednesday",
+      "thursday": "Thursday",
+      "friday": "Friday",
+      "saturday": "Saturday",
+      "sunday": "Sunday"
+    }
   },
   "layout": {
     "meta": {
@@ -528,6 +537,9 @@
     },
     "empty": {
       "message": "Your cart is empty."
+    },
+    "errors": {
+      "other_bar": "Please clear your cart before ordering from another bar."
     }
   },
   "search": {

--- a/app/i18n/translations/it.json
+++ b/app/i18n/translations/it.json
@@ -20,7 +20,16 @@
     "cart": "Carrello",
     "previous": "Precedente",
     "next": "Successivo",
-    "search": "Cerca"
+    "search": "Cerca",
+    "weekdays": {
+      "monday": "Lunedì",
+      "tuesday": "Martedì",
+      "wednesday": "Mercoledì",
+      "thursday": "Giovedì",
+      "friday": "Venerdì",
+      "saturday": "Sabato",
+      "sunday": "Domenica"
+    }
   },
   "layout": {
     "meta": {
@@ -528,6 +537,9 @@
     },
     "empty": {
       "message": "Il tuo carrello è vuoto."
+    },
+    "errors": {
+      "other_bar": "Svuota il carrello prima di ordinare da un altro locale."
     }
   },
   "search": {

--- a/templates/bar_detail.html
+++ b/templates/bar_detail.html
@@ -26,7 +26,7 @@
       <div class="hours-col">
         {% for h in opening_hours[:4] %}
         <div class="hour-row">
-          <span>{{ h.day }}</span>
+          <span>{{ _('common.weekdays.' ~ h.day_key, default=h.day) }}</span>
           <span>{% if h.open and h.close %}{{ h.open }} - {{ h.close }}{% else %}{{ _('bar_detail.hours.closed', default='Closed') }}{% endif %}</span>
         </div>
         {% endfor %}
@@ -34,7 +34,7 @@
       <div class="hours-col">
         {% for h in opening_hours[4:] %}
         <div class="hour-row">
-          <span>{{ h.day }}</span>
+          <span>{{ _('common.weekdays.' ~ h.day_key, default=h.day) }}</span>
           <span>{% if h.open and h.close %}{{ h.open }} - {{ h.close }}{% else %}{{ _('bar_detail.hours.closed', default='Closed') }}{% endif %}</span>
         </div>
         {% endfor %}


### PR DESCRIPTION
## Summary
- add translated weekday labels for bar opening hours and surface them through the bar detail template
- localize the cart warning shown when trying to order from a different bar and document the new keys in AGENTS notes

## Testing
- pytest tests/test_bar_detail_hours_display.py

------
https://chatgpt.com/codex/tasks/task_e_68ca6503fab08320a95f5d9c5e12bd4c