### PR TITLE
Enable product translations

### DIFF
--- a/app/i18n/translations/de.json
+++ b/app/i18n/translations/de.json
@@ -1523,34 +1523,34 @@
       "create": "Erstellen",
       "update": "Aktualisieren"
     },
-    "edit_name": {
-      "back": "Zurück zum Produkt",
-      "title": "Name für {product} bearbeiten",
-      "intro": "Aktualisieren Sie den Namen, der Gästen angezeigt wird.",
-      "fields": {
-        "name": "Name"
-      },
-      "actions": {
-        "save": "Name speichern"
-      },
-      "errors": {
-        "required": "Der Name ist erforderlich."
-      }
+  "edit_name": {
+    "back": "Zurück zum Produkt",
+    "title": "Namen für {product} bearbeiten",
+    "intro": "Geben Sie für jede unterstützte Sprache einen Namen ein. Gäste sehen die Variante in ihrer gewählten Sprache.",
+    "fields": {
+      "language": "Name auf {language}"
     },
-    "edit_description": {
-      "back": "Zurück zum Produkt",
-      "title": "Beschreibung für {product} bearbeiten",
-      "intro": "Aktualisieren Sie die Beschreibung, die Gästen angezeigt wird.",
-      "fields": {
-        "description": "Beschreibung"
-      },
-      "actions": {
-        "save": "Beschreibung speichern"
-      },
-      "errors": {
-        "required": "Die Beschreibung ist erforderlich."
-      }
+    "actions": {
+      "save": "Namen speichern"
     },
+    "errors": {
+      "required": "Alle Felder sind erforderlich."
+    }
+  },
+  "edit_description": {
+    "back": "Zurück zum Produkt",
+    "title": "Beschreibungen für {product} bearbeiten",
+    "intro": "Verfassen Sie für jede unterstützte Sprache eine Beschreibung. Die Texte erscheinen im Gästemenü.",
+    "fields": {
+      "language": "Beschreibung auf {language}"
+    },
+    "actions": {
+      "save": "Beschreibungen speichern"
+    },
+    "errors": {
+      "required": "Alle Felder sind erforderlich."
+    }
+  },
     "manage": {
       "title": "Produkte in {category} für {bar}",
       "subtitle": "Hinzufügen, Bearbeiten und Organisieren von Produkten für diese Kategorie.",

--- a/app/i18n/translations/en.json
+++ b/app/i18n/translations/en.json
@@ -1523,34 +1523,34 @@
       "create": "Create",
       "update": "Update"
     },
-    "edit_name": {
-      "back": "Back to product",
-      "title": "Edit name for {product}",
-      "intro": "Update the name shown to customers.",
-      "fields": {
-        "name": "Name"
-      },
-      "actions": {
-        "save": "Save name"
-      },
-      "errors": {
-        "required": "Name is required."
-      }
+  "edit_name": {
+    "back": "Back to product",
+    "title": "Edit names for {product}",
+    "intro": "Provide a name for each supported language. Customers see the option matching their selected language.",
+    "fields": {
+      "language": "{language} name"
     },
-    "edit_description": {
-      "back": "Back to product",
-      "title": "Edit description for {product}",
-      "intro": "Update the description shown to customers.",
-      "fields": {
-        "description": "Description"
-      },
-      "actions": {
-        "save": "Save description"
-      },
-      "errors": {
-        "required": "Description is required."
-      }
+    "actions": {
+      "save": "Save names"
     },
+    "errors": {
+      "required": "All fields are required."
+    }
+  },
+  "edit_description": {
+    "back": "Back to product",
+    "title": "Edit descriptions for {product}",
+    "intro": "Write a description for each supported language. Descriptions appear on the customer menu.",
+    "fields": {
+      "language": "{language} description"
+    },
+    "actions": {
+      "save": "Save descriptions"
+    },
+    "errors": {
+      "required": "All fields are required."
+    }
+  },
     "manage": {
       "title": "Products in {category} for {bar}",
       "subtitle": "Add, edit and organize products for this category.",

--- a/app/i18n/translations/fr.json
+++ b/app/i18n/translations/fr.json
@@ -1547,34 +1547,34 @@
       "create": "Créer",
       "update": "Mise à jour"
     },
-    "edit_name": {
-      "back": "Retour au produit",
-      "title": "Modifier le nom de {product}",
-      "intro": "Mettez à jour le nom affiché aux clients.",
-      "fields": {
-        "name": "Nom"
-      },
-      "actions": {
-        "save": "Enregistrer le nom"
-      },
-      "errors": {
-        "required": "Le nom est obligatoire."
-      }
+  "edit_name": {
+    "back": "Retour au produit",
+    "title": "Modifier les noms de {product}",
+    "intro": "Saisissez un nom pour chaque langue prise en charge. Les clients voient l'option correspondant à leur langue sélectionnée.",
+    "fields": {
+      "language": "Nom en {language}"
     },
-    "edit_description": {
-      "back": "Retour au produit",
-      "title": "Modifier la description de {product}",
-      "intro": "Mettez à jour la description affichée aux clients.",
-      "fields": {
-        "description": "Description"
-      },
-      "actions": {
-        "save": "Enregistrer la description"
-      },
-      "errors": {
-        "required": "La description est obligatoire."
-      }
+    "actions": {
+      "save": "Enregistrer les noms"
     },
+    "errors": {
+      "required": "Tous les champs sont obligatoires."
+    }
+  },
+  "edit_description": {
+    "back": "Retour au produit",
+    "title": "Modifier les descriptions de {product}",
+    "intro": "Rédigez une description pour chaque langue prise en charge. Les descriptions apparaissent sur le menu client.",
+    "fields": {
+      "language": "Description en {language}"
+    },
+    "actions": {
+      "save": "Enregistrer les descriptions"
+    },
+    "errors": {
+      "required": "Tous les champs sont obligatoires."
+    }
+  },
     "manage": {
       "title": "Produits en {category} pour {bar}",
       "subtitle": "Ajouter, modifier et organiser des produits pour cette catégorie.",

--- a/app/i18n/translations/it.json
+++ b/app/i18n/translations/it.json
@@ -1523,34 +1523,34 @@
       "create": "Crea",
       "update": "Aggiorna"
     },
-    "edit_name": {
-      "back": "Torna al prodotto",
-      "title": "Modifica il nome di {product}",
-      "intro": "Aggiorna il nome mostrato ai clienti.",
-      "fields": {
-        "name": "Nome"
-      },
-      "actions": {
-        "save": "Salva nome"
-      },
-      "errors": {
-        "required": "Il nome è obbligatorio."
-      }
+  "edit_name": {
+    "back": "Torna al prodotto",
+    "title": "Modifica i nomi di {product}",
+    "intro": "Inserisci un nome per ogni lingua supportata. I clienti vedono l'opzione corrispondente alla lingua selezionata.",
+    "fields": {
+      "language": "Nome in {language}"
     },
-    "edit_description": {
-      "back": "Torna al prodotto",
-      "title": "Modifica la descrizione di {product}",
-      "intro": "Aggiorna la descrizione mostrata ai clienti.",
-      "fields": {
-        "description": "Descrizione"
-      },
-      "actions": {
-        "save": "Salva descrizione"
-      },
-      "errors": {
-        "required": "La descrizione è obbligatoria."
-      }
+    "actions": {
+      "save": "Salva nomi"
     },
+    "errors": {
+      "required": "Tutti i campi sono obbligatori."
+    }
+  },
+  "edit_description": {
+    "back": "Torna al prodotto",
+    "title": "Modifica le descrizioni di {product}",
+    "intro": "Scrivi una descrizione per ogni lingua supportata. Le descrizioni vengono mostrate nel menu clienti.",
+    "fields": {
+      "language": "Descrizione in {language}"
+    },
+    "actions": {
+      "save": "Salva descrizioni"
+    },
+    "errors": {
+      "required": "Tutti i campi sono obbligatori."
+    }
+  },
     "manage": {
       "title": "Prodotti in {category} per {bar}",
       "subtitle": "Aggiungi, modifica e organizza i prodotti per questa categoria.",

--- a/models.py
+++ b/models.py
@@ -135,6 +135,8 @@ class MenuItem(Base):
     category_id = Column(Integer, ForeignKey("categories.id"), nullable=False)
     name = Column(String(100), nullable=False)
     description = Column(String(190))
+    name_translations = Column(JSON)
+    description_translations = Column(JSON)
     price_chf = Column(Numeric(10, 2), nullable=False)
     vat_rate = Column(Numeric(4, 2), default=0)
     sku = Column(String(50))

--- a/templates/bar_category_products.html
+++ b/templates/bar_category_products.html
@@ -31,10 +31,10 @@
         <tr>
           <td>{{ product.display_order }}</td>
           <td>
-            <img src="{{ product.photo_url }}" alt="{{ product.name }} photo" width="50" height="28" loading="lazy" onerror="this.src='{{ fallback_img }}';this.onerror=null;">
+            <img src="{{ product.photo_url }}" alt="{{ product_name(product) }} photo" width="50" height="28" loading="lazy" onerror="this.src='{{ fallback_img }}';this.onerror=null;">
           </td>
-          <td>{{ product.name }}</td>
-          <td>{{ product.description }}</td>
+          <td>{{ product_name(product) }}</td>
+          <td>{{ product_description(product) }}</td>
           <td>{{ "%.2f"|format(product.price) }}</td>
           <td class="actions">
             <div class="actions-group">

--- a/templates/bar_detail.html
+++ b/templates/bar_detail.html
@@ -60,14 +60,16 @@
     <p>{{ category_summary }}</p>
     <ul class="products scroller">
       {% for product in products %}
+      {% set display_name = product_name(product) %}
+      {% set display_description = product_description(product) %}
       <li>
         <article class="product-card">
           <div class="thumb-wrapper">
-            <img class="thumb" src="{{ product.photo_url }}" alt="{{ product.name }} photo" itemprop="image" loading="lazy" decoding="async" width="400" height="225" srcset="{{ product.photo_url }} 400w, {{ product.photo_url }} 800w" sizes="(max-width: 600px) 100vw, 400px" onerror="this.src='{{ fallback_img }}';this.onerror=null;">
+            <img class="thumb" src="{{ product.photo_url }}" alt="{{ display_name }} photo" itemprop="image" loading="lazy" decoding="async" width="400" height="225" srcset="{{ product.photo_url }} 400w, {{ product.photo_url }} 800w" sizes="(max-width: 600px) 100vw, 400px" onerror="this.src='{{ fallback_img }}';this.onerror=null;">
           </div>
-          <h3 class="title">{{ product.name }}</h3>
+          <h3 class="title">{{ display_name }}</h3>
           <div class="card-body">
-            <p class="desc description">{{ product.description }}</p>
+            <p class="desc description">{{ display_description }}</p>
             <p class="price"><strong>CHF {{ '%.2f'|format(product.price) }}</strong></p>
             {% if user %}
             <form class="form form--inline add-to-cart-form" method="post" action="/bars/{{ bar.id }}/add_to_cart">

--- a/templates/bar_edit_product.html
+++ b/templates/bar_edit_product.html
@@ -1,14 +1,16 @@
 {% extends "layout.html" %}
 {% block content %}
 {% set fallback_img = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCA0MDAgMjI1Jz48cmVjdCB3aWR0aD0nNDAwJyBoZWlnaHQ9JzIyNScgZmlsbD0nJTIzZjFmM2Y1Jy8+PC9zdmc+" %}
-<h1>{{ _('bar_products.edit.title', product=product.name, default='Edit Product {product}') }}</h1>
+{% set preview_name = product_name(product) %}
+{% set preview_description = product_description(product) %}
+<h1>{{ _('bar_products.edit.title', product=preview_name, default='Edit Product {product}') }}</h1>
 <section class="product-edit">
   <div class="card">
     <div class="card__body">
       <form class="form" method="post" enctype="multipart/form-data">
         <div class="form-field locked-field">
           <label for="name">{{ _('bar_products.form.name', default='Name') }}</label>
-          <p class="description-preview">{{ product.name }}</p>
+          <p class="description-preview">{{ preview_name }}</p>
           <input id="name" name="name" type="hidden" value="{{ product.name }}" required>
           <a class="btn-outline field-action" href="/bar/{{ bar.id }}/categories/{{ category.id }}/products/{{ product.id }}/edit/name">{{ _('bar_products.edit.actions.edit_name', default='Edit name') }}</a>
         </div>
@@ -18,7 +20,7 @@
         </div>
         <div class="form-field locked-field">
           <label for="description">{{ _('bar_products.form.description', default='Description') }}</label>
-          <p class="description-preview">{{ product.description }}</p>
+          <p class="description-preview">{{ preview_description }}</p>
           <textarea id="description" name="description" hidden maxlength="190">{{ product.description }}</textarea>
           <a class="btn-outline field-action" href="/bar/{{ bar.id }}/categories/{{ category.id }}/products/{{ product.id }}/edit/description">{{ _('bar_products.edit.actions.edit_description', default='Edit description') }}</a>
         </div>
@@ -29,7 +31,7 @@
         <div class="form-field">
           <label>{{ _('bar_products.form.photo', default='Photo') }}</label>
           <div class="photo-preview">
-            <img src="{{ product.photo_url }}" alt="{{ product.name }} photo" loading="lazy" decoding="async" onerror="this.src='{{ fallback_img }}';this.onerror=null;" width="400" height="225" />
+            <img src="{{ product.photo_url }}" alt="{{ preview_name }} photo" loading="lazy" decoding="async" onerror="this.src='{{ fallback_img }}';this.onerror=null;" width="400" height="225" />
           </div>
           <input id="photo" type="file" name="photo" accept="image/*">
         </div>

--- a/templates/bar_edit_product_description.html
+++ b/templates/bar_edit_product_description.html
@@ -1,32 +1,34 @@
 {% extends "layout.html" %}
 {% block content %}
-<section class="product-field-editor">
+<section class="product-translation-editor">
   <a class="back-link" href="/bar/{{ bar.id }}/categories/{{ category.id }}/products/{{ product.id }}/edit"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('bar_products.edit_description.back', default='Back to product') }}</a>
-  <h1>{{ _('bar_products.edit_description.title', product=product.name, default='Edit description for {product}') }}</h1>
-  <p class="intro">{{ _('bar_products.edit_description.intro', default='Update the description shown to customers.') }}</p>
+  <h1>{{ _('bar_products.edit_description.title', product=product_name(product), default='Edit descriptions for {product}') }}</h1>
+  <p class="intro">{{ _('bar_products.edit_description.intro', default='Write a description for each supported language. Descriptions appear on the customer menu.') }}</p>
   {% if error_code %}
-  <div class="alert alert-danger">{{ _('bar_products.edit_description.errors.' + error_code, default='Description is required.') }}</div>
+  <div class="alert alert-danger">{{ _('bar_products.edit_description.errors.' + error_code, default='All fields are required.') }}</div>
   {% endif %}
-  <form method="post" action="/bar/{{ bar.id }}/categories/{{ category.id }}/products/{{ product.id }}/edit/description" class="field-form">
+  <form method="post" action="/bar/{{ bar.id }}/categories/{{ category.id }}/products/{{ product.id }}/edit/description" class="translation-form">
+    {% for lang in languages %}
     <div class="field-group">
-      <label for="description">{{ _('bar_products.edit_description.fields.description', default='Description') }}</label>
-      <textarea id="description" name="description" maxlength="190" required>{{ description_value }}</textarea>
+      <label for="description_{{ lang.code }}">{{ _('bar_products.edit_description.fields.language', language=lang.name, default='{language} description') }}</label>
+      <textarea id="description_{{ lang.code }}" name="description_{{ lang.code }}" maxlength="190" required>{{ descriptions.get(lang.code, '') }}</textarea>
     </div>
+    {% endfor %}
     <div class="form-actions">
-      <button type="submit" class="btn btn--primary">{{ _('bar_products.edit_description.actions.save', default='Save description') }}</button>
+      <button type="submit" class="btn btn--primary">{{ _('bar_products.edit_description.actions.save', default='Save descriptions') }}</button>
     </div>
   </form>
 </section>
 <style>
-.product-field-editor{max-width:720px;margin-inline:auto;padding-block:var(--space-6,24px);display:flex;flex-direction:column;gap:var(--space-4,16px);}
-.product-field-editor .back-link{display:inline-flex;align-items:center;gap:8px;text-decoration:none;opacity:.8;}
-.product-field-editor .back-link:hover{opacity:1;}
-.product-field-editor .intro{margin:0;opacity:.8;}
-.field-form{display:flex;flex-direction:column;gap:var(--space-4,16px);}
-.field-form .field-group{display:flex;flex-direction:column;gap:8px;}
-.field-form input,.field-form textarea{padding:12px 14px;border-radius:var(--radius-xl,16px);border:1px solid rgba(15,23,42,.12);font-size:1rem;}
-.field-form input:focus,.field-form textarea:focus{outline:2px solid rgba(91,45,238,.25);outline-offset:2px;}
-.field-form .form-actions{display:flex;justify-content:flex-end;margin-top:var(--space-4,16px);}
+.product-translation-editor{max-width:720px;margin-inline:auto;padding-block:var(--space-6,24px);display:flex;flex-direction:column;gap:var(--space-4,16px);}
+.product-translation-editor .back-link{display:inline-flex;align-items:center;gap:8px;text-decoration:none;opacity:.8;}
+.product-translation-editor .back-link:hover{opacity:1;}
+.product-translation-editor .intro{margin:0;opacity:.8;}
+.translation-form{display:flex;flex-direction:column;gap:var(--space-4,16px);}
+.translation-form .field-group{display:flex;flex-direction:column;gap:8px;}
+.translation-form textarea{padding:12px 14px;border-radius:var(--radius-xl,16px);border:1px solid rgba(15,23,42,.12);font-size:1rem;min-height:120px;}
+.translation-form textarea:focus{outline:2px solid rgba(91,45,238,.25);outline-offset:2px;}
+.translation-form .form-actions{display:flex;justify-content:flex-end;margin-top:var(--space-4,16px);}
 .alert{padding:12px 14px;border-radius:var(--radius-lg,12px);}
 .alert-danger{background:#fee2e2;color:#991b1b;}
 </style>

--- a/templates/bar_edit_product_name.html
+++ b/templates/bar_edit_product_name.html
@@ -1,32 +1,34 @@
 {% extends "layout.html" %}
 {% block content %}
-<section class="product-field-editor">
+<section class="product-translation-editor">
   <a class="back-link" href="/bar/{{ bar.id }}/categories/{{ category.id }}/products/{{ product.id }}/edit"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('bar_products.edit_name.back', default='Back to product') }}</a>
-  <h1>{{ _('bar_products.edit_name.title', product=product.name, default='Edit name for {product}') }}</h1>
-  <p class="intro">{{ _('bar_products.edit_name.intro', default='Update the name shown to customers.') }}</p>
+  <h1>{{ _('bar_products.edit_name.title', product=product_name(product), default='Edit names for {product}') }}</h1>
+  <p class="intro">{{ _('bar_products.edit_name.intro', default='Provide a name for each supported language. Customers see the option matching their selected language.') }}</p>
   {% if error_code %}
-  <div class="alert alert-danger">{{ _('bar_products.edit_name.errors.' + error_code, default='Name is required.') }}</div>
+  <div class="alert alert-danger">{{ _('bar_products.edit_name.errors.' + error_code, default='All fields are required.') }}</div>
   {% endif %}
-  <form method="post" action="/bar/{{ bar.id }}/categories/{{ category.id }}/products/{{ product.id }}/edit/name" class="field-form">
+  <form method="post" action="/bar/{{ bar.id }}/categories/{{ category.id }}/products/{{ product.id }}/edit/name" class="translation-form">
+    {% for lang in languages %}
     <div class="field-group">
-      <label for="name">{{ _('bar_products.edit_name.fields.name', default='Name') }}</label>
-      <input id="name" name="name" value="{{ name_value }}" required maxlength="80">
+      <label for="name_{{ lang.code }}">{{ _('bar_products.edit_name.fields.language', language=lang.name, default='{language} name') }}</label>
+      <input id="name_{{ lang.code }}" name="name_{{ lang.code }}" value="{{ names.get(lang.code, '') }}" required maxlength="80">
     </div>
+    {% endfor %}
     <div class="form-actions">
-      <button type="submit" class="btn btn--primary">{{ _('bar_products.edit_name.actions.save', default='Save name') }}</button>
+      <button type="submit" class="btn btn--primary">{{ _('bar_products.edit_name.actions.save', default='Save names') }}</button>
     </div>
   </form>
 </section>
 <style>
-.product-field-editor{max-width:720px;margin-inline:auto;padding-block:var(--space-6,24px);display:flex;flex-direction:column;gap:var(--space-4,16px);}
-.product-field-editor .back-link{display:inline-flex;align-items:center;gap:8px;text-decoration:none;opacity:.8;}
-.product-field-editor .back-link:hover{opacity:1;}
-.product-field-editor .intro{margin:0;opacity:.8;}
-.field-form{display:flex;flex-direction:column;gap:var(--space-4,16px);}
-.field-form .field-group{display:flex;flex-direction:column;gap:8px;}
-.field-form input,.field-form textarea{padding:12px 14px;border-radius:var(--radius-xl,16px);border:1px solid rgba(15,23,42,.12);font-size:1rem;}
-.field-form input:focus,.field-form textarea:focus{outline:2px solid rgba(91,45,238,.25);outline-offset:2px;}
-.field-form .form-actions{display:flex;justify-content:flex-end;margin-top:var(--space-4,16px);}
+.product-translation-editor{max-width:720px;margin-inline:auto;padding-block:var(--space-6,24px);display:flex;flex-direction:column;gap:var(--space-4,16px);}
+.product-translation-editor .back-link{display:inline-flex;align-items:center;gap:8px;text-decoration:none;opacity:.8;}
+.product-translation-editor .back-link:hover{opacity:1;}
+.product-translation-editor .intro{margin:0;opacity:.8;}
+.translation-form{display:flex;flex-direction:column;gap:var(--space-4,16px);}
+.translation-form .field-group{display:flex;flex-direction:column;gap:8px;}
+.translation-form input,.translation-form textarea{padding:12px 14px;border-radius:var(--radius-xl,16px);border:1px solid rgba(15,23,42,.12);font-size:1rem;}
+.translation-form input:focus,.translation-form textarea:focus{outline:2px solid rgba(91,45,238,.25);outline-offset:2px;}
+.translation-form .form-actions{display:flex;justify-content:flex-end;margin-top:var(--space-4,16px);}
 .alert{padding:12px 14px;border-radius:var(--radius-lg,12px);}
 .alert-danger{background:#fee2e2;color:#991b1b;}
 </style>

--- a/templates/cart.html
+++ b/templates/cart.html
@@ -28,7 +28,7 @@
           <tbody>
             {% for item in cart.items.values() %}
             <tr>
-              <td>{{ item.product.name }}</td>
+              <td>{{ product_name(item.product) }}</td>
               <td>
                 <form class="form form--inline" method="post" action="/cart/update">
                   <input type="hidden" name="product_id" value="{{ item.product.id }}">

--- a/tests/test_product_translations.py
+++ b/tests/test_product_translations.py
@@ -1,0 +1,130 @@
+import os
+import sys
+import pathlib
+from decimal import Decimal
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, engine, SessionLocal  # noqa: E402
+from models import Bar as BarModel, Category as CategoryModel, MenuItem  # noqa: E402
+from main import (  # noqa: E402
+    app,
+    DemoUser,
+    users,
+    users_by_email,
+    users_by_username,
+    bars,
+    LANGUAGES,
+)
+
+
+def reset_state():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()
+    bars.clear()
+
+
+def seed_product():
+    db = SessionLocal()
+    bar = BarModel(name="Bar", slug="bar")
+    db.add(bar)
+    db.commit()
+    db.refresh(bar)
+
+    category = CategoryModel(bar_id=bar.id, name="Drinks")
+    db.add(category)
+    db.commit()
+    db.refresh(category)
+
+    item = MenuItem(
+        bar_id=bar.id,
+        category_id=category.id,
+        name="Spritz",
+        description="Classic aperitif",
+        price_chf=Decimal("12.00"),
+    )
+    db.add(item)
+    db.commit()
+    db.refresh(item)
+    bar_id, category_id, product_id = bar.id, category.id, item.id
+    db.close()
+    return bar_id, category_id, product_id
+
+
+def create_admin():
+    admin = DemoUser(
+        id=1,
+        username="admin",
+        password="secret",
+        email="admin@example.com",
+        role="super_admin",
+    )
+    users[admin.id] = admin
+    users_by_email[admin.email] = admin
+    users_by_username[admin.username] = admin
+    return admin
+
+
+def test_edit_product_name_updates_translations():
+    reset_state()
+    bar_id, category_id, product_id = seed_product()
+    admin = create_admin()
+
+    client = TestClient(app, follow_redirects=False)
+    client.post("/login", data={"email": admin.email, "password": admin.password})
+
+    payload = {
+        f"name_{code}": f"Name {code.upper()}"
+        for code in LANGUAGES.keys()
+    }
+    response = client.post(
+        f"/bar/{bar_id}/categories/{category_id}/products/{product_id}/edit/name",
+        data=payload,
+    )
+    assert response.status_code == 303
+
+    db = SessionLocal()
+    item = db.get(MenuItem, product_id)
+    assert item is not None
+    assert set(item.name_translations.keys()) == set(LANGUAGES.keys())
+    for code in LANGUAGES.keys():
+        expected = payload[f"name_{code}"][:80]
+        assert item.name_translations[code] == expected
+    assert item.name == payload.get("name_en")
+    db.close()
+
+
+def test_edit_product_description_updates_translations():
+    reset_state()
+    bar_id, category_id, product_id = seed_product()
+    admin = create_admin()
+
+    client = TestClient(app, follow_redirects=False)
+    client.post("/login", data={"email": admin.email, "password": admin.password})
+
+    payload = {}
+    for code in LANGUAGES.keys():
+        text = f"Description {code.upper()}"
+        if code == "en":
+            text = "X" * 195
+        payload[f"description_{code}"] = text
+    response = client.post(
+        f"/bar/{bar_id}/categories/{category_id}/products/{product_id}/edit/description",
+        data=payload,
+    )
+    assert response.status_code == 303
+
+    db = SessionLocal()
+    item = db.get(MenuItem, product_id)
+    assert item is not None
+    assert set(item.description_translations.keys()) == set(LANGUAGES.keys())
+    for code in LANGUAGES.keys():
+        expected = payload[f"description_{code}"][:190]
+        assert item.description_translations[code] == expected
+    assert item.description == payload["description_en"][:190]
+    db.close()


### PR DESCRIPTION
## Summary
- add multilingual name and description storage for menu items and normalize cached data
- surface helpers and UI updates so product management and customer views render localized copy
- extend product edit routes/forms with per-language inputs and cover them with tests

## Testing
- pytest tests/test_product_translations.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbcc778728832094fafe3dfce9047a