### PR TITLE
Add missing dashboard back buttons

### DIFF
--- a/app/i18n/translations/de.json
+++ b/app/i18n/translations/de.json
@@ -733,10 +733,12 @@
   },
   "admin_tables": {
     "edit": {
-      "title": "Tabelle bearbeiten für {bar}"
+      "title": "Tabelle bearbeiten für {bar}",
+      "back": "Zurück zu den Tabellen"
     },
     "new": {
-      "title": "Tabelle hinzufügen für {bar}"
+      "title": "Tabelle hinzufügen für {bar}",
+      "back": "Zurück zu den Tabellen"
     },
     "form": {
       "labels": {
@@ -751,6 +753,7 @@
     "manage": {
       "title": "Tabellen verwalten für {bar}",
       "subtitle": "Tabellen für diesen Lokal hinzufügen, bearbeiten und organisieren.",
+      "back": "Zurück zu den Bareinstellungen",
       "search": {
         "aria": "Suchtabellen",
         "placeholder": "Tabellen durchsuchen...",
@@ -780,6 +783,7 @@
   "admin_bar_users": {
     "title": "Benutzer verwalten für {bar}",
     "subtitle": "Hinzufügen oder Zuweisen von Mitarbeitern zu diesem Lokal.",
+    "back": "Zurück zu den Bareinstellungen",
     "add_existing": {
       "summary": "Bestehende Benutzer hinzufügen",
       "email": "E-Mail-Adresse",
@@ -849,6 +853,7 @@
   },
   "admin_change_user_password": {
     "title": "Passwort für {user} bearbeiten",
+    "back": "Zurück zu den Nutzereinstellungen",
     "form": {
       "new_password": "Neues Passwort",
       "confirm_password": "Passwort bestätigen",
@@ -929,6 +934,7 @@
   },
   "admin_edit_user": {
     "title": "Benutzer bearbeiten {user}",
+    "back": "Zurück zu den Nutzern",
     "dialog": {
       "ok": "In Ordnung.",
       "cancel": "Abbrechen",
@@ -1031,6 +1037,7 @@
   },
   "admin_edit_bar": {
     "title": "Balken bearbeiten",
+    "back": "Zurück zu den Bareinstellungen",
     "cards": {
       "details": {
         "title": "Einzelheiten"
@@ -1161,6 +1168,7 @@
   "admin_new_notification": {
     "title": "Neue Benachrichtigung",
     "subtitle": "Sende eine Nachricht an Benutzer.",
+    "back": "Zurück zu den Benachrichtigungen",
     "form": {
       "target": {
         "label": "Ziel",
@@ -1228,6 +1236,7 @@
   },
   "admin_new_bar": {
     "title": "Neue Balken erstellen",
+    "back": "Zurück zu den Bars",
     "form": {
       "name": "Bezeichnung",
       "address": "Anschrift",
@@ -1259,6 +1268,7 @@
   },
   "admin_edit_welcome": {
     "title": "Begrüßungsnachricht bearbeiten",
+    "back": "Zurück zu den Benachrichtigungen",
     "form": {
       "subject": "Gegenstand",
       "subject_translate_button": "Gegenstand übersetzen",
@@ -1276,6 +1286,7 @@
   "admin_notification_view": {
     "title": "Meldung {id}",
     "subtitle": "Details und Empfänger.",
+    "back": "Zurück zu den Benachrichtigungen",
     "actions": {
       "back": "Zurück",
       "back_to_list": "Zurück zur Liste"
@@ -1298,6 +1309,12 @@
       },
       "read_yes": "Nein",
       "read_no": "Nein"
+    }
+  },
+  "admin_order_detail": {
+    "back": {
+      "user": "Zurück zum Nutzer",
+      "payments": "Zurück zu den Zahlungen"
     }
   },
   "admin_payments": {
@@ -1324,6 +1341,7 @@
   "admin_view_user": {
     "title": "Benutzer: {user}",
     "subtitle": "Kontodetails und Aktivitäten.",
+    "back": "Zurück zu den Nutzern",
     "profile": {
       "title": "Profil",
       "email": "E-Mail:",

--- a/app/i18n/translations/en.json
+++ b/app/i18n/translations/en.json
@@ -733,10 +733,12 @@
   },
   "admin_tables": {
     "edit": {
-      "title": "Edit Table for {bar}"
+      "title": "Edit Table for {bar}",
+      "back": "Back to tables"
     },
     "new": {
-      "title": "Add Table for {bar}"
+      "title": "Add Table for {bar}",
+      "back": "Back to tables"
     },
     "form": {
       "labels": {
@@ -751,6 +753,7 @@
     "manage": {
       "title": "Manage Tables for {bar}",
       "subtitle": "Add, edit and organize tables for this venue.",
+      "back": "Back to bar settings",
       "search": {
         "aria": "Search tables",
         "placeholder": "Search tables…",
@@ -780,6 +783,7 @@
   "admin_bar_users": {
     "title": "Manage Users for {bar}",
     "subtitle": "Add or assign staff to this venue.",
+    "back": "Back to bar settings",
     "add_existing": {
       "summary": "Add Existing User",
       "email": "Email",
@@ -849,6 +853,7 @@
   },
   "admin_change_user_password": {
     "title": "Edit Password for {user}",
+    "back": "Back to user settings",
     "form": {
       "new_password": "New Password",
       "confirm_password": "Confirm Password",
@@ -929,6 +934,7 @@
   },
   "admin_edit_user": {
     "title": "Edit User {user}",
+    "back": "Back to users",
     "dialog": {
       "ok": "OK",
       "cancel": "Cancel",
@@ -1031,6 +1037,7 @@
   },
   "admin_edit_bar": {
     "title": "Edit Bar",
+    "back": "Back to bar settings",
     "cards": {
       "details": {
         "title": "Details"
@@ -1161,6 +1168,7 @@
   "admin_new_notification": {
     "title": "New Notification",
     "subtitle": "Send a message to users.",
+    "back": "Back to notifications",
     "form": {
       "target": {
         "label": "Target",
@@ -1228,6 +1236,7 @@
   },
   "admin_new_bar": {
     "title": "Create New Bar",
+    "back": "Back to Bars",
     "form": {
       "name": "Name",
       "address": "Address",
@@ -1259,6 +1268,7 @@
   },
   "admin_edit_welcome": {
     "title": "Edit Welcome Message",
+    "back": "Back to notifications",
     "form": {
       "subject": "Subject",
       "subject_translate_button": "Translate subject",
@@ -1276,6 +1286,7 @@
   "admin_notification_view": {
     "title": "Notification {id}",
     "subtitle": "Details and recipients.",
+    "back": "Back to notifications",
     "actions": {
       "back": "Back",
       "back_to_list": "Back to list"
@@ -1298,6 +1309,12 @@
       },
       "read_yes": "Yes",
       "read_no": "No"
+    }
+  },
+  "admin_order_detail": {
+    "back": {
+      "user": "Back to user",
+      "payments": "Back to payments"
     }
   },
   "admin_payments": {
@@ -1324,6 +1341,7 @@
   "admin_view_user": {
     "title": "User: {user}",
     "subtitle": "Account details and activity.",
+    "back": "Back to users",
     "profile": {
       "title": "Profile",
       "email": "Email:",

--- a/app/i18n/translations/fr.json
+++ b/app/i18n/translations/fr.json
@@ -757,10 +757,12 @@
   },
   "admin_tables": {
     "edit": {
-      "title": "Modifier la table pour {bar}"
+      "title": "Modifier la table pour {bar}",
+      "back": "Retour aux tables"
     },
     "new": {
-      "title": "Ajouter une table pour {bar}"
+      "title": "Ajouter une table pour {bar}",
+      "back": "Retour aux tables"
     },
     "form": {
       "labels": {
@@ -775,6 +777,7 @@
     "manage": {
       "title": "Gérer les tables pour {bar}",
       "subtitle": "Ajoutez, modifiez et organisez des tables pour ce lieu.",
+      "back": "Retour aux paramètres du bar",
       "search": {
         "aria": "Tables de recherche",
         "placeholder": "Tables de recherche…",
@@ -804,6 +807,7 @@
   "admin_bar_users": {
     "title": "Gérer les utilisateurs pour {bar}",
     "subtitle": "Ajouter ou affecter du personnel à ce lieu.",
+    "back": "Retour aux paramètres du bar",
     "add_existing": {
       "summary": "Ajouter l'utilisateur existant",
       "email": "E-mail",
@@ -873,6 +877,7 @@
   },
   "admin_change_user_password": {
     "title": "Modifier le mot de passe pour {user}",
+    "back": "Retour aux paramètres utilisateur",
     "form": {
       "new_password": "Nouveau mot de passe",
       "confirm_password": "Confirmez le mot de passe",
@@ -953,6 +958,7 @@
   },
   "admin_edit_user": {
     "title": "Modifier l'utilisateur {user}",
+    "back": "Retour aux utilisateurs",
     "dialog": {
       "ok": "D'ACCORD",
       "cancel": "Annuler",
@@ -1055,6 +1061,7 @@
   },
   "admin_edit_bar": {
     "title": "Éditer la barre",
+    "back": "Retour aux paramètres du bar",
     "cards": {
       "details": {
         "title": "Détails"
@@ -1185,6 +1192,7 @@
   "admin_new_notification": {
     "title": "Nouvelle notification",
     "subtitle": "Envoyer un message aux utilisateurs.",
+    "back": "Retour aux notifications",
     "form": {
       "target": {
         "label": "Cible",
@@ -1252,6 +1260,7 @@
   },
   "admin_new_bar": {
     "title": "Créer une nouvelle barre",
+    "back": "Retour aux bars",
     "form": {
       "name": "Nom",
       "address": "Adresse",
@@ -1283,6 +1292,7 @@
   },
   "admin_edit_welcome": {
     "title": "Modifier le message de bienvenue",
+    "back": "Retour aux notifications",
     "form": {
       "subject": "Sujet",
       "subject_translate_button": "Traduire le sujet",
@@ -1300,6 +1310,7 @@
   "admin_notification_view": {
     "title": "Notification {id}",
     "subtitle": "Détails et destinataires.",
+    "back": "Retour aux notifications",
     "actions": {
       "back": "Dos",
       "back_to_list": "Retour à la liste"
@@ -1322,6 +1333,12 @@
       },
       "read_yes": "Oui",
       "read_no": "Non"
+    }
+  },
+  "admin_order_detail": {
+    "back": {
+      "user": "Retour à l'utilisateur",
+      "payments": "Retour aux paiements"
     }
   },
   "admin_payments": {
@@ -1348,6 +1365,7 @@
   "admin_view_user": {
     "title": "Utilisateur: {user}",
     "subtitle": "Détails et activité du compte.",
+    "back": "Retour aux utilisateurs",
     "profile": {
       "title": "Profil",
       "email": "E-mail:",

--- a/app/i18n/translations/it.json
+++ b/app/i18n/translations/it.json
@@ -733,10 +733,12 @@
   },
   "admin_tables": {
     "edit": {
-      "title": "Modifica tavolo per {bar}"
+      "title": "Modifica tavolo per {bar}",
+      "back": "Torna ai tavoli"
     },
     "new": {
-      "title": "Aggiungi tavolo per {bar}"
+      "title": "Aggiungi tavolo per {bar}",
+      "back": "Torna ai tavoli"
     },
     "form": {
       "labels": {
@@ -751,6 +753,7 @@
     "manage": {
       "title": "Gestisci tavoli per {bar}",
       "subtitle": "Aggiungi, modifica e organizza i tavoli per questo locale.",
+      "back": "Torna alle impostazioni del locale",
       "search": {
         "aria": "Cerca tavoli",
         "placeholder": "Cerca tavoli…",
@@ -780,6 +783,7 @@
   "admin_bar_users": {
     "title": "Gestisci utenti per {bar}",
     "subtitle": "Aggiungi o assegna lo staff a questo locale.",
+    "back": "Torna alle impostazioni del locale",
     "add_existing": {
       "summary": "Aggiungi utente esistente",
       "email": "Email",
@@ -849,6 +853,7 @@
   },
   "admin_change_user_password": {
     "title": "Modifica password per {user}",
+    "back": "Torna alle impostazioni utente",
     "form": {
       "new_password": "Nuova password",
       "confirm_password": "Conferma password",
@@ -929,6 +934,7 @@
   },
   "admin_edit_user": {
     "title": "Modifica utente {user}",
+    "back": "Torna agli utenti",
     "dialog": {
       "ok": "OK",
       "cancel": "Annulla",
@@ -1031,6 +1037,7 @@
   },
   "admin_edit_bar": {
     "title": "Modifica locale",
+    "back": "Torna alle impostazioni del locale",
     "cards": {
       "details": {
         "title": "Dettagli"
@@ -1161,6 +1168,7 @@
   "admin_new_notification": {
     "title": "Nuova notifica",
     "subtitle": "Invia un messaggio agli utenti.",
+    "back": "Torna alle notifiche",
     "form": {
       "target": {
         "label": "Destinatari",
@@ -1228,6 +1236,7 @@
   },
   "admin_new_bar": {
     "title": "Crea nuovo locale",
+    "back": "Torna ai locali",
     "form": {
       "name": "Nome",
       "address": "Indirizzo",
@@ -1259,6 +1268,7 @@
   },
   "admin_edit_welcome": {
     "title": "Modifica messaggio di benvenuto",
+    "back": "Torna alle notifiche",
     "form": {
       "subject": "Oggetto",
       "subject_translate_button": "Traduci oggetto",
@@ -1276,6 +1286,7 @@
   "admin_notification_view": {
     "title": "Notifica {id}",
     "subtitle": "Dettagli e destinatari.",
+    "back": "Torna alle notifiche",
     "actions": {
       "back": "Indietro",
       "back_to_list": "Torna all'elenco"
@@ -1298,6 +1309,12 @@
       },
       "read_yes": "Sì",
       "read_no": "No"
+    }
+  },
+  "admin_order_detail": {
+    "back": {
+      "user": "Torna all'utente",
+      "payments": "Torna ai pagamenti"
     }
   },
   "admin_payments": {
@@ -1324,6 +1341,7 @@
   "admin_view_user": {
     "title": "Utente: {user}",
     "subtitle": "Dettagli account e attività.",
+    "back": "Torna agli utenti",
     "profile": {
       "title": "Profilo",
       "email": "Email:",

--- a/templates/admin_bar_edit_table.html
+++ b/templates/admin_bar_edit_table.html
@@ -1,5 +1,6 @@
 {% extends "layout.html" %}
 {% block content %}
+<a class="back-link" href="/admin/bars/{{ bar.id }}/tables"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_tables.edit.back', default='Back to tables') }}</a>
 <h1>{{ _('admin_tables.edit.title', bar=bar.name, default='Edit Table for {bar}') }}</h1>
 <form class="form" method="post">
   <label for="name">{{ _('admin_tables.form.labels.name', default='Name') }}

--- a/templates/admin_bar_new_table.html
+++ b/templates/admin_bar_new_table.html
@@ -1,5 +1,6 @@
 {% extends "layout.html" %}
 {% block content %}
+<a class="back-link" href="/admin/bars/{{ bar.id }}/tables"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_tables.new.back', default='Back to tables') }}</a>
 <h1>{{ _('admin_tables.new.title', bar=bar.name, default='Add Table for {bar}') }}</h1>
 <form class="form" method="post">
   <label for="name">{{ _('admin_tables.form.labels.name', default='Name') }}

--- a/templates/admin_bar_tables.html
+++ b/templates/admin_bar_tables.html
@@ -2,6 +2,7 @@
 {% block content %}
 <section class="menu-page">
   <header class="menu-toolbar">
+    <a class="back-link" href="/admin/bars/edit/{{ bar.id }}"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_tables.manage.back', default='Back to bar settings') }}</a>
     <div class="title-wrap">
       <h1>{{ _('admin_tables.manage.title', bar=bar.name, default='Manage Tables for {bar}') }}</h1>
       <p class="subtitle">{{ _('admin_tables.manage.subtitle', default='Add, edit and organize tables for this venue.') }}</p>

--- a/templates/admin_bar_users.html
+++ b/templates/admin_bar_users.html
@@ -2,6 +2,7 @@
 {% block content %}
 <section class="users-page">
   <header class="users-toolbar">
+    <a class="back-link" href="/admin/bars/edit/{{ bar.id }}"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_bar_users.back', default='Back to bar settings') }}</a>
     <div class="title-wrap">
       <h1>{{ _('admin_bar_users.title', bar=bar.name, default='Manage Users for {bar}') }}</h1>
       <p class="subtitle">{{ _('admin_bar_users.subtitle', default='Add or assign staff to this venue.') }}</p>

--- a/templates/admin_change_user_password.html
+++ b/templates/admin_change_user_password.html
@@ -1,5 +1,6 @@
 {% extends "layout.html" %}
 {% block content %}
+<a class="back-link" href="/admin/users/edit/{{ user.id }}"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_change_user_password.back', default='Back to user settings') }}</a>
 <h1>{{ _('admin_change_user_password.title', user=user.username, default='Edit Password for {user}') }}</h1>
 {% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
 <form class="form" method="post" action="/admin/users/{{ user.id }}/password">

--- a/templates/admin_edit_bar.html
+++ b/templates/admin_edit_bar.html
@@ -2,6 +2,7 @@
 {% block content %}
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
 <section class="editbar">
+  <a class="back-link" href="/admin/bars/edit/{{ bar.id }}"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_edit_bar.back', default='Back to bar settings') }}</a>
   <h1>{{ _('admin_edit_bar.title', default='Edit Bar') }}</h1>
   {% if error %}<p class="error">{{ error }}</p>{% endif %}
 

--- a/templates/admin_edit_user.html
+++ b/templates/admin_edit_user.html
@@ -1,5 +1,6 @@
 {% extends "layout.html" %}
 {% block content %}
+<a class="back-link" href="/admin/users"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_edit_user.back', default='Back to users') }}</a>
 <h1>{{ _('admin_edit_user.title', user=user.username, default='Edit User {user}') }}</h1>
 {% if error %}
 <div id="errorBlocker" class="cart-blocker">

--- a/templates/admin_edit_welcome.html
+++ b/templates/admin_edit_welcome.html
@@ -4,6 +4,7 @@
 {% set body_map = body_translations if body_translations is defined else {} %}
 <section class="users-page">
   <header class="users-toolbar">
+    <a class="back-link" href="/admin/notifications"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_edit_welcome.back', default='Back to notifications') }}</a>
     <div class="title-wrap">
       <h1>{{ _('admin_edit_welcome.title', default='Edit Welcome Message') }}</h1>
     </div>

--- a/templates/admin_new_bar.html
+++ b/templates/admin_new_bar.html
@@ -1,5 +1,6 @@
 {% extends "layout.html" %}
 {% block content %}
+<a class="back-link" href="/admin/bars"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_new_bar.back', default='Back to Bars') }}</a>
 <h1>{{ _('admin_new_bar.title', default='Create New Bar') }}</h1>
 {% if error %}<p class="error">{{ error }}</p>{% endif %}
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>

--- a/templates/admin_new_notification.html
+++ b/templates/admin_new_notification.html
@@ -5,6 +5,7 @@
 {% set default_lang = (available_languages | selectattr('code', 'equalto', default_language) | list | first) %}
 <section class="users-page">
   <header class="users-toolbar">
+    <a class="back-link" href="/admin/notifications"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_new_notification.back', default='Back to notifications') }}</a>
     <div class="title-wrap">
       <h1>{{ _('admin_new_notification.title', default='New Notification') }}</h1>
       <p class="subtitle">{{ _('admin_new_notification.subtitle', default='Send a message to users.') }}</p>

--- a/templates/admin_notification_view.html
+++ b/templates/admin_notification_view.html
@@ -2,11 +2,11 @@
 {% block content %}
 <section class="users-page">
   <header class="users-toolbar">
+    <a href="/admin/notifications" class="back-link"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_notification_view.back', default='Back to notifications') }}</a>
     <div class="title-wrap">
       <h1>{{ _('admin_notification_view.title', id=note.id, default='Notification {id}') }}</h1>
       <p class="subtitle">{{ _('admin_notification_view.subtitle', default='Details and recipients.') }}</p>
     </div>
-    <a href="/admin/notifications" class="btn-outline">{{ _('admin_notification_view.actions.back', default='Back') }}</a>
   </header>
 
   <div class="table-card">

--- a/templates/admin_order_detail.html
+++ b/templates/admin_order_detail.html
@@ -2,6 +2,11 @@
 {% block content %}
 {% set order_code = order.public_order_code or ('#' ~ order.id) %}
 {% set status_label = order.status|replace('_', ' ')|title %}
+{% if order.customer_id %}
+<a class="back-link" href="/admin/users/view/{{ order.customer_id }}"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_order_detail.back.user', default='Back to user') }}</a>
+{% else %}
+<a class="back-link" href="/admin/payments"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_order_detail.back.payments', default='Back to payments') }}</a>
+{% endif %}
 <h1>{{ _('order_history.card.title', code=order_code, default='Order {code}') }}</h1>
 <div class="order-list">
   <article class="order-card card card--{{ order.status|lower }}" role="article" aria-labelledby="order-{{ order.id }}-title" data-status="{{ order.status }}">

--- a/templates/admin_view_user.html
+++ b/templates/admin_view_user.html
@@ -2,6 +2,7 @@
 {% block content %}
 <section class="users-page">
   <header class="users-toolbar">
+    <a class="back-link" href="/admin/users"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_view_user.back', default='Back to users') }}</a>
     <div class="title-wrap">
       <h1>{{ _('admin_view_user.title', user=user.username, default='User: {user}') }}</h1>
       <p class="subtitle">{{ _('admin_view_user.subtitle', default='Account details and activity.') }}</p>


### PR DESCRIPTION
## Summary
- add the shared back-link component to remaining admin dashboard templates, covering bar editing, tables, users, notifications, and order detail views
- localize the new back-link labels across English, Italian, French, and German translation files

## Testing
- pytest tests/test_translations.py

------
https://chatgpt.com/codex/tasks/task_e_68d0ebe084e08320a0294884cd4245e8