### PR TITLE
Enforce 10 CHF minimum top-up

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@
 - `cart.errors.other_bar` localises the warning shown when trying to order from a different bar while the cart is full.
 
 - Wallet page UI lives in `templates/wallet.html` using a `.wallet-page` wrapper and inline scoped styles. Transaction rows render inside `<ul id="txList">` as static `.tx` divs with no detail links. "Load more," "Export CSV," "Manage payment methods," and all filters have been removed; the "Top Up" button uses `text-decoration:none` to avoid an underline.
+- Wallet top-ups must be at least 10 CHF; enforce this in both API validation and client-side forms.
 - Transaction detail views have been removed, so there is no `/wallet/tx/{index}` route or `transaction_detail.html` template.
 - Wallet Recent Activity shows all transactions with the newest first, and wallet cards override the base mobile `max-height` so the feed length isn't capped.
 - The balance card's meta now only shows an `Available` badge and omits any "last updated" text.

--- a/app/i18n/translations/de.json
+++ b/app/i18n/translations/de.json
@@ -1641,7 +1641,7 @@
       "submit": "Mit Karte aufladen"
     },
     "alerts": {
-      "invalid_amount": "Ungültiger Betrag",
+      "invalid_amount": "Ungültiger Betrag (mindestens 10 CHF)",
       "failed": "Aufladung konnte nicht gestartet werden"
     }
   },

--- a/app/i18n/translations/en.json
+++ b/app/i18n/translations/en.json
@@ -1641,7 +1641,7 @@
       "submit": "Top up with card"
     },
     "alerts": {
-      "invalid_amount": "Invalid amount",
+      "invalid_amount": "Invalid amount (minimum 10 CHF)",
       "failed": "Unable to start top-up"
     }
   },

--- a/app/i18n/translations/fr.json
+++ b/app/i18n/translations/fr.json
@@ -621,7 +621,7 @@
       "submit": "Recharger par carte"
     },
     "alerts": {
-      "invalid_amount": "Montant invalide",
+      "invalid_amount": "Montant invalide (minimum 10 CHF)",
       "failed": "Impossible de lancer la recharge"
     }
   },

--- a/app/i18n/translations/it.json
+++ b/app/i18n/translations/it.json
@@ -1641,7 +1641,7 @@
       "submit": "Ricarica con carta"
     },
     "alerts": {
-      "invalid_amount": "Importo non valido",
+      "invalid_amount": "Importo non valido (minimo 10 CHF)",
       "failed": "Impossibile avviare la ricarica"
     }
   },

--- a/main.py
+++ b/main.py
@@ -3504,8 +3504,10 @@ async def init_topup(
         raise HTTPException(status_code=401)
 
     amount = topup_req.amount
-    if not math.isfinite(amount) or amount < 1 or amount > 1000:
-        raise HTTPException(status_code=400, detail="Invalid amount")
+    if not math.isfinite(amount) or amount < 10 or amount > 1000:
+        raise HTTPException(
+            status_code=400, detail="Amount must be between 10 and 1000"
+        )
     amount = round(amount + 1e-9, 2)
 
     CURRENCY = os.getenv("CURRENCY", "CHF")

--- a/templates/topup.html
+++ b/templates/topup.html
@@ -4,7 +4,7 @@
   <h1>{{ _('topup.title', default='Top Up Credit') }}</h1>
   <form id="topupForm">
     <label for="amount">{{ _('topup.form.amount_label', default='Amount') }}
-      <input id="amount" name="amount" type="number" min="1" step="0.05" required inputmode="decimal">
+      <input id="amount" name="amount" type="number" min="10" step="0.05" required inputmode="decimal">
     </label>
     <div class="preset-buttons">
       <button type="button" class="btn" data-amount="10">10 CHF</button>
@@ -29,7 +29,7 @@
     e.preventDefault();
     if (submitBtn.disabled) return;
     const amount = parseFloat(amountInput.value);
-    if (!Number.isFinite(amount) || amount < 1) {
+    if (!Number.isFinite(amount) || amount < 10) {
       alert(invalidAmountMessage);
       return;
     }

--- a/tests/test_topup_init.py
+++ b/tests/test_topup_init.py
@@ -100,6 +100,15 @@ def test_topup_init_missing_wallee_config_returns_503():
         assert resp.json()["detail"] == "Top-up service unavailable"
 
 
+def test_topup_below_minimum_rejected():
+    user = _register_user()
+    with TestClient(app) as client:
+        _login_user(client, user.email, "testpass")
+        resp = client.post("/api/topup/init", json={"amount": 5})
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Amount must be between 10 and 1000"
+
+
 def test_topup_transaction_updates_wallet():
     user = _register_user()
     with TestClient(app) as client:
@@ -109,7 +118,7 @@ def test_topup_transaction_updates_wallet():
         ) as MockPage:
             MockTx.create.return_value = SimpleNamespace(id=456)
             MockPage.payment_page_url.return_value = "https://pay.example/456"
-            resp = client.post("/api/topup/init", json={"amount": 5})
+            resp = client.post("/api/topup/init", json={"amount": 12})
             assert resp.status_code == 200
         wallet = client.get("/wallet")
         assert "Processing" in wallet.text
@@ -122,7 +131,7 @@ def test_topup_transaction_updates_wallet():
         )
         wallet = client.get("/wallet")
         assert "Completed" in wallet.text
-        assert "CHF 5.00" in wallet.text
+        assert "CHF 12.00" in wallet.text
 
 
 def test_failed_topup_shows_zero_amount():
@@ -134,7 +143,7 @@ def test_failed_topup_shows_zero_amount():
         ) as MockPage:
             MockTx.create.return_value = SimpleNamespace(id=789)
             MockPage.payment_page_url.return_value = "https://pay.example/789"
-            resp = client.post("/api/topup/init", json={"amount": 8})
+            resp = client.post("/api/topup/init", json={"amount": 15})
             assert resp.status_code == 200
         db = SessionLocal()
         topup = db.query(WalletTopup).filter(WalletTopup.user_id == user.id).one()
@@ -158,12 +167,12 @@ def test_wallet_transactions_ordered_newest_first():
         ) as MockPage:
             MockTx.create.return_value = SimpleNamespace(id=111)
             MockPage.payment_page_url.return_value = "https://pay.example/111"
-            client.post("/api/topup/init", json={"amount": 5})
+            client.post("/api/topup/init", json={"amount": 12})
         with patch("app.wallee_client.tx_service") as MockTx, patch(
             "app.wallee_client.pp_service"
         ) as MockPage:
             MockTx.create.return_value = SimpleNamespace(id=222)
             MockPage.payment_page_url.return_value = "https://pay.example/222"
-            client.post("/api/topup/init", json={"amount": 7})
+            client.post("/api/topup/init", json={"amount": 18})
         wallet = client.get("/wallet")
-        assert wallet.text.index("CHF 7.00") < wallet.text.index("CHF 5.00")
+        assert wallet.text.index("CHF 18.00") < wallet.text.index("CHF 12.00")


### PR DESCRIPTION
## Summary
- enforce a 10 CHF minimum on wallet top-ups across the API and client form
- refresh top-up messaging in every locale and document the rule in AGENTS.md
- update wallet top-up tests for the higher minimum and cover the rejection case

## Testing
- `pytest tests/test_topup_init.py tests/test_topup_popup.py tests/test_topup_failed_redirect.py tests/test_translations.py`


------
https://chatgpt.com/codex/tasks/task_e_68d0f6a7df7c8320a96e72c19d456bf7