### PR TITLE
Pad bar IDs to three digits

### DIFF
--- a/templates/admin_payments.html
+++ b/templates/admin_payments.html
@@ -37,7 +37,7 @@
       <tbody>
         {% for bar in bars %}
         <tr>
-          <td class="number">{{ bar.id }}</td>
+          <td class="number">{{ "{:03d}".format(bar.id) }}</td>
           <td>{{ bar.name }}</td>
           <td class="actions">
             <div class="actions-group">


### PR DESCRIPTION
## Summary
- pad bar numbers in the admin payments table to three digits for consistent display

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d10c69be908320a6029cdfa39bbb82