### PR TITLE
Set DB role to IP Block

### DIFF
--- a/main.py
+++ b/main.py
@@ -3899,7 +3899,13 @@ async def login(request: Request, db: Session = Depends(get_db)):
             longitude=lon,
         )
         if canonical_ip and canonical_ip in blocked_ip_lookup:
-            user.role = "ip_block"
+            if user.role != "ip_block":
+                user.role = "ip_block"
+            user.base_role = "ip_block"
+            db_user = db.get(User, user.id)
+            if db_user and db_user.role != RoleEnum.IPBLOCK:
+                db_user.role = RoleEnum.IPBLOCK
+                db.commit()
             return RedirectResponse(
                 url="/ip-blocked", status_code=status.HTTP_303_SEE_OTHER
             )

--- a/tests/test_ip_block.py
+++ b/tests/test_ip_block.py
@@ -118,9 +118,9 @@ def test_login_from_blocked_ip_redirects_user():
 
     demo_user = users[user_id]
     assert demo_user.role == 'ip_block'
-    assert demo_user.base_role == 'customer'
+    assert demo_user.base_role == 'ip_block'
 
     db = SessionLocal()
     stored_user = db.get(User, user_id)
-    assert stored_user.role == RoleEnum.CUSTOMER
+    assert stored_user.role == RoleEnum.IPBLOCK
     db.close()


### PR DESCRIPTION
## Summary
- ensure logging in from a blocked IP persists the IP Block role in the database
- align in-memory demo user role tracking with the IP Block state
- update the IP block test to reflect the stored role change

## Testing
- pytest tests/test_ip_block.py

------
https://chatgpt.com/codex/tasks/task_e_68cd1aa4be7483209a2a83b4da719c53