### PR TITLE
Allow category card to expand

### DIFF
--- a/templates/bar_edit_category.html
+++ b/templates/bar_edit_category.html
@@ -26,6 +26,7 @@
 </section>
 <style>
 .category-edit{max-width:720px;margin-inline:auto;}
+.category-edit .card{max-height:none;}
 .category-edit .card__body{display:flex;}
 .category-edit .form{display:flex;flex-direction:column;gap:var(--space-5,24px);width:100%;}
 .category-edit .form-field{display:flex;flex-direction:column;gap:var(--space-2,12px);}


### PR DESCRIPTION
## Summary
- override the category edit card to remove its mobile max-height limit so it can grow with its contents

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbbb77a7688320989fce545b9e102c