### PR TITLE
Localise welcome notification language

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,6 +353,7 @@
   - The default-language textarea (English) is required on submit; `admin_welcome_post` falls back to the previous English copy if it isn't provided. The handler keeps the active language's previous text when its textarea is submitted empty and clears other translations when their fields are blank.
   - Each row includes **View** and **Delete** actions; Delete requires confirmation via `.cart-popup`.
   - Viewing a notification at `/admin/notifications/{id}` shows full details and a list of recipient users.
+  - `register_details` resolves the active language via `translator_for_request` before sending welcome notifications so users receive the message in their chosen locale.
   - Each send is logged to `NotificationLog` so broadcasts to all users appear once in the table instead of repeating per user.
   - Selecting a specific user or bar uses searchable tables; choosing "All Users" hides these selectors and does not require an ID.
   - The form disables hidden `user_id` and `bar_id` inputs when not targeting specific recipients and alerts if a required selection is missing.

--- a/main.py
+++ b/main.py
@@ -3395,6 +3395,9 @@ async def register_details(request: Request, db: Session = Depends(get_db)):
     user = get_current_user(request)
     if not user or user.role != "registering":
         return RedirectResponse(url="/login", status_code=status.HTTP_303_SEE_OTHER)
+    # Ensure the request's language is resolved so welcome notifications
+    # respect the active locale when sent.
+    translator_for_request(request)
     form = await request.form()
     username = form.get("username") or ""
     phone = form.get("phone") or ""

--- a/tests/test_welcome_notification.py
+++ b/tests/test_welcome_notification.py
@@ -7,7 +7,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 from fastapi.testclient import TestClient  # noqa: E402
 from database import Base, engine, SessionLocal  # noqa: E402
-from models import User, Notification  # noqa: E402
+from models import User, Notification, WelcomeMessage  # noqa: E402
 from main import app  # noqa: E402
 
 
@@ -47,4 +47,53 @@ def test_welcome_notification_sent():
     note = db.query(Notification).filter_by(user_id=user.id).one()
     assert note.subject == "Welcome"
     assert note.body == "Welcome to SiplyGo!"
+    db.close()
+
+
+def test_welcome_notification_respects_language():
+    db = SessionLocal()
+    wm = WelcomeMessage(
+        id=1,
+        subject="Welcome",
+        body="Welcome to SiplyGo!",
+        subject_translations={"en": "Welcome", "it": "Benvenuto"},
+        body_translations={
+            "en": "Welcome to SiplyGo!",
+            "it": "Benvenuto su SiplyGo!",
+        },
+    )
+    db.merge(wm)
+    db.commit()
+    db.close()
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/register?lang=it",
+            data={
+                "email": "italian@example.com",
+                "password": "Password123",
+                "confirm_password": "Password123",
+            },
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303
+        assert resp.headers["location"] == "/register/details"
+
+        resp = client.post(
+            "/register/details?lang=it",
+            data={
+                "username": "italianuser",
+                "phone": "3123456790",
+                "prefix": "+39",
+            },
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303
+        assert resp.headers["location"] == "/login"
+
+    db = SessionLocal()
+    user = db.query(User).filter_by(email="italian@example.com").one()
+    note = db.query(Notification).filter_by(user_id=user.id).one()
+    assert note.subject == "Benvenuto"
+    assert note.body == "Benvenuto su SiplyGo!"
     db.close()


### PR DESCRIPTION
## Summary
- resolve the active language during registration details submission so the welcome message uses the selected locale
- document the language handling in AGENTS.md for future reference
- add a regression test ensuring Italian welcome copy is delivered when the language is set to it

## Testing
- pytest tests/test_welcome_notification.py

------
https://chatgpt.com/codex/tasks/task_e_68cbfb7bc8708320bbef6d44b081fcbc