### PR TITLE
Extract inline assets from order dashboards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,9 @@
 - Horizontal scrolling is locked with `overflow-x: clip` on `html, body`, and header width uses `100%` to avoid viewport overflow.
 - Body uses a column flex layout with `min-height: 100dvh` and grows `<main>` so the footer always anchors to the bottom even on sparse pages.
 - Display orders page uses `/static/css/pages/display-orders.css` for layout adjustments and `/static/js/display-page.js` to bootstrap `initDisplay` via the `data-bar-id` attribute.
+- Bartender and bar admin order dashboards share `/static/css/pages/bar-orders.css` for layout and `/static/js/bar-orders.js` to bootstrap `initBartender` (reading the `data-bar-id` attribute) and handle pause toggles.
 - Admin payments search logic now lives in `/static/js/admin-payments.js`; templates only render markup.
+- Admin users search filtering now runs through `/static/js/admin-users.js` loaded with `defer`.
 - Registration username lowercase enforcement is handled by `/static/js/register.js` loaded with `defer`.
 - Registration is a two-step flow. `/register` collects email and password and assigns a temporary `REGISTERING` role. Users are redirected to `/register/details` to supply username, phone prefix, and number, and cannot access other pages until this step completes.
   - Once step two succeeds and the role becomes `CUSTOMER`, the user stays signed in and is redirected to the homepage (`/`).

--- a/static/css/pages/bar-orders.css
+++ b/static/css/pages/bar-orders.css
@@ -1,0 +1,53 @@
+.orders-page{
+  --surface:#fff;
+  --bg-subtle:#f6f8fb;
+  --border:#e5e7eb;
+  --text:#0f172a;
+  --muted:#475569;
+  --accent:var(--brand,#7c3aed);
+  --radius:16px;
+  --shadow:0 6px 16px rgba(0,0,0,.06);
+}
+.orders-page .orders-head{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:10px;
+  margin:8px 0 14px;
+}
+.orders-page .orders-title{
+  margin:0;
+  font-size:1.6rem;
+  font-weight:800;
+  color:var(--text);
+}
+.orders-page .orders-section{ margin-top:18px; }
+.orders-page .section-head{
+  display:flex;
+  align-items:center;
+  gap:10px;
+  margin-bottom:10px;
+}
+.orders-page .section-head h2{
+  margin:0;
+  font-size:1.125rem;
+  font-weight:800;
+  color:var(--text);
+}
+.orders-page .orders-grid{
+  display:grid;
+  gap:12px;
+  grid-template-columns:minmax(100px,1fr);
+  margin:0;
+}
+.orders-page .orders-grid .card{
+  width:100%;
+  max-width:none;
+  min-width:100px;
+}
+@media (min-width:960px){
+  .orders-page .orders-grid{ grid-template-columns:repeat(3,minmax(100px,1fr)); }
+}
+@media (max-width:768px){
+  .orders-page .orders-title{ font-size:1.4rem; }
+}

--- a/static/js/admin-users.js
+++ b/static/js/admin-users.js
@@ -1,0 +1,60 @@
+(function(){
+  function normalize(value){
+    return (value || '')
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .trim();
+  }
+
+  function init(){
+    const input = document.getElementById('userSearch');
+    const tbody = document.querySelector('.users-table tbody');
+    if(!input || !tbody) return;
+
+    const rows = Array.from(tbody.rows);
+
+    function applyFilter(){
+      const query = normalize(input.value);
+      rows.forEach(row => {
+        const name = row.cells && row.cells[0] ? row.cells[0].textContent : '';
+        const email = row.cells && row.cells[1] ? row.cells[1].textContent : '';
+        const match = !query || normalize(name).includes(query) || normalize(email).includes(query);
+        row.style.display = match ? '' : 'none';
+      });
+    }
+
+    function debounce(fn, delay){
+      let timer;
+      return function debounced(...args){
+        clearTimeout(timer);
+        timer = setTimeout(() => fn.apply(this, args), delay);
+      };
+    }
+
+    const run = debounce(applyFilter, 120);
+    input.addEventListener('input', run);
+
+    const clearButton = document.querySelector('.users-search .clear');
+    if(clearButton){
+      clearButton.addEventListener('click', () => {
+        input.value = '';
+        applyFilter();
+        input.focus();
+      });
+    }
+
+    const qs = new URLSearchParams(window.location.search);
+    const preset = qs.get('q');
+    if(preset){
+      input.value = preset;
+      applyFilter();
+    }
+  }
+
+  if(document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/static/js/bar-orders.js
+++ b/static/js/bar-orders.js
@@ -1,0 +1,28 @@
+(function(){
+  function init(){
+    const root = document.querySelector('.orders-page[data-bar-id]');
+    if(!root) return;
+    const barId = Number.parseInt(root.dataset.barId, 10);
+    if(Number.isNaN(barId) || typeof window.initBartender !== 'function') return;
+
+    window.initBartender(barId);
+
+    const pauseToggle = document.getElementById('pause-ordering');
+    const pauseUrl = root.dataset.pauseUrl;
+    if(pauseToggle && pauseUrl){
+      pauseToggle.addEventListener('change', () => {
+        fetch(pauseUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ paused: pauseToggle.checked })
+        }).catch(() => {});
+      });
+    }
+  }
+
+  if(document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -67,34 +67,9 @@
     </table>
   </div>
 </section>
-
-<script>
-(function(){
-  const input = document.getElementById('userSearch');
-  const tbody = document.querySelector('.users-table tbody');
-  if(input && tbody){
-    const rows = Array.from(tbody.rows);
-    const norm = s => (s||'').toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g,'').trim();
-    function applyFilter(){
-      const q = norm(input.value);
-      rows.forEach(tr=>{
-        const name = tr.cells && tr.cells[0] ? tr.cells[0].textContent : '';
-        const email = tr.cells && tr.cells[1] ? tr.cells[1].textContent : '';
-        const match = !q || norm(name).includes(q) || norm(email).includes(q);
-        tr.style.display = match ? '' : 'none';
-      });
-    }
-    function debounce(fn,ms){let t;return (...a)=>{clearTimeout(t);t=setTimeout(()=>fn.apply(this,a),ms)}}
-    const run = debounce(applyFilter,120);
-    input.addEventListener('input', run);
-    document.querySelector('.users-search .clear')?.addEventListener('click',()=>{
-      input.value=''; applyFilter(); input.focus();
-    });
-    const qs = new URLSearchParams(location.search);
-    const q = qs.get('q');
-    if(q){ input.value = q; applyFilter(); }
-  }
-})();
-</script>
 {% endblock %}
 
+{% block scripts %}
+{{ super() }}
+<script src="/static/js/admin-users.js" defer></script>
+{% endblock %}

--- a/templates/bar_admin_orders.html
+++ b/templates/bar_admin_orders.html
@@ -1,6 +1,10 @@
 {% extends "layout.html" %}
+{% block page_styles %}
+{{ super() }}
+<link rel="stylesheet" href="/static/css/pages/bar-orders.css">
+{% endblock %}
 {% block content %}
-<section class="orders-page">
+<section class="orders-page" data-bar-id="{{ bar.id }}">
   <header class="orders-head">
     <a class="back-link" href="/dashboard">
       <i class="bi bi-chevron-left" aria-hidden="true"></i>
@@ -32,40 +36,10 @@
     <div id="completed-orders" class="orders-grid order-list"></div>
   </section>
 </section>
+{% endblock %}
 
-<style>
-.orders-page{
-  --surface:#fff; --bg-subtle:#f6f8fb; --border:#e5e7eb;
-  --text:#0f172a; --muted:#475569; --accent:var(--brand,#7c3aed);
-  --radius:16px; --shadow:0 6px 16px rgba(0,0,0,.06);
-}
-.orders-page .orders-head{
-  display:flex; align-items:center; justify-content:space-between;
-  gap:10px; margin:8px 0 14px;
-}
-.orders-page .orders-title{ margin:0; font-size:1.6rem; font-weight:800; color:var(--text); }
-.orders-page .orders-section{ margin-top:18px; }
-.orders-page .section-head{ display:flex; align-items:center; gap:10px; margin-bottom:10px; }
-.orders-page .section-head h2{ margin:0; font-size:1.125rem; font-weight:800; color:var(--text); }
-.orders-page .orders-grid{
-  display:grid; gap:12px;
-  grid-template-columns:minmax(100px,1fr);
-  margin:0;
-}
-.orders-page .orders-grid .card{ width:100%; max-width:none; min-width:100px; }
-@media (min-width:960px){
-  .orders-page .orders-grid{ grid-template-columns:repeat(3,minmax(100px,1fr)); }
-}
-@media (max-width:768px){
-  .orders-page .orders-title{ font-size:1.4rem; }
-}
-</style>
-
+{% block scripts %}
+{{ super() }}
 <script src="/static/js/orders.js" defer></script>
-<script>
-  document.addEventListener('DOMContentLoaded', () => {
-    // start bartender WebSocket listener for live orders
-    initBartender({{ bar.id }});
-  });
-</script>
+<script src="/static/js/bar-orders.js" defer></script>
 {% endblock %}

--- a/templates/bartender_orders.html
+++ b/templates/bartender_orders.html
@@ -1,6 +1,10 @@
 {% extends "layout.html" %}
+{% block page_styles %}
+{{ super() }}
+<link rel="stylesheet" href="/static/css/pages/bar-orders.css">
+{% endblock %}
 {% block content %}
-<section class="orders-page">
+<section class="orders-page" data-bar-id="{{ bar.id }}" data-pause-url="/dashboard/bar/{{ bar.id }}/toggle_pause">
   <header class="orders-head">
     <a class="back-link" href="/dashboard">
       <i class="bi bi-chevron-left" aria-hidden="true"></i>
@@ -32,50 +36,10 @@
     <div id="completed-orders" class="orders-grid order-list"></div>
   </section>
 </section>
+{% endblock %}
 
-<style>
-.orders-page{
-  --surface:#fff; --bg-subtle:#f6f8fb; --border:#e5e7eb;
-  --text:#0f172a; --muted:#475569; --accent:var(--brand,#7c3aed);
-  --radius:16px; --shadow:0 6px 16px rgba(0,0,0,.06);
-}
-.orders-page .orders-head{
-  display:flex; align-items:center; justify-content:space-between;
-  gap:10px; margin:8px 0 14px;
-}
-.orders-page .orders-title{ margin:0; font-size:1.6rem; font-weight:800; color:var(--text); }
-.orders-page .orders-section{ margin-top:18px; }
-.orders-page .section-head{ display:flex; align-items:center; gap:10px; margin-bottom:10px; }
-.orders-page .section-head h2{ margin:0; font-size:1.125rem; font-weight:800; color:var(--text); }
-.orders-page .orders-grid{
-  display:grid; gap:12px;
-  grid-template-columns:minmax(100px,1fr);
-  margin:0;
-}
-.orders-page .orders-grid .card{ width:100%; max-width:none; min-width:100px; }
-@media (min-width:960px){
-  .orders-page .orders-grid{ grid-template-columns:repeat(3,minmax(100px,1fr)); }
-}
-@media (max-width:768px){
-  .orders-page .orders-title{ font-size:1.4rem; }
-}
-</style>
-
+{% block scripts %}
+{{ super() }}
 <script src="/static/js/orders.js" defer></script>
-<script>
-  document.addEventListener('DOMContentLoaded', () => {
-    // start bartender WebSocket listener for live orders
-    initBartender({{ bar.id }});
-    const toggle = document.getElementById('pause-ordering');
-    if (toggle) {
-      toggle.addEventListener('change', () => {
-        fetch(`/dashboard/bar/{{ bar.id }}/toggle_pause`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ paused: toggle.checked })
-        });
-      });
-    }
-  });
-</script>
+<script src="/static/js/bar-orders.js" defer></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- move the bar admin and bartender order dashboards to a shared stylesheet and bootstrap script
- load the admin users search filtering logic from a dedicated deferred script
- document the new asset locations in AGENTS.md for easier discovery

## Testing
- pytest *(fails: sqlalchemy.exc.InvalidRequestError: Could not refresh instance '<AuditLog ...>' across multiple existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68da4b096aac8320b6f8d35f9f0a4ed7