### PR TITLE
Align category locked styling

### DIFF
--- a/templates/bar_edit_category.html
+++ b/templates/bar_edit_category.html
@@ -5,14 +5,16 @@
   <div class="card">
     <div class="card__body">
       <form class="form" method="post">
-        <div class="form-field">
+        <div class="form-field locked-field">
           <label for="name">{{ _('bar_categories.form.name', default='Name') }}</label>
-          <input id="name" name="name" value="{{ category.name }}" required readonly>
+          <p class="description-preview">{{ category.name }}</p>
+          <input id="name" name="name" type="hidden" value="{{ category.name }}" required>
           <a class="btn-outline field-action" href="/bar/{{ bar.id }}/categories/{{ category.id }}/edit/name">{{ _('bar_categories.edit.actions.edit_name', default='Edit name') }}</a>
         </div>
-        <div class="form-field">
+        <div class="form-field locked-field">
           <label for="description">{{ _('bar_categories.form.description', default='Description') }}</label>
-          <textarea id="description" name="description" readonly>{{ category.description }}</textarea>
+          <p class="description-preview">{{ category.description }}</p>
+          <textarea id="description" name="description" hidden>{{ category.description }}</textarea>
           <a class="btn-outline field-action" href="/bar/{{ bar.id }}/categories/{{ category.id }}/edit/description">{{ _('bar_categories.edit.actions.edit_description', default='Edit description') }}</a>
         </div>
         <div class="form-field">
@@ -31,8 +33,8 @@
 .category-edit .form{display:flex;flex-direction:column;gap:var(--space-5,24px);width:100%;}
 .category-edit .form-field{display:flex;flex-direction:column;gap:var(--space-2,12px);}
 .category-edit .field-action{align-self:flex-start;}
-.category-edit textarea{min-height:110px;}
-.category-edit input[readonly],.category-edit textarea[readonly]{background:var(--surface-strong,#f3f4f6);cursor:not-allowed;}
+.category-edit .locked-field .description-preview{margin:0;padding:12px 16px;border-radius:var(--radius-xl,16px);background:var(--surface-strong,#f3f4f6);font-size:0.95rem;line-height:1.5;}
+.category-edit .locked-field .description-preview:empty::before{content:"";}
 </style>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- restyle the locked name and description fields in the bar category edit form to match the admin bar description preview
- retain hidden inputs so form submissions continue to include the existing values
- add shared preview styling for those locked sections

## Testing
- pytest tests/test_translations.py

------
https://chatgpt.com/codex/tasks/task_e_68cbbe38c8088320bc6d5686b3a8f2d7