### PR TITLE
Add back navigation to bartender orders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -415,6 +415,7 @@
 - Bartender confirmation strings live under the `bartender_confirm` namespace in `app/i18n/translations/*.json`; `templates/bartender_confirm.html` references them.
 - Display orders screen strings live under the `display_orders` namespace in `app/i18n/translations/*.json`; `templates/display_orders.html` references them.
 - Bar admin revenue history pages use the `bar_admin_history` namespace in `app/i18n/translations/*.json`; `templates/bar_admin_month_history.html`, `templates/bar_admin_order_history.html`, and `templates/bar_admin_order_history_view.html` reference these keys.
+- Bartender live orders page (`templates/bartender_orders.html`) uses the `bartender_orders.back` translation key for its dashboard return link; update all language JSON files when adjusting this label.
 - Bar admin live orders strings live under the `bar_admin_orders` namespace in `app/i18n/translations/*.json`; `templates/bar_admin_orders.html` pulls from these keys.
 - Bar category management pages use the `bar_categories` namespace in `app/i18n/translations/*.json`; see `templates/bar_manage_categories.html`, `templates/bar_new_category.html`, and `templates/bar_edit_category.html`.
 - Bar product management pages use the `bar_products` namespace in `app/i18n/translations/*.json`; `templates/bar_category_products.html`, `templates/bar_new_product.html`, and `templates/bar_edit_product.html` reference them.

--- a/app/i18n/translations/de.json
+++ b/app/i18n/translations/de.json
@@ -1387,6 +1387,7 @@
   },
   "bartender_orders": {
     "title": "{bar} Bestellungen",
+    "back": "Zurück zum Dashboard",
     "pause": "Anhalten der Bestellung",
     "sections": {
       "incoming": "Eingehende Aufträge",

--- a/app/i18n/translations/en.json
+++ b/app/i18n/translations/en.json
@@ -1387,6 +1387,7 @@
   },
   "bartender_orders": {
     "title": "{bar} Orders",
+    "back": "Back to dashboard",
     "pause": "Pause ordering",
     "sections": {
       "incoming": "Incoming Orders",

--- a/app/i18n/translations/fr.json
+++ b/app/i18n/translations/fr.json
@@ -1411,6 +1411,7 @@
   },
   "bartender_orders": {
     "title": "{bar} ORDERS",
+    "back": "Retour au tableau de bord",
     "pause": "Commande de pause",
     "sections": {
       "incoming": "Ordres entrants",

--- a/app/i18n/translations/it.json
+++ b/app/i18n/translations/it.json
@@ -1387,6 +1387,7 @@
   },
   "bartender_orders": {
     "title": "Ordini {bar}",
+    "back": "Torna alla dashboard",
     "pause": "Metti in pausa gli ordini",
     "sections": {
       "incoming": "Ordini in arrivo",

--- a/templates/bartender_orders.html
+++ b/templates/bartender_orders.html
@@ -2,8 +2,14 @@
 {% block content %}
 <section class="orders-page">
   <header class="orders-head">
+    <a class="back-link" href="/dashboard">
+      <i class="bi bi-chevron-left" aria-hidden="true"></i>
+      {{ _('bartender_orders.back', default='Back to dashboard') }}
+    </a>
     <h1 class="orders-title">{{ _('bartender_orders.title', bar=bar.name, default='{bar} Orders') }}</h1>
-    <label><input type="checkbox" id="pause-ordering" {% if bar.ordering_paused %}checked{% endif %}> {{ _('bartender_orders.pause', default='Pause ordering') }}</label>
+    <div class="orders-controls">
+      <label><input type="checkbox" id="pause-ordering" {% if bar.ordering_paused %}checked{% endif %}> {{ _('bartender_orders.pause', default='Pause ordering') }}</label>
+    </div>
   </header>
 
   <section class="orders-section">


### PR DESCRIPTION
## Summary
- add a dashboard back link to the bartender live orders header and keep the pause toggle aligned with other dashboard panels
- localize the new back label across EN/IT/FR/DE and note the key in `AGENTS.md`

## Testing
- pytest tests/test_translations.py

------
https://chatgpt.com/codex/tasks/task_e_68cd5d4b29fc83208f4763ad8b1b8a63