### PR TITLE
Remove translation hint strings

### DIFF
--- a/app/i18n/translations/de.json
+++ b/app/i18n/translations/de.json
@@ -1453,9 +1453,7 @@
     },
     "form": {
       "name": "Bezeichnung",
-      "name_help": "Verwenden Sie den Übersetzungs-Editor, um Bezeichnungen zu aktualisieren.",
       "description": "Warenbezeichnung",
-      "description_help": "Verwenden Sie den Übersetzungs-Editor, um Beschreibungen zu aktualisieren.",
       "display_order": "Reihenfolge anzeigen",
       "name_translate_button": "Name übersetzen",
       "description_translate_button": "Beschreibung übersetzen",
@@ -1471,7 +1469,6 @@
     },
     "edit": {
       "title": "Kategorie bearbeiten für {bar}",
-      "translation_note": "Müssen Übersetzungen aktualisiert werden? Verwenden Sie die Schaltflächen unten, um Namen und Beschreibungen in allen Sprachen zu bearbeiten.",
       "actions": {
         "edit_name": "Namen bearbeiten",
         "edit_description": "Beschreibung bearbeiten"

--- a/app/i18n/translations/en.json
+++ b/app/i18n/translations/en.json
@@ -1453,9 +1453,7 @@
     },
     "form": {
       "name": "Name",
-      "name_help": "Use the translation editor to update names.",
       "description": "Description",
-      "description_help": "Use the translation editor to update descriptions.",
       "display_order": "Display Order",
       "name_translate_button": "Translate name",
       "description_translate_button": "Translate description",
@@ -1471,7 +1469,6 @@
     },
     "edit": {
       "title": "Edit Category for {bar}",
-      "translation_note": "Need to update translations? Use the buttons below to edit names and descriptions for every language.",
       "actions": {
         "edit_name": "Edit name",
         "edit_description": "Edit description"

--- a/app/i18n/translations/fr.json
+++ b/app/i18n/translations/fr.json
@@ -1477,9 +1477,7 @@
     },
     "form": {
       "name": "Nom",
-      "name_help": "Utilisez l'éditeur de traductions pour mettre à jour les noms.",
       "description": "Description",
-      "description_help": "Utilisez l'éditeur de traductions pour mettre à jour les descriptions.",
       "display_order": "Commande d'affichage",
       "name_translate_button": "Traduire le nom",
       "description_translate_button": "Traduire la description",
@@ -1495,7 +1493,6 @@
     },
     "edit": {
       "title": "Modifier la catégorie pour {bar}",
-      "translation_note": "Besoin de mettre à jour les traductions ? Utilisez les boutons ci-dessous pour modifier les noms et descriptions dans chaque langue.",
       "actions": {
         "edit_name": "Modifier le nom",
         "edit_description": "Modifier la description"

--- a/app/i18n/translations/it.json
+++ b/app/i18n/translations/it.json
@@ -1453,9 +1453,7 @@
     },
     "form": {
       "name": "Nome",
-      "name_help": "Usa l'editor di traduzione per aggiornare i nomi.",
       "description": "Descrizione",
-      "description_help": "Usa l'editor di traduzione per aggiornare le descrizioni.",
       "display_order": "Ordine di visualizzazione",
       "name_translate_button": "Traduci nome",
       "description_translate_button": "Traduci descrizione",
@@ -1471,7 +1469,6 @@
     },
     "edit": {
       "title": "Modifica categoria per {bar}",
-      "translation_note": "Devi aggiornare le traduzioni? Usa i pulsanti qui sotto per modificare nomi e descrizioni in tutte le lingue.",
       "actions": {
         "edit_name": "Modifica nome",
         "edit_description": "Modifica descrizione"

--- a/templates/bar_edit_category.html
+++ b/templates/bar_edit_category.html
@@ -2,7 +2,6 @@
 {% block content %}
 <h1>{{ _('bar_categories.edit.title', bar=bar.name, default='Edit Category for {bar}') }}</h1>
 <section class="category-edit">
-  <p class="translation-note">{{ _('bar_categories.edit.translation_note', default='Need to update translations? Use the buttons below to edit names and descriptions for every language.') }}</p>
   <div class="translation-actions">
     <a class="btn-outline" href="/bar/{{ bar.id }}/categories/{{ category.id }}/edit/name">{{ _('bar_categories.edit.actions.edit_name', default='Edit name') }}</a>
     <a class="btn-outline" href="/bar/{{ bar.id }}/categories/{{ category.id }}/edit/description">{{ _('bar_categories.edit.actions.edit_description', default='Edit description') }}</a>
@@ -10,11 +9,9 @@
   <form class="form" method="post">
     <label for="name">{{ _('bar_categories.form.name', default='Name') }}
       <input id="name" name="name" value="{{ category.name }}" required readonly>
-      <small class="help">{{ _('bar_categories.form.name_help', default='Use the translation editor to update names in any language.') }}</small>
     </label>
     <label for="description">{{ _('bar_categories.form.description', default='Description') }}
       <textarea id="description" name="description" readonly>{{ category.description }}</textarea>
-      <small class="help">{{ _('bar_categories.form.description_help', default='Use the translation editor to update descriptions in any language.') }}</small>
     </label>
     <label for="display_order">{{ _('bar_categories.form.display_order', default='Display Order') }}
       <input id="display_order" type="number" name="display_order" value="{{ category.display_order }}">
@@ -24,13 +21,11 @@
 </section>
 <style>
 .category-edit{max-width:720px;margin-inline:auto;display:flex;flex-direction:column;gap:var(--space-4,16px);}
-.category-edit .translation-note{margin:0;opacity:.75;}
 .category-edit .translation-actions{display:flex;flex-wrap:wrap;gap:12px;}
 .category-edit .translation-actions .btn-outline{flex:0 0 auto;}
 .category-edit .form{display:flex;flex-direction:column;gap:var(--space-4,16px);}
 .category-edit textarea{min-height:110px;}
 .category-edit input[readonly],.category-edit textarea[readonly]{background:var(--surface-strong,#f3f4f6);cursor:not-allowed;}
-.category-edit .help{display:block;margin-top:6px;font-size:.85rem;opacity:.7;}
 </style>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- delete the bar category translation reminder strings from every locale file
- remove the unused translation editor help copy from each locale

## Testing
- pytest tests/test_translations.py

------
https://chatgpt.com/codex/tasks/task_e_68cbafb65bc883209a8d831958efa434