### PR TITLE
Fix header blur overlay

### DIFF
--- a/static/css/components.css
+++ b/static/css/components.css
@@ -30,6 +30,7 @@ body.dark-mode{
 .visually-hidden{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0;}
 
 .site-header{position:sticky;top:0;z-index:1050;background:var(--bg);padding:12px 16px;min-height:56px;box-shadow:var(--sg-shadow-md);transition:padding .2s var(--ease),box-shadow .2s var(--ease);}
+.site-header> :not(.menu-backdrop):not(.language-dialog):not(.mobile-menu){position:relative;z-index:1051;}
 .site-header::after{content:"";position:absolute;left:0;right:0;bottom:0;height:2px;background:linear-gradient(to right,var(--sg-purple-700),transparent);}
 .site-header.is-scrolled{padding:8px 16px;box-shadow:0 8px 24px rgba(16,12,40,.12);} /* stronger shadow on scroll */
 .mobile-header,.navbar{display:flex;align-items:center;justify-content:space-between;}
@@ -75,7 +76,7 @@ body.dark-mode{
 .cart-popup-actions{display:flex;flex-direction:column;gap:12px;margin-top:var(--space-2);}
 .cart-popup-actions .btn{width:100%;font-size:1rem;}
 
-.mobile-menu{position:fixed;top:64px;left:50%;transform:translate(-50%,-10px);width:94%;max-width:360px;background:#fff;border-radius:var(--sg-radius-xl);box-shadow:var(--sg-shadow-lg);padding:20px;display:flex;flex-direction:column;gap:8px;z-index:1003;opacity:0;transition:transform .22s var(--ease),opacity .22s var(--ease);}
+.mobile-menu{position:fixed;top:64px;left:50%;transform:translate(-50%,-10px);width:94%;max-width:360px;background:#fff;border-radius:var(--sg-radius-xl);box-shadow:var(--sg-shadow-lg);padding:20px;display:flex;flex-direction:column;gap:8px;z-index:1200;opacity:0;transition:transform .22s var(--ease),opacity .22s var(--ease);}
 .mobile-menu[hidden]{display:none;}
 .mobile-menu.is-open{opacity:1;transform:translate(-50%,0);}
 .mobile-menu:focus,.mobile-menu:focus-within{outline:none;box-shadow:none;}
@@ -96,7 +97,7 @@ body.dark-mode{
 .menu-language{justify-content:flex-start;}
 .menu-language__code{font-size:.9rem;font-weight:600;text-transform:uppercase;color:var(--muted);margin-left:auto;text-align:right;}
 .language-backdrop{z-index:1002;}
-.language-dialog{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;z-index:1004;transition:opacity .22s var(--ease);opacity:0;}
+.language-dialog{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;z-index:1300;transition:opacity .22s var(--ease);opacity:0;}
 .language-dialog[hidden]{display:none;}
 .language-dialog.is-open{opacity:1;}
 .language-dialog__panel{background:var(--surface);color:var(--text);border-radius:var(--sg-radius-xl);box-shadow:var(--sg-shadow-lg);padding:28px 24px;max-width:400px;width:min(90%,360px);position:relative;transform:translateY(12px);transition:transform .22s var(--ease),opacity .22s var(--ease);opacity:0;}


### PR DESCRIPTION
## Summary
- keep header content above the mobile menu blur backdrop so the header stays sharp when the menu opens
- raise the mobile menu and language dialog stacking levels so overlays still appear above the header controls

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caa27cc8e88320be2c1930415d7ad9