### PR TITLE
Guard welcome translations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,7 +347,9 @@
   - `Notification` model in `models.py` stores per-user messages with optional image, attachment, and link.
   - Super admins send messages via `/admin/notifications/new`, targeting all users, a single user, or users who ordered at a specific bar.
   - The Admin Notifications page lists recent messages with a **New Message** button linking to the send form and an **Edit Welcome** button for updating the default welcome message.
-    - The welcome message editor captures translated subjects and bodies for every supported language; updates are stored on `WelcomeMessage.subject_translations` and `WelcomeMessage.body_translations` with a 30-character limit per subject variant.
+- The welcome message editor captures translated subjects and bodies for every supported language; updates are stored on `WelcomeMessage.subject_translations` and `WelcomeMessage.body_translations` with a 30-character limit per subject variant.
+- Welcome message bodies are edited solely through the per-language fields; the primary message textarea and translate toggle were removed.
+  - The default-language textarea (English) is required on submit; `admin_welcome_post` falls back to the previous English copy if it isn't provided. The handler keeps the active language's previous text when its textarea is submitted empty and clears other translations when their fields are blank.
   - Each row includes **View** and **Delete** actions; Delete requires confirmation via `.cart-popup`.
   - Viewing a notification at `/admin/notifications/{id}` shows full details and a list of recipient users.
   - Each send is logged to `NotificationLog` so broadcasts to all users appear once in the table instead of repeating per user.

--- a/app/i18n/translations/de.json
+++ b/app/i18n/translations/de.json
@@ -1243,6 +1243,7 @@
       "message": "Nachricht",
       "message_translate_button": "Nachricht übersetzen",
       "message_translation_help": "Schreiben Sie die Begrüßungsnachricht in jeder unterstützten Sprache.",
+      "message_default_language_help": "Tragen Sie die Nachricht auf {language} ein. Andere Sprachen übernehmen diesen Text, wenn keine Übersetzung vorhanden ist.",
       "language_message_label": "Nachricht in {language}",
       "save": "Speichern"
     }

--- a/app/i18n/translations/en.json
+++ b/app/i18n/translations/en.json
@@ -1243,6 +1243,7 @@
       "message": "Message",
       "message_translate_button": "Translate message",
       "message_translation_help": "Write the welcome message in each supported language.",
+      "message_default_language_help": "Provide the {language} message. Other languages inherit it when no translation is set.",
       "language_message_label": "{language} message",
       "save": "Save"
     }

--- a/app/i18n/translations/fr.json
+++ b/app/i18n/translations/fr.json
@@ -1267,6 +1267,7 @@
       "message": "Message",
       "message_translate_button": "Traduire le message",
       "message_translation_help": "Rédigez le message de bienvenue dans chaque langue prise en charge.",
+      "message_default_language_help": "Renseignez le message en {language}. Les autres langues utiliseront ce texte si aucune traduction n'est disponible.",
       "language_message_label": "Message en {language}",
       "save": "Sauvegarder"
     }

--- a/app/i18n/translations/it.json
+++ b/app/i18n/translations/it.json
@@ -1243,6 +1243,7 @@
       "message": "Messaggio",
       "message_translate_button": "Traduci messaggio",
       "message_translation_help": "Scrivi il messaggio di benvenuto in ogni lingua supportata.",
+      "message_default_language_help": "Compila il messaggio in {language}. Le altre lingue useranno questo testo se non è disponibile una traduzione.",
       "language_message_label": "Messaggio in {language}",
       "save": "Salva"
     }

--- a/templates/admin_edit_welcome.html
+++ b/templates/admin_edit_welcome.html
@@ -26,17 +26,16 @@
       </label>
       {% endfor %}
     </div>
-    <div class="field-group translation-control">
-      <label for="body">{{ _('admin_edit_welcome.form.message', default='Message') }}
-        <textarea id="body" name="body" required>{{ body_map.get(language_code, body) }}</textarea>
-      </label>
-      <button type="button" class="btn-outline translation-toggle" data-translation-target="bodyTranslations" aria-expanded="false">{{ _('admin_edit_welcome.form.message_translate_button', default='Translate message') }}</button>
+    <div class="field-group">
+      <p class="translation-label">{{ _('admin_edit_welcome.form.message', default='Message') }}</p>
     </div>
-    <div id="bodyTranslations" class="translation-panel" hidden>
+    <div id="bodyTranslations" class="translation-panel">
       <p class="translation-help">{{ _('admin_edit_welcome.form.message_translation_help', default='Write the welcome message in each supported language.') }}</p>
+      {% set default_lang = (available_languages | selectattr('code', 'equalto', default_language) | list | first) %}
+      <p class="translation-note">{{ _('admin_edit_welcome.form.message_default_language_help', language=(default_lang.name if default_lang else default_language|upper), default='Provide the {language} message. Other languages inherit it when no translation is set.') }}</p>
       {% for lang in available_languages %}
       <label for="body_{{ lang.code }}">{{ _('admin_edit_welcome.form.language_message_label', language=lang.name, default='{language} message') }}
-        <textarea id="body_{{ lang.code }}" name="body_{{ lang.code }}">{{ body_map.get(lang.code, body) }}</textarea>
+        <textarea id="body_{{ lang.code }}" name="body_{{ lang.code }}"{% if lang.code == default_language %} required aria-required="true"{% endif %}>{{ body_map.get(lang.code, body) }}</textarea>
       </label>
       {% endfor %}
     </div>
@@ -52,6 +51,8 @@
 .translation-panel input,.translation-panel textarea{width:100%;}
 .translation-panel textarea{min-height:96px;}
 .translation-help{margin:0;font-size:.9rem;opacity:.75;}
+.translation-note{margin:0;font-size:.85rem;color:#475569;}
+.translation-label{margin:0;font-weight:600;}
 @media (min-width:600px){
   .translation-control{flex-direction:row;align-items:flex-end;}
   .translation-control label{flex:1;}


### PR DESCRIPTION
## Summary
- remove the welcome message translate button and single-language textarea so only per-language fields remain visible
- enforce a required default-language textarea, preserving existing translations when a field is left blank, and prevent saving without English copy
- add guidance about the new handling to AGENTS.md and expose translation helper text in all locales

## Testing
- pytest tests/test_welcome_notification.py tests/test_translations.py

------
https://chatgpt.com/codex/tasks/task_e_68cbed6d21748320b16d48ce913f16c6