### PR TITLE
Localize wallet top-up UI

### DIFF
--- a/app/i18n/translations/it.json
+++ b/app/i18n/translations/it.json
@@ -467,7 +467,8 @@
   "notices": {
     "payment_failed": {
       "title": "Pagamento non riuscito",
-      "body": "Il pagamento non è andato a buon fine. Riprova oppure contatta il nostro staff se il problema persiste."
+      "body": "Il pagamento non è andato a buon fine. Riprova oppure contatta il nostro staff se il problema persiste.",
+      "close": "Chiudi"
     }
   },
   "notifications": {
@@ -1474,7 +1475,7 @@
     "title": "Ricarica crediti",
     "form": {
       "amount_label": "Importo",
-      "submit": "Top up with card"
+      "submit": "Ricarica con carta"
     },
     "alerts": {
       "invalid_amount": "Importo non valido",


### PR DESCRIPTION
## Summary
- translate the Italian wallet top-up button label
- add Italian copy for the payment failure popup close button

## Testing
- pytest tests/test_topup_init.py

------
https://chatgpt.com/codex/tasks/task_e_68ca6bc0b97083208397e991e74c0faa