### PR TITLE
Log profile edits in admin view

### DIFF
--- a/app/i18n/translations/de.json
+++ b/app/i18n/translations/de.json
@@ -1352,6 +1352,24 @@
       "credit": "Einnahmen",
       "bars": "Bars:"
     },
+    "updates": {
+      "title": "Profilaktualisierungen",
+      "subtitle": "Detaillierte Historie der Profiländerungen.",
+      "table": {
+        "headers": {
+          "field": "Feld",
+          "previous": "Bisheriger Wert",
+          "current": "Neuer Wert",
+          "date": "Datum"
+        }
+      },
+      "fields": {
+        "username": "Benutzername",
+        "email": "E-Mail",
+        "phone": "Telefon"
+      },
+      "empty": "Keine Profilaktualisierungen vorhanden."
+    },
     "orders": {
       "title": "Bestellungen",
       "subtitle": "Zuletzt zuerst. Scrollen, um ältere Bestellungen anzuzeigen.",

--- a/app/i18n/translations/en.json
+++ b/app/i18n/translations/en.json
@@ -1352,6 +1352,24 @@
       "credit": "Credit:",
       "bars": "Bars:"
     },
+    "updates": {
+      "title": "Profile updates",
+      "subtitle": "Detailed history of profile edits.",
+      "table": {
+        "headers": {
+          "field": "Field",
+          "previous": "Previous value",
+          "current": "New value",
+          "date": "Date"
+        }
+      },
+      "fields": {
+        "username": "Username",
+        "email": "Email",
+        "phone": "Phone"
+      },
+      "empty": "No profile updates recorded."
+    },
     "orders": {
       "title": "Orders",
       "subtitle": "Most recent first. Scroll to view older orders.",

--- a/app/i18n/translations/fr.json
+++ b/app/i18n/translations/fr.json
@@ -1379,6 +1379,24 @@
       "credit": "Crédit:",
       "bars": "Bars:"
     },
+    "updates": {
+      "title": "Mises à jour du profil",
+      "subtitle": "Historique détaillé des modifications du profil.",
+      "table": {
+        "headers": {
+          "field": "Champ",
+          "previous": "Valeur précédente",
+          "current": "Nouvelle valeur",
+          "date": "Date"
+        }
+      },
+      "fields": {
+        "username": "Nom d'utilisateur",
+        "email": "E-mail",
+        "phone": "Téléphone"
+      },
+      "empty": "Aucune mise à jour du profil enregistrée."
+    },
     "orders": {
       "title": "Ordres",
       "subtitle": "Le plus récent en premier. Faites défiler pour afficher les commandes plus anciennes.",

--- a/app/i18n/translations/it.json
+++ b/app/i18n/translations/it.json
@@ -1352,6 +1352,24 @@
       "credit": "Credito:",
       "bars": "Locali:"
     },
+    "updates": {
+      "title": "Aggiornamenti profilo",
+      "subtitle": "Cronologia dettagliata delle modifiche al profilo.",
+      "table": {
+        "headers": {
+          "field": "Campo",
+          "previous": "Valore precedente",
+          "current": "Nuovo valore",
+          "date": "Data"
+        }
+      },
+      "fields": {
+        "username": "Nome utente",
+        "email": "Email",
+        "phone": "Telefono"
+      },
+      "empty": "Nessun aggiornamento profilo registrato."
+    },
     "orders": {
       "title": "Ordini",
       "subtitle": "Dal più recente. Scorri per visualizzare gli ordini più vecchi.",

--- a/templates/admin_view_user.html
+++ b/templates/admin_view_user.html
@@ -20,6 +20,34 @@
     </ul>
   </div>
 
+  <h2>{{ _('admin_view_user.updates.title', default='Profile updates') }}</h2>
+  <p class="subtitle">{{ _('admin_view_user.updates.subtitle', default='Detailed history of profile edits.') }}</p>
+  <div class="table-card" style="max-height:300px; overflow-y:auto;">
+    <table class="users-table">
+      <thead>
+        <tr>
+          <th>{{ _('admin_view_user.updates.table.headers.field', default='Field') }}</th>
+          <th>{{ _('admin_view_user.updates.table.headers.previous', default='Previous value') }}</th>
+          <th>{{ _('admin_view_user.updates.table.headers.current', default='New value') }}</th>
+          <th>{{ _('admin_view_user.updates.table.headers.date', default='Date') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for change in profile_updates %}
+        <tr>
+          <td>{{ _('admin_view_user.updates.fields.' ~ change.field, default=change.field|title) }}</td>
+          <td>{{ change.previous or '-' }}</td>
+          <td>{{ change.current or '-' }}</td>
+          <td>{{ change.created_at|format_time }}</td>
+        </tr>
+        {% endfor %}
+        {% if profile_updates|length == 0 %}
+        <tr><td colspan="4">{{ _('admin_view_user.updates.empty', default='No profile updates recorded.') }}</td></tr>
+        {% endif %}
+      </tbody>
+    </table>
+  </div>
+
   <h2>{{ _('admin_view_user.orders.title', default='Orders') }}</h2>
   <p class="subtitle">{{ _('admin_view_user.orders.subtitle', default='Most recent first. Scroll to view older orders.') }}</p>
   <div class="table-card" style="max-height:300px; overflow-y:auto;">


### PR DESCRIPTION
## Summary
- log profile updates with before/after details in the audit log
- show profile update history on the admin user view with localized copy
- extend automated tests to cover profile update logging and display

## Testing
- pytest tests/test_profile_update.py tests/test_admin_view_user.py tests/test_translations.py

------
https://chatgpt.com/codex/tasks/task_e_68d11d21ebf88320b77c84872e2dbe67