### PR TITLE
Add dashboard back links

### DIFF
--- a/static/css/components.css
+++ b/static/css/components.css
@@ -351,6 +351,8 @@ body{background:var(--bg);color:var(--text);font-family:var(--font-sans);transit
 .dashboard-actions .card h3{margin-top:0;}
 
 /* admin dashboard */
+.back-link{display:inline-flex;align-items:center;gap:8px;text-decoration:none;opacity:.85;margin-bottom:var(--space-2,8px);}
+.back-link:hover,.back-link:focus-visible{opacity:1;}
 .admin-dashboard{display:block;}
 .admin-header{margin-block:var(--space-4);}
 .admin-subtitle{margin-top:var(--space-1);opacity:.9;}

--- a/templates/admin_analytics.html
+++ b/templates/admin_analytics.html
@@ -1,5 +1,6 @@
 {% extends "layout.html" %}
 {% block content %}
+<a class="back-link" href="/dashboard"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_analytics.back', default='Back to dashboard') }}</a>
 <h1>{{ _('admin_analytics.title', default='Analytics') }}</h1>
 <div class="dashboard-info">
   <div class="card">

--- a/templates/admin_audit_logs.html
+++ b/templates/admin_audit_logs.html
@@ -2,6 +2,7 @@
 {% block content %}
 <section class="users-page audit-page">
   <header class="users-toolbar">
+    <a class="back-link" href="/dashboard"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_audit_logs.back', default='Back to dashboard') }}</a>
     <div class="title-wrap">
       <h1>{{ _('admin_audit_logs.title', default='Audit Logs') }}</h1>
       <p class="subtitle">{{ _('admin_audit_logs.subtitle', default='Review system activity.') }}</p>

--- a/templates/admin_bars.html
+++ b/templates/admin_bars.html
@@ -2,6 +2,7 @@
 {% block content %}
 <section class="bars-page"> <!-- CHANGED -->
   <header class="bars-toolbar"> <!-- CHANGED -->
+    <a class="back-link" href="/dashboard"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_bars.back', default='Back to dashboard') }}</a>
     <div class="title-wrap">
       <h1>{{ _('admin_bars.title', default='Bars') }}</h1> <!-- CHANGED -->
       <p class="subtitle">{{ _('admin_bars.subtitle', default='Create, edit and manage venues on the platform.') }}</p> <!-- CHANGED -->

--- a/templates/admin_ip_block.html
+++ b/templates/admin_ip_block.html
@@ -2,6 +2,7 @@
 {% block content %}
 <section class="users-page">
   <header class="users-toolbar">
+    <a class="back-link" href="/dashboard"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_ip_block.back', default='Back to dashboard') }}</a>
     <div class="title-wrap">
       <h1>{{ _('admin_ip_block.title', default='IP Block') }}</h1>
       <p class="subtitle">{{ _('admin_ip_block.subtitle', default='Manage network addresses that cannot access the platform.') }}</p>

--- a/templates/admin_notifications.html
+++ b/templates/admin_notifications.html
@@ -2,6 +2,7 @@
 {% block content %}
 <section class="users-page">
   <header class="users-toolbar">
+    <a class="back-link" href="/dashboard"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_notifications.back', default='Back to dashboard') }}</a>
     <div class="title-wrap">
       <h1>{{ _('admin_notifications.title', default='Notifications') }}</h1>
       <p class="subtitle">{{ _('admin_notifications.subtitle', default='Send messages to users.') }}</p>

--- a/templates/admin_payments.html
+++ b/templates/admin_payments.html
@@ -2,6 +2,7 @@
 {% block content %}
 <section class="payments-page users-page">
   <header class="payments-toolbar users-toolbar">
+    <a class="back-link" href="/dashboard"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_payments.back', default='Back to dashboard') }}</a>
     <div class="title-wrap">
       <h1>{{ _('admin_payments.title', default='Payments') }}</h1>
       <p class="subtitle">{{ _('admin_payments.subtitle', default='Review bar revenue and closings.') }}</p>

--- a/templates/admin_profile.html
+++ b/templates/admin_profile.html
@@ -1,5 +1,6 @@
 {% extends "layout.html" %}
 {% block content %}
+<a class="back-link" href="/dashboard"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_profile.back', default='Back to dashboard') }}</a>
 <h1>{{ _('admin_profile.title', default='Profile') }}</h1>
 <div class="card">
   <div class="card__body">

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -2,6 +2,7 @@
 {% block content %}
 <section class="users-page">
   <header class="users-toolbar">
+    <a class="back-link" href="/dashboard"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_users.back', default='Back to dashboard') }}</a>
     <div class="title-wrap">
       <h1>{{ _('admin_users.title', default='Users') }}</h1>
       <p class="subtitle">{{ _('admin_users.subtitle', default='Manage platform accounts.') }}</p>


### PR DESCRIPTION
## Summary
- add back links to admin management views so users can return to the dashboard quickly
- add shared back-link styling to remove text underlines across dashboard pages

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd4ff9a6148320a6e9c36060db5e97