### PR TITLE
Expand notification cards to viewport width

### DIFF
--- a/static/css/components.css
+++ b/static/css/components.css
@@ -446,6 +446,10 @@ body{background:var(--bg);color:var(--text);font-family:var(--font-sans);transit
 .notification-body{white-space:pre-line;overflow-wrap:anywhere;word-break:break-word;}
 
 .notifications-list{list-style:none;margin:0;padding:0;}
+.notifications-page .table-card{background:transparent;box-shadow:none;border-radius:0;overflow:visible;margin-top:var(--space-2);}
+.notifications-page .notifications-list{display:flex;flex-direction:column;gap:var(--space-2);}
+.notifications-page .notifications-list li{margin:0;}
+.notifications-page .notification-card{width:100vw;margin-inline:calc(50% - 50vw);border-radius:0;border-left:0;border-right:0;}
 
 /* utilities */
 .alert{padding:var(--space-2);border-radius:var(--radius);margin-bottom:var(--space-3);}

--- a/templates/notifications.html
+++ b/templates/notifications.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% block content %}
-<section class="users-page">
+<section class="users-page notifications-page">
   <header class="users-toolbar">
     <div class="title-wrap">
       <h1>{{ _('notifications.title', default='Notifications') }}</h1>


### PR DESCRIPTION
## Summary
- widen the notifications page section so message cards can stretch across the viewport
- adjust notification card styling to remove the enclosing table card chrome and keep spacing between entries

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68d14c3de3608320b40f0a47c25384e2