### PR TITLE
Shift display orders left

### DIFF
--- a/templates/display_orders.html
+++ b/templates/display_orders.html
@@ -16,8 +16,8 @@
 .display-page{display:flex;gap:20px;margin-top:10px;}
 .display-column{flex:1;}
 .display-orders{display:flex;flex-direction:column;gap:12px;}
-.display-orders .order-card{width:100%;max-width:none;min-width:100px;text-align:center;display:flex;align-items:center;justify-content:center;}
-.display-orders .order-card__header{justify-content:center;align-items:center;}
+.display-orders .order-card{width:100%;max-width:none;min-width:100px;text-align:left;display:flex;align-items:center;justify-content:flex-start;}
+.display-orders .order-card__header{justify-content:flex-start;align-items:center;width:100%;}
 .display-orders .order-card h3{font-size:2em;}
 </style>
 


### PR DESCRIPTION
## Summary
- align display order cards to the left to give wrapped codes more room

## Testing
- pytest tests/test_display_orders_html.py

------
https://chatgpt.com/codex/tasks/task_e_68ccfb914eb08320a6783cf5bb40756d