### PR TITLE
Avoid duplicate Wallee names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,7 @@
     - `wallet_topups` columns include `id`, `user_id`, `amount_decimal`, `currency`, `wallee_tx_id` (unique BIGINT), `status`, `processed_at`, `created_at`, and `updated_at`.
     - Save `int(tx.id)` to `wallet_topups.wallee_tx_id` and query by this field in the webhook.
     - Transaction payloads send the user's username via `billing_address`, `customer_id`, and `meta_data['username']` so Wallee's dashboard shows who initiated each payment.
+      - Leave `billing_address.family_name` unset so Wallee only displays the username once in its customer name field.
     - Startup ensures these fields via `ensure_wallet_topup_columns()` which renames any legacy `wallee_transaction_id` column and sets the `status` default to `PENDING`.
     - The `payments` table tracks order payments only and no longer defines a `user_id` column.
     - Wallee API clients live in `app/wallee_client.py`; reuse the module's `tx_service`, `pp_service`, and `whenc_srv` instead of creating new clients.

--- a/main.py
+++ b/main.py
@@ -3113,7 +3113,7 @@ async def checkout(
             customer_label = user.username or user.email or f"user-{user.id}"
             billing_address = AddressCreate(
                 given_name=customer_label,
-                family_name=customer_label,
+                family_name=None,
                 email_address=user.email,
             )
             tx_create = TransactionCreate(
@@ -3577,7 +3577,7 @@ async def init_topup(
     customer_label = user.username or user.email or f"user-{user.id}"
     billing_address = AddressCreate(
         given_name=customer_label,
-        family_name=customer_label,
+        family_name=None,
         email_address=user.email,
     )
     line = LineItemCreate(

--- a/tests/test_checkout_failed_redirect.py
+++ b/tests/test_checkout_failed_redirect.py
@@ -68,6 +68,6 @@ def test_checkout_failed_redirects_to_cart():
         assert tx_create.customer_id == str(user.id)
         assert tx_create.customer_email_address == user.email
         assert tx_create.billing_address.given_name == user.username
-        assert tx_create.billing_address.family_name == user.username
+        assert tx_create.billing_address.family_name is None
         assert tx_create.billing_address.email_address == user.email
         assert tx_create.meta_data == {"username": user.username}

--- a/tests/test_checkout_line_item_amount.py
+++ b/tests/test_checkout_line_item_amount.py
@@ -64,6 +64,6 @@ def test_checkout_uses_amount_including_tax():
         assert tx_create.customer_id == str(user.id)
         assert tx_create.customer_email_address == user.email
         assert tx_create.billing_address.given_name == user.username
-        assert tx_create.billing_address.family_name == user.username
+        assert tx_create.billing_address.family_name is None
         assert tx_create.billing_address.email_address == user.email
         assert tx_create.meta_data == {"username": user.username}

--- a/tests/test_topup_init.py
+++ b/tests/test_topup_init.py
@@ -80,7 +80,7 @@ def test_topup_init_creates_record():
     assert tx_create.customer_id == str(user.id)
     assert tx_create.customer_email_address == user.email
     assert tx_create.billing_address.given_name == user.username
-    assert tx_create.billing_address.family_name == user.username
+    assert tx_create.billing_address.family_name is None
     assert tx_create.billing_address.email_address == user.email
     assert tx_create.meta_data == {"username": user.username}
     updated = db.query(User).filter(User.id == user.id).first()


### PR DESCRIPTION
## Summary
- stop populating the Wallee billing family name so customer labels only appear once
- document the naming constraint in AGENTS.md
- update tests to expect the new billing address payload

## Testing
- pytest tests/test_checkout_failed_redirect.py tests/test_checkout_line_item_amount.py tests/test_topup_init.py

------
https://chatgpt.com/codex/tasks/task_e_68d11a05e3a08320aac5c4502b191134