### PR TITLE
Add directions pill on bar page

### DIFF
--- a/app/i18n/translations/de.json
+++ b/app/i18n/translations/de.json
@@ -586,7 +586,8 @@
       "closed": "Geschlossen"
     },
     "add_to_cart": "Zum Warenkorb hinzufügen",
-    "login_to_order": "Zum Bestellen anmelden"
+    "login_to_order": "Zum Bestellen anmelden",
+    "get_directions": "Route planen"
   },
   "all_bars": {
     "title": "Alle Bars",

--- a/app/i18n/translations/en.json
+++ b/app/i18n/translations/en.json
@@ -586,7 +586,8 @@
       "closed": "Closed"
     },
     "add_to_cart": "Add to Cart",
-    "login_to_order": "Login to order"
+    "login_to_order": "Login to order",
+    "get_directions": "Get directions"
   },
   "all_bars": {
     "title": "All bars",

--- a/app/i18n/translations/fr.json
+++ b/app/i18n/translations/fr.json
@@ -586,7 +586,8 @@
       "closed": "Fermé"
     },
     "add_to_cart": "Ajouter au panier",
-    "login_to_order": "Connectez-vous pour commander"
+    "login_to_order": "Connectez-vous pour commander",
+    "get_directions": "Obtenir l’itinéraire"
   },
   "all_bars": {
     "title": "Tous les bars",

--- a/app/i18n/translations/it.json
+++ b/app/i18n/translations/it.json
@@ -586,7 +586,8 @@
       "closed": "Chiuso"
     },
     "add_to_cart": "Aggiungi al carrello",
-    "login_to_order": "Accedi per ordinare"
+    "login_to_order": "Accedi per ordinare",
+    "get_directions": "Ottieni indicazioni"
   },
   "all_bars": {
     "title": "Tutti i locali",

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -656,6 +656,18 @@ body{background:var(--bg);color:var(--text);font-family:var(--font-sans);transit
   gap:16px;
   margin-bottom:var(--space-4);
 }
+.bar-title-row{
+  display:flex;
+  align-items:center;
+  gap:12px;
+  flex-wrap:wrap;
+}
+.bar-title{
+  margin:0;
+}
+.bar-directions{
+  text-decoration:none;
+}
 .bar-cover-wrapper{
   width:100%;
   aspect-ratio:16/9;

--- a/templates/bar_detail.html
+++ b/templates/bar_detail.html
@@ -9,7 +9,34 @@
     <img class="bar-cover" src="{{ fallback_img }}" alt="" loading="lazy" width="400" height="225">
     {% endif %}
   </div>
-  <h1 class="bar-title" itemprop="name">{{ bar.name }}</h1>
+  {% set google_maps_url = None %}
+  {% set apple_maps_url = None %}
+  {% if bar.latitude and bar.longitude %}
+  {% set destination_value = bar.latitude ~ ',' ~ bar.longitude %}
+  {% set google_maps_url = 'https://www.google.com/maps/dir/?api=1&destination=' ~ destination_value|urlencode %}
+  {% set apple_maps_url = 'https://maps.apple.com/?daddr=' ~ destination_value|urlencode %}
+  {% elif bar.address and bar.city %}
+    {% if bar.state %}
+    {% set destination_value = bar.address ~ ', ' ~ bar.city ~ ', ' ~ bar.state %}
+    {% else %}
+    {% set destination_value = bar.address ~ ', ' ~ bar.city %}
+    {% endif %}
+  {% set google_maps_url = 'https://www.google.com/maps/dir/?api=1&destination=' ~ destination_value|urlencode %}
+  {% set apple_maps_url = 'https://maps.apple.com/?daddr=' ~ destination_value|urlencode %}
+  {% endif %}
+  <div class="bar-title-row">
+    <h1 class="bar-title" itemprop="name">{{ bar.name }}</h1>
+    {% if google_maps_url and apple_maps_url %}
+    <a class="cta-pill cta-pill--ghost bar-directions"
+      href="{{ google_maps_url }}"
+      data-google-url="{{ google_maps_url }}"
+      data-apple-url="{{ apple_maps_url }}"
+      target="_blank"
+      rel="noopener">
+      {{ _('bar_detail.get_directions', default='Get directions') }}
+    </a>
+    {% endif %}
+  </div>
   <div class="bar-meta">
     <span class="bar-status">
       <span class="status {% if bar.is_open_now %}status-open{% else %}status-closed{% endif %}">{% if bar.is_open_now %}{{ _('bar_detail.status.open', default='Open now') }}{% else %}{{ _('bar_detail.status.closed', default='Closed now') }}{% endif %}</span>
@@ -89,5 +116,27 @@
 {% endblock %}
 
 {% block scripts %}
-<script>window.orderingPaused = {{ 'true' if bar.ordering_paused else 'false' }};</script>
+<script>
+  window.orderingPaused = {{ 'true' if bar.ordering_paused else 'false' }};
+</script>
+<script>
+  (function() {
+    var directionsLink = document.querySelector('.bar-directions');
+    if (!directionsLink) {
+      return;
+    }
+
+    var appleUrl = directionsLink.getAttribute('data-apple-url');
+    var googleUrl = directionsLink.getAttribute('data-google-url');
+    var userAgent = window.navigator.userAgent || '';
+    var platform = window.navigator.platform || '';
+    var isAppleDevice = /iPad|iPhone|iPod/.test(userAgent) || (platform === 'MacIntel' && typeof window.navigator.standalone !== 'undefined');
+
+    if (isAppleDevice && appleUrl) {
+      directionsLink.setAttribute('href', appleUrl);
+    } else if (googleUrl) {
+      directionsLink.setAttribute('href', googleUrl);
+    }
+  })();
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a directions pill beside the bar title that opens Google Maps or Apple Maps for navigation
- compute destination links from coordinates or address details and localize the call-to-action in all languages
- style the title row so the button aligns cleanly with the existing header content

## Testing
- pytest tests/test_translations.py

------
https://chatgpt.com/codex/tasks/task_e_68d1108284d483208b0c0a11edc6fc11