### PR TITLE
Add Wallee customer metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,7 @@
     - Webhook `/webhooks/wallee` updates `wallet_topups` by `wallee_tx_id` with a row-level lock; processed records are skipped so repeated calls stay idempotent.
     - `wallet_topups` columns include `id`, `user_id`, `amount_decimal`, `currency`, `wallee_tx_id` (unique BIGINT), `status`, `processed_at`, `created_at`, and `updated_at`.
     - Save `int(tx.id)` to `wallet_topups.wallee_tx_id` and query by this field in the webhook.
+    - Transaction payloads send the user's username via `billing_address`, `customer_id`, and `meta_data['username']` so Wallee's dashboard shows who initiated each payment.
     - Startup ensures these fields via `ensure_wallet_topup_columns()` which renames any legacy `wallee_transaction_id` column and sets the `status` default to `PENDING`.
     - The `payments` table tracks order payments only and no longer defines a `user_id` column.
     - Wallee API clients live in `app/wallee_client.py`; reuse the module's `tx_service`, `pp_service`, and `whenc_srv` instead of creating new clients.

--- a/tests/test_checkout_failed_redirect.py
+++ b/tests/test_checkout_failed_redirect.py
@@ -65,3 +65,9 @@ def test_checkout_failed_redirects_to_cart():
         assert parsed.path == '/cart'
         qs = parse_qs(parsed.query)
         assert qs.get('notice') == ['payment_failed']
+        assert tx_create.customer_id == str(user.id)
+        assert tx_create.customer_email_address == user.email
+        assert tx_create.billing_address.given_name == user.username
+        assert tx_create.billing_address.family_name == user.username
+        assert tx_create.billing_address.email_address == user.email
+        assert tx_create.meta_data == {"username": user.username}

--- a/tests/test_checkout_line_item_amount.py
+++ b/tests/test_checkout_line_item_amount.py
@@ -58,5 +58,12 @@ def test_checkout_uses_amount_including_tax():
             )
             create_kwargs = MockTx.create.call_args.kwargs
         assert resp.status_code == 303
-        line_item = create_kwargs['transaction'].line_items[0]
+        tx_create = create_kwargs['transaction']
+        line_item = tx_create.line_items[0]
         assert line_item.amount_including_tax == 5.2
+        assert tx_create.customer_id == str(user.id)
+        assert tx_create.customer_email_address == user.email
+        assert tx_create.billing_address.given_name == user.username
+        assert tx_create.billing_address.family_name == user.username
+        assert tx_create.billing_address.email_address == user.email
+        assert tx_create.meta_data == {"username": user.username}

--- a/tests/test_topup_init.py
+++ b/tests/test_topup_init.py
@@ -77,6 +77,12 @@ def test_topup_init_creates_record():
     tx_create = create_kwargs["transaction"]
     assert tx_create.success_url == expected_success
     assert tx_create.failed_url == expected_failed
+    assert tx_create.customer_id == str(user.id)
+    assert tx_create.customer_email_address == user.email
+    assert tx_create.billing_address.given_name == user.username
+    assert tx_create.billing_address.family_name == user.username
+    assert tx_create.billing_address.email_address == user.email
+    assert tx_create.meta_data == {"username": user.username}
     updated = db.query(User).filter(User.id == user.id).first()
     assert float(updated.credit or 0) == 0.0
     db.close()


### PR DESCRIPTION
## Summary
- include the customer's username and email on Wallee transaction payloads for card checkouts and wallet top-ups so the dashboard displays who initiated each payment
- document the new Wallee payload behaviour in the agent notes
- extend the checkout and top-up tests to assert the new customer metadata

## Testing
- pytest tests/test_topup_init.py tests/test_checkout_line_item_amount.py tests/test_checkout_failed_redirect.py

------
https://chatgpt.com/codex/tasks/task_e_68d115b3019083209f5ea28c4b6c6b07