### PR TITLE
Restrict auth page access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,8 @@
 - Username input on `/register/details` forces lowercase on every keystroke so pasted or typed uppercase characters are normalised before submission. See the inline script at the bottom of `templates/register.html`.
 - Registering users hitting any other route are redirected back to `/register/details` by middleware until step two finishes.
 - Super admins can create users directly from the Admin Users page by entering only an email and password; this bypasses the normal registration flow and checks.
+- Authenticated users are redirected away from `/login` and `/register`; use `redirect_for_authenticated_user` in `main.py` when adding new entry points.
+- Blocked and IP-blocked users cannot log out; BlockRedirectMiddleware denies `/logout` and the layout hides the link for these roles.
 - Startup ensures the `roleenum` type contains `REGISTERING` via `ensure_role_enum()`.
 - Display role users see only a two-column live orders screen (preparing/ready) at `/dashboard/bar/{id}/orders` with order codes only and no footer or cart links.
 - Display role header removes navigation links and menu toggles; the logo is not clickable and only a Logout link remains.

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -93,7 +93,6 @@
       {% if user %}
       {% if user.is_blocked or user.is_ip_blocked %}
       <a href="/notifications" role="menuitem"><i class="bi bi-bell" aria-hidden="true"></i><span>{{ _('common.notifications', default='Notifications') }}</span>{% if unread_notifications %}<span class="notif-badge" aria-live="polite">{{ unread_notifications }}</span>{% endif %}</a>
-      <a href="/logout" role="menuitem"><i class="bi bi-box-arrow-right" aria-hidden="true"></i><span>{{ _('common.logout', default='Logout') }}</span></a>
       {% else %}
       {% if not user.is_ip_blocked %}
       <a href="/wallet" role="menuitem"><i class="bi bi-wallet2" aria-hidden="true"></i><span>{{ _('common.wallet', default='Wallet') }}</span></a>


### PR DESCRIPTION
## Summary
- add a shared redirect helper so authenticated users cannot revisit the login or initial register step
- block blocked/ip-blocked users from logging out and hide the navigation link, documenting the behaviour in AGENTS.md

## Testing
- pytest tests/test_register_redirect.py tests/test_blocked_role_access.py tests/test_ip_block.py

------
https://chatgpt.com/codex/tasks/task_e_68d1430b7bf08320bf6eabf338a32aad