### PR TITLE
Localize admin notifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,6 +368,7 @@
 - Notifications older than 30 days are purged automatically by `purge_old_notifications_worker`.
 - New users automatically receive the welcome message after completing registration.
 - Notification and NotificationLog rows persist `subject_translations` and `body_translations` JSON maps so user-facing views can localise message copy when switching languages.
+- Admin new notification form collects per-language subjects and bodies; submissions store translations on both `NotificationLog` and each recipient `Notification`.
 - Mobile menu now includes a **Language** entry (bi-translate icon) that opens an in-app dialog for choosing between English, Italiano, Français, and Deutsch; see `templates/layout.html`, `static/js/app.js`, and related styles in `static/css/components.css`.
 
 ## Internationalization

--- a/app/i18n/translations/de.json
+++ b/app/i18n/translations/de.json
@@ -1153,7 +1153,13 @@
         }
       },
       "subject": "Gegenstand",
+      "subject_translation_help": "Geben Sie für jede unterstützte Sprache einen Betreff an.",
+      "subject_default_language_help": "Geben Sie den Betreff auf {language} ein. Andere Sprachen übernehmen diesen Text, wenn keine Übersetzung vorhanden ist.",
+      "language_subject_label": "{language}-Betreff",
       "message": "Nachricht",
+      "message_translation_help": "Formulieren Sie die Benachrichtigung in allen unterstützten Sprachen.",
+      "message_default_language_help": "Geben Sie die Nachricht auf {language} ein. Andere Sprachen verwenden diesen Text, wenn keine Übersetzung verfügbar ist.",
+      "language_message_label": "{language}-Nachricht",
       "link_url": "Verknüpfungs-URL",
       "image": "Bild",
       "attachment": "Anlage",

--- a/app/i18n/translations/en.json
+++ b/app/i18n/translations/en.json
@@ -1153,7 +1153,13 @@
         }
       },
       "subject": "Subject",
+      "subject_translation_help": "Provide a subject for every supported language.",
+      "subject_default_language_help": "Provide the {language} subject. Other languages inherit it when no translation is set.",
+      "language_subject_label": "{language} subject",
       "message": "Message",
+      "message_translation_help": "Write the notification message in each supported language.",
+      "message_default_language_help": "Provide the {language} message. Other languages inherit it when no translation is set.",
+      "language_message_label": "{language} message",
       "link_url": "Link URL",
       "image": "Image",
       "attachment": "Attachment",

--- a/app/i18n/translations/fr.json
+++ b/app/i18n/translations/fr.json
@@ -1177,7 +1177,13 @@
         }
       },
       "subject": "Sujet",
+      "subject_translation_help": "Indiquez un objet pour chaque langue prise en charge.",
+      "subject_default_language_help": "Saisissez l'objet en {language}. Les autres langues reprendront ce texte s'il n'y a pas de traduction.",
+      "language_subject_label": "Objet en {language}",
       "message": "Message",
+      "message_translation_help": "Rédigez le message de notification dans chaque langue prise en charge.",
+      "message_default_language_help": "Renseignez le message en {language}. Les autres langues utiliseront ce texte s'il n'existe pas de traduction.",
+      "language_message_label": "Message en {language}",
       "link_url": "URL de liaison",
       "image": "Image",
       "attachment": "Pièce jointe",

--- a/app/i18n/translations/it.json
+++ b/app/i18n/translations/it.json
@@ -1153,7 +1153,13 @@
         }
       },
       "subject": "Oggetto",
+      "subject_translation_help": "Inserisci l'oggetto per ogni lingua supportata.",
+      "subject_default_language_help": "Inserisci l'oggetto in {language}. Le altre lingue erediteranno questo testo se non è disponibile una traduzione.",
+      "language_subject_label": "Oggetto in {language}",
       "message": "Messaggio",
+      "message_translation_help": "Scrivi il messaggio della notifica in ogni lingua supportata.",
+      "message_default_language_help": "Inserisci il messaggio in {language}. Le altre lingue useranno questo testo se non è disponibile una traduzione.",
+      "language_message_label": "Messaggio in {language}",
       "link_url": "URL del collegamento",
       "image": "Immagine",
       "attachment": "Allegato",

--- a/templates/admin_new_notification.html
+++ b/templates/admin_new_notification.html
@@ -1,5 +1,8 @@
 {% extends "layout.html" %}
 {% block content %}
+{% set subject_map = subject_translations if subject_translations is defined else {} %}
+{% set body_map = body_translations if body_translations is defined else {} %}
+{% set default_lang = (available_languages | selectattr('code', 'equalto', default_language) | list | first) %}
 <section class="users-page">
   <header class="users-toolbar">
     <div class="title-wrap">
@@ -91,12 +94,30 @@
       <input type="hidden" name="bar_id" id="bar_id">
     </section>
 
-    <label>{{ _('admin_new_notification.form.subject', default='Subject') }}
-      <input type="text" name="subject" maxlength="30">
-    </label>
-    <label>{{ _('admin_new_notification.form.message', default='Message') }}
-      <textarea name="body" rows="4"></textarea>
-    </label>
+    <div class="field-group">
+      <p class="translation-label">{{ _('admin_new_notification.form.subject', default='Subject') }}</p>
+    </div>
+    <div class="translation-panel">
+      <p class="translation-help">{{ _('admin_new_notification.form.subject_translation_help', default='Provide a subject for every supported language.') }}</p>
+      <p class="translation-note">{{ _('admin_new_notification.form.subject_default_language_help', language=(default_lang.name if default_lang else default_language|upper), default='Provide the {language} subject. Other languages inherit it when no translation is set.') }}</p>
+      {% for lang in available_languages %}
+      <label for="subject_{{ lang.code }}">{{ _('admin_new_notification.form.language_subject_label', language=lang.name, default='{language} subject') }}
+        <input id="subject_{{ lang.code }}" name="subject_{{ lang.code }}" maxlength="30" value="{{ subject_map.get(lang.code, '') }}"{% if lang.code == default_language %} required aria-required="true"{% endif %}>
+      </label>
+      {% endfor %}
+    </div>
+    <div class="field-group">
+      <p class="translation-label">{{ _('admin_new_notification.form.message', default='Message') }}</p>
+    </div>
+    <div class="translation-panel">
+      <p class="translation-help">{{ _('admin_new_notification.form.message_translation_help', default='Write the notification message in each supported language.') }}</p>
+      <p class="translation-note">{{ _('admin_new_notification.form.message_default_language_help', language=(default_lang.name if default_lang else default_language|upper), default='Provide the {language} message. Other languages inherit it when no translation is set.') }}</p>
+      {% for lang in available_languages %}
+      <label for="body_{{ lang.code }}">{{ _('admin_new_notification.form.language_message_label', language=lang.name, default='{language} message') }}
+        <textarea id="body_{{ lang.code }}" name="body_{{ lang.code }}" rows="4"{% if lang.code == default_language %} required aria-required="true"{% endif %}>{{ body_map.get(lang.code, '') }}</textarea>
+      </label>
+      {% endfor %}
+    </div>
     <label>{{ _('admin_new_notification.form.link_url', default='Link URL') }}
       <input type="url" name="link_url">
     </label>
@@ -109,7 +130,10 @@
     <button class="btn btn--primary" type="submit">{{ _('admin_new_notification.form.submit', default='Send') }}</button>
   </form>
 </section>
+{% endblock %}
 
+{% block scripts %}
+{{ super() }}
 <script>
 (function(){
   const target = document.getElementById('target');
@@ -178,4 +202,17 @@
   });
 })();
 </script>
+{% endblock %}
+
+{% block styles %}
+{{ super() }}
+<style>
+.translation-panel{border:1px dashed rgba(15,23,42,.25);border-radius:12px;padding:16px;margin-bottom:var(--space-3,12px);display:flex;flex-direction:column;gap:12px;}
+.translation-panel label{display:flex;flex-direction:column;font-weight:500;gap:6px;}
+.translation-panel input,.translation-panel textarea{width:100%;}
+.translation-panel textarea{min-height:96px;}
+.translation-help{margin:0;font-size:.9rem;opacity:.75;}
+.translation-note{margin:0;font-size:.85rem;color:#475569;}
+.translation-label{margin:0;font-weight:600;}
+</style>
 {% endblock %}

--- a/tests/test_admin_notification_view_delete.py
+++ b/tests/test_admin_notification_view_delete.py
@@ -49,7 +49,7 @@ def test_view_and_delete_notification():
         _login_super_admin(client)
         resp = client.post(
             "/admin/notifications",
-            data={"target": "all", "subject": "Hi", "body": "Test"},
+            data={"target": "all", "subject_en": "Hi", "body_en": "Test"},
             follow_redirects=False,
         )
         assert resp.status_code == 303

--- a/tests/test_admin_notifications_all_users.py
+++ b/tests/test_admin_notifications_all_users.py
@@ -50,7 +50,7 @@ def test_all_user_notification_shows_single_row():
         _login_super_admin(client)
         resp = client.post(
             "/admin/notifications",
-            data={"target": "all", "subject": "Hi", "body": "Test"},
+            data={"target": "all", "subject_en": "Hi", "body_en": "Test"},
             follow_redirects=False,
         )
         assert resp.status_code == 303

--- a/tests/test_notification_badge.py
+++ b/tests/test_notification_badge.py
@@ -44,7 +44,12 @@ def test_notification_badge():
         _login(client, "admin@example.com", "ChangeMe!123")
         resp = client.post(
             "/admin/notifications",
-            data={"target": "user", "user_id": user_id, "subject": "Hi", "body": "Test"},
+            data={
+                "target": "user",
+                "user_id": user_id,
+                "subject_en": "Hi",
+                "body_en": "Test",
+            },
             follow_redirects=False,
         )
         assert resp.status_code == 303

--- a/tests/test_notification_delete_removes_user.py
+++ b/tests/test_notification_delete_removes_user.py
@@ -49,7 +49,7 @@ def test_notification_deletion_removes_user_entries():
         _login(client, "admin@example.com", "ChangeMe!123")
         resp = client.post(
             "/admin/notifications",
-            data={"target": "all", "subject": "Hi", "body": "Test"},
+            data={"target": "all", "subject_en": "Hi", "body_en": "Test"},
             follow_redirects=False,
         )
         assert resp.status_code == 303

--- a/tests/test_notification_mark_read.py
+++ b/tests/test_notification_mark_read.py
@@ -44,7 +44,12 @@ def test_notification_marked_read_after_view():
         _login(client, "admin@example.com", "ChangeMe!123")
         resp = client.post(
             "/admin/notifications",
-            data={"target": "user", "user_id": user_id, "subject": "Hi", "body": "Test body"},
+            data={
+                "target": "user",
+                "user_id": user_id,
+                "subject_en": "Hi",
+                "body_en": "Test body",
+            },
             follow_redirects=False,
         )
         assert resp.status_code == 303
@@ -74,3 +79,63 @@ def test_notification_marked_read_after_view():
         _login(client, "admin@example.com", "ChangeMe!123")
         resp = client.get(f"/admin/notifications/{log_id}")
         assert ">Yes<" in resp.text
+
+
+def test_notification_translations_render_for_user():
+    db = SessionLocal()
+    password_hash = hashlib.sha256("pass".encode("utf-8")).hexdigest()
+    user = User(
+        username="languser",
+        email="lang@example.com",
+        password_hash=password_hash,
+        role=RoleEnum.CUSTOMER,
+    )
+    db.add(user)
+    db.commit()
+    user_id = user.id
+    db.close()
+
+    with TestClient(app) as client:
+        _login(client, "admin@example.com", "ChangeMe!123")
+        resp = client.post(
+            "/admin/notifications",
+            data={
+                "target": "user",
+                "user_id": user_id,
+                "subject_en": "Hello",
+                "body_en": "English body",
+                "subject_it": "Ciao",
+                "body_it": "Messaggio italiano",
+            },
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303
+
+        db = SessionLocal()
+        note = (
+            db.query(Notification)
+            .filter(Notification.user_id == user_id)
+            .first()
+        )
+        assert note is not None
+        assert note.subject_translations["en"] == "Hello"
+        assert note.subject_translations["it"] == "Ciao"
+        assert note.body_translations["en"] == "English body"
+        assert note.body_translations["it"] == "Messaggio italiano"
+        note_id = note.id
+        db.close()
+
+        _login(client, "lang@example.com", "pass")
+        resp = client.get("/notifications")
+        assert resp.status_code == 200
+        assert "English body" in resp.text
+        resp = client.get(f"/notifications/{note_id}")
+        assert resp.status_code == 200
+        assert "Hello" in resp.text
+
+        resp = client.get("/notifications?lang=it")
+        assert resp.status_code == 200
+        assert "Messaggio italiano" in resp.text
+        resp = client.get(f"/notifications/{note_id}?lang=it")
+        assert resp.status_code == 200
+        assert "Ciao" in resp.text

--- a/tests/test_notification_subject_limit.py
+++ b/tests/test_notification_subject_limit.py
@@ -43,7 +43,7 @@ def test_subject_too_long_is_rejected():
         _login_super_admin(client)
         resp = client.post(
             "/admin/notifications",
-            data={"target": "all", "subject": "x" * 31, "body": "Test"},
+            data={"target": "all", "subject_en": "x" * 31, "body_en": "Test"},
             follow_redirects=False,
         )
         assert resp.status_code == 303


### PR DESCRIPTION
## Summary
- add multi-language subject and message inputs to the admin new notification form
- store per-language notification content in NotificationLog and Notification records for delivery in the requested locale
- update translations, documentation, and tests to cover localized notifications

## Testing
- pytest tests/test_translations.py tests/test_admin_notifications_all_users.py tests/test_admin_notification_view_delete.py tests/test_notification_badge.py tests/test_notification_mark_read.py tests/test_notification_subject_limit.py tests/test_notification_delete_removes_user.py

------
https://chatgpt.com/codex/tasks/task_e_68cc00f06348832084476072d6d0b97b