### PR TITLE
Clear carts for blocked users

### DIFF
--- a/main.py
+++ b/main.py
@@ -5809,6 +5809,13 @@ async def update_user(request: Request, user_id: int, db: Session = Depends(get_
     role_enum = role_enum_map.get(role, RoleEnum.CUSTOMER)
     db_user.role = role_enum
     db_user.credit = Decimal(str(user.credit))
+    if role == "blocked":
+        cart = user_carts.pop(user.id, None)
+        if cart:
+            cart.clear()
+        db.query(UserCart).filter(UserCart.user_id == user_id).delete(
+            synchronize_session=False
+        )
     # Update user-bar role association: remove previous roles then add new assignment
     db.query(UserBarRole).filter(UserBarRole.user_id == user_id).delete(
         synchronize_session=False


### PR DESCRIPTION
## Summary
- clear any in-memory and persisted cart items when an admin blocks a user
- cover the blocking workflow with a regression test that builds and clears a cart

## Testing
- pytest tests/test_update_user.py

------
https://chatgpt.com/codex/tasks/task_e_68cd0bf81f7483209fc404a57f35923a