### PR TITLE
Require default welcome subject

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -348,7 +348,8 @@
   - Super admins send messages via `/admin/notifications/new`, targeting all users, a single user, or users who ordered at a specific bar.
   - The Admin Notifications page lists recent messages with a **New Message** button linking to the send form and an **Edit Welcome** button for updating the default welcome message.
 - The welcome message editor captures translated subjects and bodies for every supported language; updates are stored on `WelcomeMessage.subject_translations` and `WelcomeMessage.body_translations` with a 30-character limit per subject variant.
-- Welcome message bodies are edited solely through the per-language fields; the primary message textarea and translate toggle were removed.
+- Welcome message subjects and bodies are edited solely through the per-language fields; the primary inputs and translate toggles were removed.
+  - The default-language subject input (English) is required on submit; `admin_welcome_post` falls back to the previous English copy if it isn't provided. Empty subject fields inherit the active language value or the English default.
   - The default-language textarea (English) is required on submit; `admin_welcome_post` falls back to the previous English copy if it isn't provided. The handler keeps the active language's previous text when its textarea is submitted empty and clears other translations when their fields are blank.
   - Each row includes **View** and **Delete** actions; Delete requires confirmation via `.cart-popup`.
   - Viewing a notification at `/admin/notifications/{id}` shows full details and a list of recipient users.

--- a/app/i18n/translations/de.json
+++ b/app/i18n/translations/de.json
@@ -1239,6 +1239,7 @@
       "subject": "Gegenstand",
       "subject_translate_button": "Gegenstand übersetzen",
       "subject_translation_help": "Geben Sie einen Gegenstand für jede unterstützte Sprache ein.",
+      "subject_default_language_help": "Tragen Sie den Gegenstand auf {language} ein. Andere Sprachen übernehmen diesen Text, wenn keine Übersetzung vorhanden ist.",
       "language_subject_label": "Gegenstand in {language}",
       "message": "Nachricht",
       "message_translate_button": "Nachricht übersetzen",

--- a/app/i18n/translations/en.json
+++ b/app/i18n/translations/en.json
@@ -1239,6 +1239,7 @@
       "subject": "Subject",
       "subject_translate_button": "Translate subject",
       "subject_translation_help": "Provide a subject for every supported language.",
+      "subject_default_language_help": "Provide the {language} subject. Other languages inherit it when no translation is set.",
       "language_subject_label": "{language} subject",
       "message": "Message",
       "message_translate_button": "Translate message",

--- a/app/i18n/translations/fr.json
+++ b/app/i18n/translations/fr.json
@@ -1263,6 +1263,7 @@
       "subject": "Sujet",
       "subject_translate_button": "Traduire le sujet",
       "subject_translation_help": "Fournissez un sujet pour chaque langue prise en charge.",
+      "subject_default_language_help": "Renseignez le sujet en {language}. Les autres langues utiliseront ce texte si aucune traduction n'est disponible.",
       "language_subject_label": "Sujet en {language}",
       "message": "Message",
       "message_translate_button": "Traduire le message",

--- a/app/i18n/translations/it.json
+++ b/app/i18n/translations/it.json
@@ -1239,6 +1239,7 @@
       "subject": "Oggetto",
       "subject_translate_button": "Traduci oggetto",
       "subject_translation_help": "Inserisci un oggetto per ogni lingua supportata.",
+      "subject_default_language_help": "Compila l'oggetto in {language}. Le altre lingue useranno questo testo se non è disponibile una traduzione.",
       "language_subject_label": "Oggetto in {language}",
       "message": "Messaggio",
       "message_translate_button": "Traduci messaggio",

--- a/templates/admin_edit_welcome.html
+++ b/templates/admin_edit_welcome.html
@@ -12,17 +12,16 @@
   <p class="alert-danger">{{ error }}</p>
   {% endif %}
   <form class="form" method="post" action="/admin/notifications/welcome">
-    <div class="field-group translation-control">
-      <label for="subject">{{ _('admin_edit_welcome.form.subject', default='Subject') }}
-        <input id="subject" type="text" name="subject" value="{{ subject_map.get(language_code, subject) }}" maxlength="30" required>
-      </label>
-      <button type="button" class="btn-outline translation-toggle" data-translation-target="subjectTranslations" aria-expanded="false">{{ _('admin_edit_welcome.form.subject_translate_button', default='Translate subject') }}</button>
+    {% set default_lang = (available_languages | selectattr('code', 'equalto', default_language) | list | first) %}
+    <div class="field-group">
+      <p class="translation-label">{{ _('admin_edit_welcome.form.subject', default='Subject') }}</p>
     </div>
-    <div id="subjectTranslations" class="translation-panel" hidden>
+    <div id="subjectTranslations" class="translation-panel">
       <p class="translation-help">{{ _('admin_edit_welcome.form.subject_translation_help', default='Provide a subject for every supported language.') }}</p>
+      <p class="translation-note">{{ _('admin_edit_welcome.form.subject_default_language_help', language=(default_lang.name if default_lang else default_language|upper), default='Provide the {language} subject. Other languages inherit it when no translation is set.') }}</p>
       {% for lang in available_languages %}
       <label for="subject_{{ lang.code }}">{{ _('admin_edit_welcome.form.language_subject_label', language=lang.name, default='{language} subject') }}
-        <input id="subject_{{ lang.code }}" name="subject_{{ lang.code }}" value="{{ subject_map.get(lang.code, subject) }}" maxlength="30">
+        <input id="subject_{{ lang.code }}" name="subject_{{ lang.code }}" value="{{ subject_map.get(lang.code, subject) }}" maxlength="30"{% if lang.code == default_language %} required aria-required="true"{% endif %}>
       </label>
       {% endfor %}
     </div>
@@ -31,7 +30,6 @@
     </div>
     <div id="bodyTranslations" class="translation-panel">
       <p class="translation-help">{{ _('admin_edit_welcome.form.message_translation_help', default='Write the welcome message in each supported language.') }}</p>
-      {% set default_lang = (available_languages | selectattr('code', 'equalto', default_language) | list | first) %}
       <p class="translation-note">{{ _('admin_edit_welcome.form.message_default_language_help', language=(default_lang.name if default_lang else default_language|upper), default='Provide the {language} message. Other languages inherit it when no translation is set.') }}</p>
       {% for lang in available_languages %}
       <label for="body_{{ lang.code }}">{{ _('admin_edit_welcome.form.language_message_label', language=lang.name, default='{language} message') }}


### PR DESCRIPTION
## Summary
- require the default language subject when saving the welcome message and reuse it for fallbacks
- adjust the welcome message editor to collect per-language subject copy directly
- document the subject behaviour and localise helper copy for every supported language

## Testing
- pytest tests/test_translations.py
- pytest tests/test_welcome_notification.py

------
https://chatgpt.com/codex/tasks/task_e_68cbf759242c832089dee369d9f4bc07