### PR TITLE
Allow placed timestamps to wrap

### DIFF
--- a/static/js/orders.js
+++ b/static/js/orders.js
@@ -129,7 +129,7 @@ function initBartender(barId) {
       `<section class="order-card__meta"><dl class="order-kv">` +
       `<div><dt>${getField('total', 'Total')}</dt><dd class="num nowrap">CHF ${order.total.toFixed(2)}</dd></div>` +
       refund +
-      `<div><dt>${getField('placed', 'Placed')}</dt><dd class="num nowrap">${placed}</dd></div>` +
+      `<div><dt>${getField('placed', 'Placed')}</dt><dd class="num">${placed}</dd></div>` +
       `<div><dt>${getField('customer', 'Customer')}</dt><dd>${customerName}${phoneHtml}</dd></div>` +
       `<div><dt>${getField('bar', 'Bar')}</dt><dd>${order.bar_name || ''}</dd></div>` +
       `<div><dt>${getField('table', 'Table')}</dt><dd>${order.table_name || ''}</dd></div>` +
@@ -241,7 +241,7 @@ function initUser(userId) {
       `<section class="order-card__meta"><dl class="order-kv">` +
       `<div><dt>${getField('total', 'Total')}</dt><dd class="num nowrap">CHF ${order.total.toFixed(2)}</dd></div>` +
       refund +
-      `<div><dt>${getField('placed', 'Placed')}</dt><dd class="num nowrap">${placed}</dd></div>` +
+      `<div><dt>${getField('placed', 'Placed')}</dt><dd class="num">${placed}</dd></div>` +
       `<div><dt>${getField('customer', 'Customer')}</dt><dd>${customerName}${phoneHtml}</dd></div>` +
       `<div><dt>${getField('bar', 'Bar')}</dt><dd>${order.bar_name || ''}</dd></div>` +
       `<div><dt>${getField('table', 'Table')}</dt><dd>${order.table_name || ''}</dd></div>` +


### PR DESCRIPTION
## Summary
- allow order card placed timestamp lines to wrap when space is limited by removing the nowrap class

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cce45b67e0832087ff2157713e1577