### PR TITLE
Extract inline assets from templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,10 +33,13 @@
 - Browse Bars button is centered in the hero section.
 - Horizontal scrolling is locked with `overflow-x: clip` on `html, body`, and header width uses `100%` to avoid viewport overflow.
 - Body uses a column flex layout with `min-height: 100dvh` and grows `<main>` so the footer always anchors to the bottom even on sparse pages.
+- Display orders page uses `/static/css/pages/display-orders.css` for layout adjustments and `/static/js/display-page.js` to bootstrap `initDisplay` via the `data-bar-id` attribute.
+- Admin payments search logic now lives in `/static/js/admin-payments.js`; templates only render markup.
+- Registration username lowercase enforcement is handled by `/static/js/register.js` loaded with `defer`.
 - Registration is a two-step flow. `/register` collects email and password and assigns a temporary `REGISTERING` role. Users are redirected to `/register/details` to supply username, phone prefix, and number, and cannot access other pages until this step completes.
   - Once step two succeeds and the role becomes `CUSTOMER`, the user stays signed in and is redirected to the homepage (`/`).
   - Each registration step displays a disclaimer stating that creating an account accepts the Terms of Service, with the link pointing to `/terms`.
-- Username input on `/register/details` forces lowercase on every keystroke so pasted or typed uppercase characters are normalised before submission. See the inline script at the bottom of `templates/register.html`.
+- Username input on `/register/details` forces lowercase on every keystroke so pasted or typed uppercase characters are normalised before submission. The behaviour is managed by `/static/js/register.js`.
 - Registering users hitting any other route are redirected back to `/register/details` by middleware until step two finishes.
 - Super admins can create users directly from the Admin Users page by entering only an email and password; this bypasses the normal registration flow and checks.
 - Authenticated users are redirected away from `/login` and `/register`; use `redirect_for_authenticated_user` in `main.py` when adding new entry points.

--- a/static/css/pages/display-orders.css
+++ b/static/css/pages/display-orders.css
@@ -1,0 +1,41 @@
+#main {
+  max-width: none;
+  margin: 0 10px;
+  padding: 0;
+}
+
+.display-page {
+  display: flex;
+  gap: 20px;
+  margin-top: 10px;
+}
+
+.display-column {
+  flex: 1;
+}
+
+.display-orders {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.display-orders .order-card {
+  width: 100%;
+  max-width: none;
+  min-width: 100px;
+  text-align: left;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.display-orders .order-card__header {
+  justify-content: flex-start;
+  align-items: center;
+  width: 100%;
+}
+
+.display-orders .order-card h3 {
+  font-size: 2em;
+}

--- a/static/js/admin-payments.js
+++ b/static/js/admin-payments.js
@@ -1,0 +1,67 @@
+(function () {
+  function normalize(value) {
+    return (value || '')
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .trim();
+  }
+
+  function debounce(fn, delay) {
+    let timeoutId;
+    return (...args) => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      timeoutId = setTimeout(() => fn.apply(null, args), delay);
+    };
+  }
+
+  function initPaymentsFilter() {
+    const input = document.getElementById('paymentsSearch');
+    const tableBody = document.querySelector('.payments-table tbody');
+    if (!input || !tableBody) {
+      return;
+    }
+
+    const rows = Array.from(tableBody.rows);
+
+    function applyFilter() {
+      const query = normalize(input.value);
+      rows.forEach((row) => {
+        const numberCell = row.cells && row.cells[0] ? row.cells[0].textContent : '';
+        const nameCell = row.cells && row.cells[1] ? row.cells[1].textContent : '';
+        const matches =
+          !query ||
+          normalize(nameCell).includes(query) ||
+          normalize(numberCell).includes(query);
+        row.style.display = matches ? '' : 'none';
+      });
+    }
+
+    const runFilter = debounce(applyFilter, 120);
+    input.addEventListener('input', runFilter);
+
+    const clearButton = document.querySelector('.payments-search .clear');
+    if (clearButton) {
+      clearButton.addEventListener('click', () => {
+        input.value = '';
+        applyFilter();
+        input.focus();
+      });
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    const existingQuery = params.get('q');
+    if (existingQuery) {
+      input.value = existingQuery;
+      applyFilter();
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initPaymentsFilter);
+  } else {
+    initPaymentsFilter();
+  }
+})();

--- a/static/js/display-page.js
+++ b/static/js/display-page.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const displaySection = document.querySelector('.display-page');
+  if (!displaySection) {
+    return;
+  }
+
+  const barId = Number.parseInt(displaySection.dataset.barId, 10);
+  if (!Number.isFinite(barId)) {
+    return;
+  }
+
+  if (typeof initDisplay === 'function') {
+    initDisplay(barId);
+  }
+});

--- a/static/js/register.js
+++ b/static/js/register.js
@@ -1,0 +1,33 @@
+(function () {
+  function forceLowercase(event) {
+    const currentValue = event.target.value;
+    const lowerValue = currentValue.toLowerCase();
+
+    if (currentValue === lowerValue) {
+      return;
+    }
+
+    const { selectionStart, selectionEnd } = event.target;
+    event.target.value = lowerValue;
+
+    if (selectionStart !== null && selectionEnd !== null) {
+      event.target.setSelectionRange(selectionStart, selectionEnd);
+    }
+  }
+
+  function init() {
+    const usernameInput = document.getElementById('username');
+    if (!usernameInput) {
+      return;
+    }
+
+    usernameInput.addEventListener('input', forceLowercase);
+    usernameInput.addEventListener('blur', forceLowercase);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/templates/admin_payments.html
+++ b/templates/admin_payments.html
@@ -49,44 +49,14 @@
             <form id="delete_test_{{ bar.id }}" method="post" action="/admin/payments/{{ bar.id }}/test_closing/delete" style="display:none"></form>
           </td>
         </tr>
-        {% endfor %}
+{% endfor %}
       </tbody>
     </table>
   </div>
 </section>
+{% endblock %}
 
-<script>
-(function(){
-  const input = document.getElementById('paymentsSearch');
-  const tbody = document.querySelector('.payments-table tbody');
-  if(!input || !tbody) return;
-
-  const rows = Array.from(tbody.rows);
-  const norm = s => (s||'').toLowerCase()
-    .normalize('NFD').replace(/[\u0300-\u036f]/g,'').trim();
-
-  function applyFilter(){
-    const q = norm(input.value);
-    rows.forEach(tr => {
-      const numberCell = tr.cells && tr.cells[0] ? tr.cells[0].textContent : '';
-      const nameCell = tr.cells && tr.cells[1] ? tr.cells[1].textContent : '';
-      const match =
-        !q ||
-        norm(nameCell).includes(q) ||
-        norm(numberCell).includes(q);
-      tr.style.display = match ? '' : 'none';
-    });
-  }
-  function debounce(fn,ms){let t;return (...a)=>{clearTimeout(t);t=setTimeout(()=>fn.apply(this,a),ms)}}
-  const run = debounce(applyFilter,120);
-  input.addEventListener('input', run);
-  document.querySelector('.payments-search .clear')?.addEventListener('click',()=>{
-    input.value=''; applyFilter(); input.focus();
-  });
-
-  const qs = new URLSearchParams(location.search);
-  const q = qs.get('q');
-  if(q){ input.value = q; applyFilter(); }
-})();
-</script>
+{% block scripts %}
+{{ super() }}
+<script src="/static/js/admin-payments.js" defer></script>
 {% endblock %}

--- a/templates/display_orders.html
+++ b/templates/display_orders.html
@@ -1,6 +1,9 @@
 {% extends "layout.html" %}
+{% block page_styles %}
+<link rel="stylesheet" href="/static/css/pages/display-orders.css">
+{% endblock %}
 {% block content %}
-<section class="display-page">
+<section class="display-page" data-bar-id="{{ bar.id }}">
   <div class="display-column">
     <div class="section-head"><h2>{{ _('display_orders.sections.preparing', default='Preparing') }}</h2></div>
     <div id="preparing-orders" class="display-orders"></div>
@@ -10,21 +13,9 @@
     <div id="ready-orders" class="display-orders"></div>
   </div>
 </section>
+{% endblock %}
 
-<style>
-#main{max-width:none;margin:0 10px;padding:0;}
-.display-page{display:flex;gap:20px;margin-top:10px;}
-.display-column{flex:1;}
-.display-orders{display:flex;flex-direction:column;gap:12px;}
-.display-orders .order-card{width:100%;max-width:none;min-width:100px;text-align:left;display:flex;align-items:center;justify-content:flex-start;}
-.display-orders .order-card__header{justify-content:flex-start;align-items:center;width:100%;}
-.display-orders .order-card h3{font-size:2em;}
-</style>
-
+{% block scripts %}
 <script src="/static/js/display.js" defer></script>
-<script>
-  document.addEventListener('DOMContentLoaded', () => {
-    initDisplay({{ bar.id }});
-  });
-</script>
+<script src="/static/js/display-page.js" defer></script>
 {% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -26,31 +26,5 @@
 
 {% block scripts %}
   {{ super() }}
-  <script>
-    (function () {
-      const usernameInput = document.getElementById('username');
-      if (!usernameInput) {
-        return;
-      }
-
-      const forceLowercase = (event) => {
-        const currentValue = event.target.value;
-        const lowerValue = currentValue.toLowerCase();
-
-        if (currentValue === lowerValue) {
-          return;
-        }
-
-        const { selectionStart, selectionEnd } = event.target;
-        event.target.value = lowerValue;
-
-        if (selectionStart !== null && selectionEnd !== null) {
-          event.target.setSelectionRange(selectionStart, selectionEnd);
-        }
-      };
-
-      usernameInput.addEventListener('input', forceLowercase);
-      usernameInput.addEventListener('blur', forceLowercase);
-    })();
-  </script>
+  <script src="/static/js/register.js" defer></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- move display orders page styling into a dedicated stylesheet and initialise the view via data attributes
- extract the admin payments search/filter logic into a standalone JavaScript module
- load the register username lowercase handler from a new deferred script and document the asset locations in AGENTS.md

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da4980ea1c8320a9a3e51e3acacc62