### PR TITLE
Fix bar admin edit back nav

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 - Commit messages subject line must not exceed 30 characters.
 - Notification subject line must not exceed 30 characters.
 - Admin notifications form subject input enforces this with `maxlength=30`.
+- Bar admin edit pages send bar admins back to `/dashboard`; super admins continue to use `/admin/bars` for navigation.
 - Phone validation errors must use English messaging; see `app/phone.py` and `tests/test_register_phone_validation.py`.
 - Dark mode functionality has been removed; the site theme is fixed to light.
 - Product image uploads surface English errors: "No file uploaded", "Uploaded file must be an image", and "File too large (>5MB)".

--- a/templates/admin_edit_bar.html
+++ b/templates/admin_edit_bar.html
@@ -2,7 +2,7 @@
 {% block content %}
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
 <section class="editbar">
-  <a class="back-link" href="/admin/bars/edit/{{ bar.id }}"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_edit_bar.back', default='Back to bar settings') }}</a>
+  <a class="back-link" href="{{ '/dashboard' if user and user.is_bar_admin else '/admin/bars/edit/' ~ bar.id }}"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_edit_bar.back', default='Back to bar settings') }}</a>
   <h1>{{ _('admin_edit_bar.title', default='Edit Bar') }}</h1>
   {% if error %}<p class="error">{{ error }}</p>{% endif %}
 

--- a/templates/admin_edit_bar_options.html
+++ b/templates/admin_edit_bar_options.html
@@ -2,7 +2,7 @@
 {% block content %}
 <section class="bar-edit-page">
   <header class="bar-edit-header">
-    <a href="/admin/bars" class="back-link"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_edit_bar_options.back', default='Back to Bars') }}</a>
+    <a href="{{ '/dashboard' if user and user.is_bar_admin else '/admin/bars' }}" class="back-link"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_edit_bar_options.back', default='Back to Bars') }}</a>
     <h1>{{ _('admin_edit_bar_options.title', bar=bar.name, default='Edit {bar}') }}</h1>
     <p class="subtitle">{{ _('admin_edit_bar_options.subtitle', default='Select a section to manage for this venue.') }}</p>
   </header>


### PR DESCRIPTION
## Summary
- send bar admins back to their dashboard from the edit bar options and info pages
- document the navigation change in AGENTS notes

## Testing
- pytest tests/test_bar_admin_dashboard_cards.py

------
https://chatgpt.com/codex/tasks/task_e_68d0f39498948320b462a4fdeae6e8a1