### PR TITLE
Add block role restricted experience

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,8 @@
 - Display users are redirected from any non-display route to their bar's display orders page.
 - The display orders page stretches to the full viewport width and doubles the size of order headers for clearer visibility.
 - Display orders include 10px horizontal margins and center the order text within each card.
+- Block role users are limited to notifications and the `/blocked` help screen; BlockRedirectMiddleware in `main.py` enforces
+  redirects and the template lives at `templates/blocked.html`.
 
 - `common.weekdays.<day>` translations drive the opening hours day labels on bar pages. Use these keys instead of hard-coded
   weekday names.

--- a/app/i18n/translations/de.json
+++ b/app/i18n/translations/de.json
@@ -956,7 +956,8 @@
       "bar_admin": "Verwaltungsleiste",
       "bartender": "Barkeeper",
       "display": "Anzeige",
-      "customer": "Abnehmer"
+      "customer": "Abnehmer",
+      "blocked": "Blockiert"
     },
     "sections": {
       "assigned": "Zugeordnete Balken",
@@ -1548,34 +1549,34 @@
       "create": "Erstellen",
       "update": "Aktualisieren"
     },
-  "edit_name": {
-    "back": "Zurück zum Produkt",
-    "title": "Namen für {product} bearbeiten",
-    "intro": "Geben Sie für jede unterstützte Sprache einen Namen ein. Gäste sehen die Variante in ihrer gewählten Sprache.",
-    "fields": {
-      "language": "Name auf {language}"
+    "edit_name": {
+      "back": "Zurück zum Produkt",
+      "title": "Namen für {product} bearbeiten",
+      "intro": "Geben Sie für jede unterstützte Sprache einen Namen ein. Gäste sehen die Variante in ihrer gewählten Sprache.",
+      "fields": {
+        "language": "Name auf {language}"
+      },
+      "actions": {
+        "save": "Namen speichern"
+      },
+      "errors": {
+        "required": "Alle Felder sind erforderlich."
+      }
     },
-    "actions": {
-      "save": "Namen speichern"
+    "edit_description": {
+      "back": "Zurück zum Produkt",
+      "title": "Beschreibungen für {product} bearbeiten",
+      "intro": "Verfassen Sie für jede unterstützte Sprache eine Beschreibung. Die Texte erscheinen im Gästemenü.",
+      "fields": {
+        "language": "Beschreibung auf {language}"
+      },
+      "actions": {
+        "save": "Beschreibungen speichern"
+      },
+      "errors": {
+        "required": "Alle Felder sind erforderlich."
+      }
     },
-    "errors": {
-      "required": "Alle Felder sind erforderlich."
-    }
-  },
-  "edit_description": {
-    "back": "Zurück zum Produkt",
-    "title": "Beschreibungen für {product} bearbeiten",
-    "intro": "Verfassen Sie für jede unterstützte Sprache eine Beschreibung. Die Texte erscheinen im Gästemenü.",
-    "fields": {
-      "language": "Beschreibung auf {language}"
-    },
-    "actions": {
-      "save": "Beschreibungen speichern"
-    },
-    "errors": {
-      "required": "Alle Felder sind erforderlich."
-    }
-  },
     "manage": {
       "title": "Produkte in {category} für {bar}",
       "subtitle": "Hinzufügen, Bearbeiten und Organisieren von Produkten für diese Kategorie.",
@@ -1621,5 +1622,11 @@
     "actions": {
       "home": "Zur Startseite"
     }
+  },
+  "blocked": {
+    "title": "Kontozugriff eingeschränkt",
+    "lead": "Ihr Konto ist vorübergehend eingeschränkt. Prüfen Sie die neuesten Benachrichtigungen für weitere Informationen.",
+    "support": "Brauchen Sie Hilfe? Kontaktieren Sie unseren Support unter <a href=\"mailto:{email}\">{email}</a> oder rufen Sie <a href=\"tel:{phone_tel}\">{phone}</a> an.",
+    "view_notifications": "Zu den Benachrichtigungen"
   }
 }

--- a/app/i18n/translations/en.json
+++ b/app/i18n/translations/en.json
@@ -956,7 +956,8 @@
       "bar_admin": "Bar Admin",
       "bartender": "Bartender",
       "display": "Display",
-      "customer": "Customer"
+      "customer": "Customer",
+      "blocked": "Blocked"
     },
     "sections": {
       "assigned": "Assigned Bars",
@@ -1548,34 +1549,34 @@
       "create": "Create",
       "update": "Update"
     },
-  "edit_name": {
-    "back": "Back to product",
-    "title": "Edit names for {product}",
-    "intro": "Provide a name for each supported language. Customers see the option matching their selected language.",
-    "fields": {
-      "language": "{language} name"
+    "edit_name": {
+      "back": "Back to product",
+      "title": "Edit names for {product}",
+      "intro": "Provide a name for each supported language. Customers see the option matching their selected language.",
+      "fields": {
+        "language": "{language} name"
+      },
+      "actions": {
+        "save": "Save names"
+      },
+      "errors": {
+        "required": "All fields are required."
+      }
     },
-    "actions": {
-      "save": "Save names"
+    "edit_description": {
+      "back": "Back to product",
+      "title": "Edit descriptions for {product}",
+      "intro": "Write a description for each supported language. Descriptions appear on the customer menu.",
+      "fields": {
+        "language": "{language} description"
+      },
+      "actions": {
+        "save": "Save descriptions"
+      },
+      "errors": {
+        "required": "All fields are required."
+      }
     },
-    "errors": {
-      "required": "All fields are required."
-    }
-  },
-  "edit_description": {
-    "back": "Back to product",
-    "title": "Edit descriptions for {product}",
-    "intro": "Write a description for each supported language. Descriptions appear on the customer menu.",
-    "fields": {
-      "language": "{language} description"
-    },
-    "actions": {
-      "save": "Save descriptions"
-    },
-    "errors": {
-      "required": "All fields are required."
-    }
-  },
     "manage": {
       "title": "Products in {category} for {bar}",
       "subtitle": "Add, edit and organize products for this category.",
@@ -1621,5 +1622,11 @@
     "actions": {
       "home": "Return to home"
     }
+  },
+  "blocked": {
+    "title": "Account access limited",
+    "lead": "Your account is temporarily restricted. Please review the latest notifications for more details.",
+    "support": "Need help? Contact our support team at <a href=\"mailto:{email}\">{email}</a> or call <a href=\"tel:{phone_tel}\">{phone}</a>.",
+    "view_notifications": "Go to notifications"
   }
 }

--- a/app/i18n/translations/fr.json
+++ b/app/i18n/translations/fr.json
@@ -980,7 +980,8 @@
       "bar_admin": "Barre",
       "bartender": "Barman",
       "display": "Afficher",
-      "customer": "Client"
+      "customer": "Client",
+      "blocked": "Bloqué"
     },
     "sections": {
       "assigned": "Barres assignées",
@@ -1572,34 +1573,34 @@
       "create": "Créer",
       "update": "Mise à jour"
     },
-  "edit_name": {
-    "back": "Retour au produit",
-    "title": "Modifier les noms de {product}",
-    "intro": "Saisissez un nom pour chaque langue prise en charge. Les clients voient l'option correspondant à leur langue sélectionnée.",
-    "fields": {
-      "language": "Nom en {language}"
+    "edit_name": {
+      "back": "Retour au produit",
+      "title": "Modifier les noms de {product}",
+      "intro": "Saisissez un nom pour chaque langue prise en charge. Les clients voient l'option correspondant à leur langue sélectionnée.",
+      "fields": {
+        "language": "Nom en {language}"
+      },
+      "actions": {
+        "save": "Enregistrer les noms"
+      },
+      "errors": {
+        "required": "Tous les champs sont obligatoires."
+      }
     },
-    "actions": {
-      "save": "Enregistrer les noms"
+    "edit_description": {
+      "back": "Retour au produit",
+      "title": "Modifier les descriptions de {product}",
+      "intro": "Rédigez une description pour chaque langue prise en charge. Les descriptions apparaissent sur le menu client.",
+      "fields": {
+        "language": "Description en {language}"
+      },
+      "actions": {
+        "save": "Enregistrer les descriptions"
+      },
+      "errors": {
+        "required": "Tous les champs sont obligatoires."
+      }
     },
-    "errors": {
-      "required": "Tous les champs sont obligatoires."
-    }
-  },
-  "edit_description": {
-    "back": "Retour au produit",
-    "title": "Modifier les descriptions de {product}",
-    "intro": "Rédigez une description pour chaque langue prise en charge. Les descriptions apparaissent sur le menu client.",
-    "fields": {
-      "language": "Description en {language}"
-    },
-    "actions": {
-      "save": "Enregistrer les descriptions"
-    },
-    "errors": {
-      "required": "Tous les champs sont obligatoires."
-    }
-  },
     "manage": {
       "title": "Produits en {category} pour {bar}",
       "subtitle": "Ajouter, modifier et organiser des produits pour cette catégorie.",
@@ -1621,5 +1622,11 @@
       "confirm_delete": "Êtes-vous sûr de vouloir supprimer ce produit?",
       "empty": "Pas de produits dans cette catégorie."
     }
+  },
+  "blocked": {
+    "title": "Accès au compte limité",
+    "lead": "Votre compte est temporairement restreint. Consultez les dernières notifications pour plus de détails.",
+    "support": "Besoin d'aide ? Contactez notre assistance à <a href=\"mailto:{email}\">{email}</a> ou appelez le <a href=\"tel:{phone_tel}\">{phone}</a>.",
+    "view_notifications": "Aller aux notifications"
   }
 }

--- a/app/i18n/translations/it.json
+++ b/app/i18n/translations/it.json
@@ -956,7 +956,8 @@
       "bar_admin": "Amministratore del locale",
       "bartender": "Bartender",
       "display": "Display",
-      "customer": "Cliente"
+      "customer": "Cliente",
+      "blocked": "Bloccato"
     },
     "sections": {
       "assigned": "Locali assegnati",
@@ -1548,34 +1549,34 @@
       "create": "Crea",
       "update": "Aggiorna"
     },
-  "edit_name": {
-    "back": "Torna al prodotto",
-    "title": "Modifica i nomi di {product}",
-    "intro": "Inserisci un nome per ogni lingua supportata. I clienti vedono l'opzione corrispondente alla lingua selezionata.",
-    "fields": {
-      "language": "Nome in {language}"
+    "edit_name": {
+      "back": "Torna al prodotto",
+      "title": "Modifica i nomi di {product}",
+      "intro": "Inserisci un nome per ogni lingua supportata. I clienti vedono l'opzione corrispondente alla lingua selezionata.",
+      "fields": {
+        "language": "Nome in {language}"
+      },
+      "actions": {
+        "save": "Salva nomi"
+      },
+      "errors": {
+        "required": "Tutti i campi sono obbligatori."
+      }
     },
-    "actions": {
-      "save": "Salva nomi"
+    "edit_description": {
+      "back": "Torna al prodotto",
+      "title": "Modifica le descrizioni di {product}",
+      "intro": "Scrivi una descrizione per ogni lingua supportata. Le descrizioni vengono mostrate nel menu clienti.",
+      "fields": {
+        "language": "Descrizione in {language}"
+      },
+      "actions": {
+        "save": "Salva descrizioni"
+      },
+      "errors": {
+        "required": "Tutti i campi sono obbligatori."
+      }
     },
-    "errors": {
-      "required": "Tutti i campi sono obbligatori."
-    }
-  },
-  "edit_description": {
-    "back": "Torna al prodotto",
-    "title": "Modifica le descrizioni di {product}",
-    "intro": "Scrivi una descrizione per ogni lingua supportata. Le descrizioni vengono mostrate nel menu clienti.",
-    "fields": {
-      "language": "Descrizione in {language}"
-    },
-    "actions": {
-      "save": "Salva descrizioni"
-    },
-    "errors": {
-      "required": "Tutti i campi sono obbligatori."
-    }
-  },
     "manage": {
       "title": "Prodotti in {category} per {bar}",
       "subtitle": "Aggiungi, modifica e organizza i prodotti per questa categoria.",
@@ -1621,5 +1622,11 @@
     "actions": {
       "home": "Torna alla home"
     }
+  },
+  "blocked": {
+    "title": "Accesso all'account limitato",
+    "lead": "Il tuo account è temporaneamente limitato. Controlla le ultime notifiche per maggiori dettagli.",
+    "support": "Serve aiuto? Contatta l'assistenza all'indirizzo <a href=\"mailto:{email}\">{email}</a> o chiama <a href=\"tel:{phone_tel}\">{phone}</a>.",
+    "view_notifications": "Vai alle notifiche"
   }
 }

--- a/models.py
+++ b/models.py
@@ -36,6 +36,7 @@ class RoleEnum(str, PyEnum):
     CUSTOMER = "Customer"
     REGISTERING = "Registering"
     DISPLAY = "Display"
+    BLOCKED = "Blocked"
 
 
 class User(Base):

--- a/templates/admin_edit_user.html
+++ b/templates/admin_edit_user.html
@@ -39,6 +39,7 @@
     <option value="bartender" {% if user.role=='bartender' %}selected{% endif %}>{{ _('admin_edit_user.roles.bartender', default='Bartender') }}</option>
     <option value="display" {% if user.role=='display' %}selected{% endif %}>{{ _('admin_edit_user.roles.display', default='Display') }}</option>
     <option value="customer" {% if user.role=='customer' %}selected{% endif %}>{{ _('admin_edit_user.roles.customer', default='Customer') }}</option>
+    <option value="blocked" {% if user.role=='blocked' %}selected{% endif %}>{{ _('admin_edit_user.roles.blocked', default='Blocked') }}</option>
   </select>
 
   <h2>{{ _('admin_edit_user.sections.assigned', default='Assigned Bars') }}</h2>

--- a/templates/blocked.html
+++ b/templates/blocked.html
@@ -1,0 +1,9 @@
+{% extends "layout.html" %}
+{% block content %}
+<section class="static-page blocked-page">
+  <h1>{{ _('blocked.title', default='Account access limited') }}</h1>
+  <p>{{ _('blocked.lead', default='Your account is temporarily restricted. Please review the latest notifications for more details.') }}</p>
+  <p>{{ _('blocked.support', email=SUPPORT_EMAIL, phone=SUPPORT_NUMBER, phone_tel=SUPPORT_NUMBER_TEL, default='Need help? Contact our support team at <a href="mailto:{email}">{email}</a> or call <a href="tel:{phone_tel}">{phone}</a>.')|safe }}</p>
+  <a class="btn btn--primary" href="/notifications">{{ _('blocked.view_notifications', default='Go to notifications') }}</a>
+</section>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -46,10 +46,10 @@
       </button>
       <a class="hdr-logo" href="/">SiplyGo</a>
       <div class="hdr-actions">
-        {% if user and not user.is_display %}
+        {% if user and not (user.is_display or user.is_blocked) %}
         <a class="credit-pill" href="/wallet" aria-label="{{ _('common.credits', default='Credits') }}">CHF {{ "%.2f"|format(user.credit) }}</a>
         {% endif %}
-        {% if not user or not user.is_display %}
+        {% if not user or (not user.is_display and not user.is_blocked) %}
         {% set cart_count_display = cart_count if cart_count else 0 %}
         <a class="cart-icon" href="/cart" aria-label="{{ _('layout.header.cart_aria', count=cart_count_display, default='Cart ({count} items)') }}">
           <i class="bi bi-cart2" aria-hidden="true"></i>
@@ -67,10 +67,10 @@
       </button>
       <a class="hdr-logo" href="/">SiplyGo</a>
       <div class="hdr-actions">
-        {% if user and not user.is_display %}
+        {% if user and not (user.is_display or user.is_blocked) %}
         <a class="credit-pill desktop-credit" href="/wallet" aria-label="{{ _('common.credits', default='Credits') }}">CHF {{ "%.2f"|format(user.credit) }}</a>
         {% endif %}
-        {% if not user or not user.is_display %}
+        {% if not user or (not user.is_display and not user.is_blocked) %}
         {% set cart_count_display = cart_count if cart_count else 0 %}
         <a class="cart-icon" href="/cart" aria-label="{{ _('layout.header.cart_aria', count=cart_count_display, default='Cart ({count} items)') }}">
           <i class="bi bi-cart2" aria-hidden="true"></i>
@@ -87,15 +87,20 @@
         <span>{{ _('layout.header.language', default='Language') }}</span>
         <span class="menu-language__code" aria-hidden="true">{{ language_code|upper }}</span>
       </button>
-      {% if user and (user.is_super_admin or user.is_bar_admin or user.is_bartender) %}
+      {% if user and not user.is_blocked and (user.is_super_admin or user.is_bar_admin or user.is_bartender) %}
       <a href="/dashboard" role="menuitem"><i class="bi bi-speedometer2" aria-hidden="true"></i><span>{{ _('common.dashboard', default='Dashboard') }}</span></a>
       {% endif %}
       {% if user %}
+      {% if user.is_blocked %}
+      <a href="/notifications" role="menuitem"><i class="bi bi-bell" aria-hidden="true"></i><span>{{ _('common.notifications', default='Notifications') }}</span>{% if unread_notifications %}<span class="notif-badge" aria-live="polite">{{ unread_notifications }}</span>{% endif %}</a>
+      <a href="/logout" role="menuitem"><i class="bi bi-box-arrow-right" aria-hidden="true"></i><span>{{ _('common.logout', default='Logout') }}</span></a>
+      {% else %}
       <a href="/wallet" role="menuitem"><i class="bi bi-wallet2" aria-hidden="true"></i><span>{{ _('common.wallet', default='Wallet') }}</span></a>
       <a href="/orders" role="menuitem"><i class="bi bi-clock-history" aria-hidden="true"></i><span>{{ _('common.orders', default='Orders') }}</span></a>
       <a href="/notifications" role="menuitem"><i class="bi bi-bell" aria-hidden="true"></i><span>{{ _('common.notifications', default='Notifications') }}</span>{% if unread_notifications %}<span class="notif-badge" aria-live="polite">{{ unread_notifications }}</span>{% endif %}</a>
       <a href="/profile" role="menuitem"><i class="bi bi-person" aria-hidden="true"></i><span>{{ _('common.profile', default='Profile') }}</span></a>
       <a href="/logout" role="menuitem"><i class="bi bi-box-arrow-right" aria-hidden="true"></i><span>{{ _('common.logout', default='Logout') }}</span></a>
+      {% endif %}
       {% else %}
       <a href="/login" role="menuitem" class="menu-login"><i class="bi bi-box-arrow-in-right" aria-hidden="true"></i><span>{{ _('common.login', default='Login') }}</span></a>
       <a href="/register" role="menuitem" class="menu-register"><i class="bi bi-person-plus" aria-hidden="true"></i><span>{{ _('common.register', default='Register') }}</span></a>

--- a/tests/test_blocked_role_access.py
+++ b/tests/test_blocked_role_access.py
@@ -1,0 +1,56 @@
+import os
+import pathlib
+import hashlib
+import sys
+
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from database import Base, engine, SessionLocal  # noqa: E402
+from models import User, RoleEnum, Notification, NotificationLog  # noqa: E402
+from main import app, load_bars_from_db, user_carts, users, users_by_email, users_by_username  # noqa: E402
+
+
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    user_carts.clear()
+    users.clear()
+    users_by_email.clear()
+    users_by_username.clear()
+
+
+def test_blocked_user_redirects_and_can_view_notifications():
+    setup_db()
+    with TestClient(app) as client:
+        db = SessionLocal()
+        pwd = hashlib.sha256('pass'.encode('utf-8')).hexdigest()
+        blocked = User(username='blocked', email='blocked@example.com', password_hash=pwd, role=RoleEnum.BLOCKED)
+        db.add(blocked)
+        db.commit()
+        db.refresh(blocked)
+        log = NotificationLog(sender_id=blocked.id, target='user', user_id=blocked.id, subject='Update', body='Please review')
+        db.add(log)
+        db.commit()
+        db.refresh(log)
+        note = Notification(user_id=blocked.id, sender_id=blocked.id, log_id=log.id, subject='Update', body='Blocked message')
+        db.add(note)
+        db.commit()
+        db.close()
+        load_bars_from_db()
+
+        client.post('/login', data={'email': 'blocked@example.com', 'password': 'pass'})
+
+        resp = client.get('/', follow_redirects=False)
+        assert resp.status_code == 303
+        assert resp.headers['location'] == '/blocked'
+
+        blocked_page = client.get('/blocked')
+        assert blocked_page.status_code == 200
+        assert 'Account access limited' in blocked_page.text
+        assert 'support@siplygo.example.com' in blocked_page.text
+
+        notifications_page = client.get('/notifications')
+        assert notifications_page.status_code == 200
+        assert 'Update' in notifications_page.text


### PR DESCRIPTION
## Summary
- add a Block role type with middleware that redirects users to a dedicated blocked page and limits routes
- expose a support-focused `/blocked` template and adjust navigation/admin tools to handle blocked users
- translate the new copy and cover the flow with a regression test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cd07f9d7748320b2fd099d7f96ce92