### PR TITLE
Separate inline assets on admin pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,11 @@
 - Dark mode functionality has been removed; the site theme is fixed to light.
 - Product image uploads surface English errors: "No file uploaded", "Uploaded file must be an image", and "File too large (>5MB)".
 - Review recent commit history before starting new tasks.
+- Admin edit pages now offload inline assets:
+  - `templates/admin_edit_bar_options.html` imports `/static/css/pages/admin-edit-bar-options.css`.
+  - `templates/bar_edit_product.html` imports `/static/css/pages/bar-edit-product.css`.
+  - `templates/admin_new_notification.html` imports `/static/css/pages/admin-new-notification.css` and `/static/js/admin-new-notification.js`.
+  - `templates/admin_edit_user.html` imports `/static/js/admin-edit-user.js`.
 - Footer marketing pages (About, Help Center, For Bars, Terms) live in `templates/about.html`, `templates/help_center.html`, `templates/for_bars.html`, and `templates/terms.html`; they share the `.static-page` styles defined in `static/css/components.css`.
   - Support contact details for these static pages pull from Jinja globals defined in `main.py` (`SUPPORT_EMAIL`, `SUPPORT_NUMBER`, `TERMS_VERSION`, etc.); update those constants to change emails, phone numbers, or term dates sitewide.
   - The About page intro copy reads "Built and operated by Siply..." followed by "We’re building a modern ordering experience..." to highlight Siply's role and hospitality focus.

--- a/static/css/pages/admin-edit-bar-options.css
+++ b/static/css/pages/admin-edit-bar-options.css
@@ -1,0 +1,81 @@
+.bar-edit-page {
+  display: block;
+}
+
+.bar-edit-header {
+  margin-block: var(--space-6, 24px);
+}
+
+.bar-edit-header .subtitle {
+  margin-top: var(--space-1, 4px);
+  opacity: 0.85;
+}
+
+.back-link {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  text-decoration: none;
+  opacity: 0.8;
+  margin-bottom: 8px;
+}
+
+.back-link:hover {
+  opacity: 1;
+}
+
+.action-grid {
+  display: grid;
+  gap: var(--space-4, 16px);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: var(--space-4, 16px);
+}
+
+@media (max-width: 767px) {
+  .action-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.action-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: var(--space-5, 20px);
+  border-radius: var(--radius-2xl, 16px);
+  background: var(--surface, #fff);
+  box-shadow: var(--shadow-sm, 0 2px 8px rgba(0, 0, 0, 0.06));
+  text-decoration: none;
+}
+
+.action-card i {
+  font-size: 22px;
+  opacity: 0.7;
+}
+
+.action-card h3 {
+  margin: 0;
+}
+
+.action-card p {
+  margin: 0;
+  line-height: 1.45;
+  opacity: 0.9;
+}
+
+.action-card .cta {
+  margin-top: auto;
+  font-weight: 600;
+  color: var(--brand-600, #5b2dee);
+}
+
+.action-card:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md, 0 6px 18px rgba(0, 0, 0, 0.08));
+}
+
+.action-card:focus-visible {
+  outline: 2px solid rgba(0, 0, 0, 0.15);
+  outline-offset: 2px;
+}

--- a/static/css/pages/admin-new-notification.css
+++ b/static/css/pages/admin-new-notification.css
@@ -1,0 +1,42 @@
+.translation-panel {
+  border: 1px dashed rgba(15, 23, 42, 0.25);
+  border-radius: 12px;
+  padding: 16px;
+  margin-bottom: var(--space-3, 12px);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.translation-panel label {
+  display: flex;
+  flex-direction: column;
+  font-weight: 500;
+  gap: 6px;
+}
+
+.translation-panel input,
+.translation-panel textarea {
+  width: 100%;
+}
+
+.translation-panel textarea {
+  min-height: 96px;
+}
+
+.translation-help {
+  margin: 0;
+  font-size: 0.9rem;
+  opacity: 0.75;
+}
+
+.translation-note {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.translation-label {
+  margin: 0;
+  font-weight: 600;
+}

--- a/static/css/pages/bar-edit-product.css
+++ b/static/css/pages/bar-edit-product.css
@@ -1,0 +1,54 @@
+.product-edit {
+  max-width: 720px;
+  margin-inline: auto;
+}
+
+.product-edit .card {
+  max-height: none;
+}
+
+.product-edit .card__body {
+  display: flex;
+}
+
+.product-edit .form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5, 24px);
+  width: 100%;
+}
+
+.product-edit .form-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2, 12px);
+}
+
+.product-edit .field-action {
+  align-self: flex-start;
+}
+
+.product-edit .locked-field .description-preview {
+  margin: 0;
+  padding: 12px 16px;
+  border-radius: var(--radius-xl, 16px);
+  background: var(--surface-strong, #f3f4f6);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.product-edit .locked-field .description-preview:empty::before {
+  content: "";
+}
+
+.product-edit .photo-preview {
+  border-radius: var(--radius-xl, 16px);
+  overflow: hidden;
+  max-width: 200px;
+}
+
+.product-edit .photo-preview img {
+  display: block;
+  width: 100%;
+  height: auto;
+}

--- a/static/js/admin-edit-user.js
+++ b/static/js/admin-edit-user.js
@@ -1,0 +1,134 @@
+(function () {
+  const assignedSearch = document.getElementById('assignedBarSearch');
+  const availableSearch = document.getElementById('availableBarSearch');
+  const assigned = document.getElementById('assignedBars');
+  const available = document.getElementById('availableBars');
+
+  const deleteBtn = document.querySelector('.js-delete-user');
+  const blocker = document.getElementById('deleteBlocker');
+  const cancelBtn = document.querySelector('.js-cancel-delete');
+  const confirmBtn = document.querySelector('.js-confirm-delete');
+  const deleteFormId = deleteBtn ? `delete-user-${deleteBtn.dataset.userId}` : null;
+  const deleteForm = deleteFormId ? document.getElementById(deleteFormId) : null;
+
+  deleteBtn?.addEventListener('click', (event) => {
+    event.preventDefault();
+    if (blocker) {
+      blocker.hidden = false;
+    }
+  });
+
+  cancelBtn?.addEventListener('click', () => {
+    if (blocker) {
+      blocker.hidden = true;
+    }
+  });
+
+  confirmBtn?.addEventListener('click', () => {
+    deleteForm?.submit();
+  });
+
+  const errBlocker = document.getElementById('errorBlocker');
+  errBlocker?.querySelector('.js-close-error')?.addEventListener('click', () => {
+    errBlocker.hidden = true;
+  });
+
+  if (!assigned || !available) {
+    return;
+  }
+
+  const container = document.getElementById('barAssignments');
+  const addLabel = container?.dataset.addLabel || 'Add';
+  const removeLabel = container?.dataset.removeLabel || 'Remove';
+
+  const norm = (value) =>
+    (value || '')
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .trim();
+
+  const debounce = (fn, ms) => {
+    let timeout;
+    return (...args) => {
+      clearTimeout(timeout);
+      timeout = setTimeout(() => fn.apply(null, args), ms);
+    };
+  };
+
+  const setupSearch = (input, tbody) => {
+    if (!input) {
+      return () => {};
+    }
+
+    const apply = () => {
+      const query = norm(input.value);
+      Array.from(tbody.querySelectorAll('tr')).forEach((row) => {
+        const name = row.dataset.name || '';
+        row.style.display = !query || norm(name).includes(query) ? '' : 'none';
+      });
+    };
+
+    input.addEventListener('input', debounce(apply, 120));
+    input.closest('.bars-search')
+      ?.querySelector('.clear')
+      ?.addEventListener('click', () => {
+        input.value = '';
+        apply();
+        input.focus();
+      });
+
+    return apply;
+  };
+
+  const applyAssigned = setupSearch(assignedSearch, assigned);
+  const applyAvailable = setupSearch(availableSearch, available);
+
+  const moveRow = (row, toAssigned) => {
+    const checkbox = row.querySelector('input[name="bar_ids"]');
+    const button = row.querySelector('button');
+
+    if (!checkbox || !button) {
+      return;
+    }
+
+    if (toAssigned) {
+      checkbox.checked = true;
+      button.textContent = removeLabel;
+      button.classList.remove('btn-outline');
+      button.classList.add('btn-danger-soft', 'js-remove-bar');
+      button.classList.remove('js-add-bar');
+      assigned.appendChild(row);
+    } else {
+      checkbox.checked = false;
+      button.textContent = addLabel;
+      button.classList.remove('btn-danger-soft');
+      button.classList.add('btn-outline', 'js-add-bar');
+      button.classList.remove('js-remove-bar');
+      available.appendChild(row);
+    }
+
+    applyAssigned();
+    applyAvailable();
+  };
+
+  assigned.addEventListener('click', (event) => {
+    const button = event.target.closest('.js-remove-bar');
+    if (!button) {
+      return;
+    }
+
+    event.preventDefault();
+    moveRow(button.closest('tr'), false);
+  });
+
+  available.addEventListener('click', (event) => {
+    const button = event.target.closest('.js-add-bar');
+    if (!button) {
+      return;
+    }
+
+    event.preventDefault();
+    moveRow(button.closest('tr'), true);
+  });
+})();

--- a/static/js/admin-new-notification.js
+++ b/static/js/admin-new-notification.js
@@ -1,0 +1,138 @@
+(function () {
+  const form = document.getElementById('notificationForm');
+  if (!form) {
+    return;
+  }
+
+  const target = document.getElementById('target');
+  const userSection = document.getElementById('userSection');
+  const barSection = document.getElementById('barSection');
+  const userInput = document.getElementById('user_id');
+  const barInput = document.getElementById('bar_id');
+
+  const texts = {
+    selectUser: form.dataset.selectUser || 'Please select a user.',
+    selectBar: form.dataset.selectBar || 'Please select a bar.',
+    select: form.dataset.selectLabel || 'Select',
+    selected: form.dataset.selectedLabel || 'Selected',
+  };
+
+  const updateTarget = () => {
+    const value = target.value;
+    const isUser = value === 'user';
+    const isBar = value === 'bar';
+
+    if (userSection) {
+      userSection.hidden = !isUser;
+    }
+
+    if (barSection) {
+      barSection.hidden = !isBar;
+    }
+
+    if (userInput) {
+      userInput.disabled = !isUser;
+      if (!isUser) {
+        userInput.value = '';
+      }
+    }
+
+    if (barInput) {
+      barInput.disabled = !isBar;
+      if (!isBar) {
+        barInput.value = '';
+      }
+    }
+  };
+
+  target?.addEventListener('change', updateTarget);
+  updateTarget();
+
+  form.addEventListener('submit', (event) => {
+    const value = target.value;
+    const needsUser = value === 'user' && !userInput?.value;
+    const needsBar = value === 'bar' && !barInput?.value;
+
+    if (needsUser || needsBar) {
+      event.preventDefault();
+      alert(needsUser ? texts.selectUser : texts.selectBar);
+    }
+  });
+
+  const norm = (value) =>
+    (value || '')
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .trim();
+
+  const debounce = (fn, ms) => {
+    let timeout;
+    return (...args) => {
+      clearTimeout(timeout);
+      timeout = setTimeout(() => fn.apply(null, args), ms);
+    };
+  };
+
+  const setupSearch = (input, tbody) => {
+    if (!input || !tbody) {
+      return;
+    }
+
+    const apply = () => {
+      const query = norm(input.value);
+      Array.from(tbody.querySelectorAll('tr')).forEach((row) => {
+        const name = row.dataset.name || '';
+        row.style.display = !query || norm(name).includes(query) ? '' : 'none';
+      });
+    };
+
+    input.addEventListener('input', debounce(apply, 120));
+    input.closest('.users-search, .bars-search')
+      ?.querySelector('.clear')
+      ?.addEventListener('click', () => {
+        input.value = '';
+        apply();
+        input.focus();
+      });
+  };
+
+  setupSearch(document.getElementById('userSearch'), document.getElementById('userRows'));
+  setupSearch(document.getElementById('barSearch'), document.getElementById('barRows'));
+
+  document.getElementById('userRows')?.addEventListener('click', (event) => {
+    const button = event.target.closest('.js-pick-user');
+    if (!button) {
+      return;
+    }
+
+    event.preventDefault();
+    if (userInput) {
+      userInput.value = button.dataset.userId || '';
+    }
+    document
+      .querySelectorAll('.js-pick-user')
+      .forEach((node) => {
+        node.textContent = texts.select;
+      });
+    button.textContent = texts.selected;
+  });
+
+  document.getElementById('barRows')?.addEventListener('click', (event) => {
+    const button = event.target.closest('.js-pick-bar');
+    if (!button) {
+      return;
+    }
+
+    event.preventDefault();
+    if (barInput) {
+      barInput.value = button.dataset.barId || '';
+    }
+    document
+      .querySelectorAll('.js-pick-bar')
+      .forEach((node) => {
+        node.textContent = texts.select;
+      });
+    button.textContent = texts.selected;
+  });
+})();

--- a/templates/admin_edit_bar_options.html
+++ b/templates/admin_edit_bar_options.html
@@ -1,4 +1,8 @@
 {% extends "layout.html" %}
+{% block page_styles %}
+{{ super() }}
+<link rel="stylesheet" href="/static/css/pages/admin-edit-bar-options.css">
+{% endblock %}
 {% block content %}
 <section class="bar-edit-page">
   <header class="bar-edit-header">
@@ -31,39 +35,6 @@
       <p>{{ _('admin_edit_bar_options.cards.tables.body', default='Create, rename and arrange table numbers.') }}</p>
       <span class="cta">{{ _('admin_edit_bar_options.cards.tables.cta', default='Manage') }}</span>
     </a>
-  </div>
+</div>
 </section>
-
-<style>
-.bar-edit-page{display:block}
-.bar-edit-header{margin-block:var(--space-6,24px)}
-.bar-edit-header .subtitle{margin-top:var(--space-1,4px);opacity:.85}
-.back-link{display:inline-flex;gap:8px;align-items:center;text-decoration:none;opacity:.8;margin-bottom:8px}
-.back-link:hover{opacity:1}
-
-.action-grid{
-  display:grid; gap:var(--space-4,16px);
-  grid-template-columns:repeat(2,minmax(0,1fr));
-  margin-top:var(--space-4,16px)
-}
-@media (max-width:767px){ .action-grid{grid-template-columns:1fr} }
-
-.action-card{
-  position:relative; display:flex; flex-direction:column; gap:8px;
-  padding:var(--space-5,20px);
-  border-radius:var(--radius-2xl,16px);
-  background:var(--surface,#fff);
-  box-shadow:var(--shadow-sm,0 2px 8px rgba(0,0,0,.06));
-  text-decoration:none;
-}
-.action-card i{font-size:22px; opacity:.7}
-.action-card h3{margin:0}
-.action-card p{margin:0; line-height:1.45; opacity:.9}
-.action-card .cta{
-  margin-top:auto; font-weight:600;
-  color:var(--brand-600,#5b2dee);
-}
-.action-card:hover{transform:translateY(-1px); box-shadow:var(--shadow-md,0 6px 18px rgba(0,0,0,.08))}
-.action-card:focus-visible{outline:2px solid rgba(0,0,0,.15); outline-offset:2px}
-</style>
 {% endblock %}

--- a/templates/admin_edit_user.html
+++ b/templates/admin_edit_user.html
@@ -34,99 +34,103 @@
 
   <label for="role">{{ _('admin_edit_user.form.role', default='Role') }}</label>
   {% if current.is_super_admin %}
-  <select id="role" name="role">
-    <option value="super_admin" {% if user.role=='super_admin' %}selected{% endif %}>{{ _('admin_edit_user.roles.super_admin', default='Super Admin') }}</option>
-    <option value="bar_admin" {% if user.role=='bar_admin' %}selected{% endif %}>{{ _('admin_edit_user.roles.bar_admin', default='Bar Admin') }}</option>
-    <option value="bartender" {% if user.role=='bartender' %}selected{% endif %}>{{ _('admin_edit_user.roles.bartender', default='Bartender') }}</option>
-    <option value="display" {% if user.role=='display' %}selected{% endif %}>{{ _('admin_edit_user.roles.display', default='Display') }}</option>
-    <option value="customer" {% if user.role=='customer' %}selected{% endif %}>{{ _('admin_edit_user.roles.customer', default='Customer') }}</option>
-    <option value="blocked" {% if user.role=='blocked' %}selected{% endif %}>{{ _('admin_edit_user.roles.blocked', default='Blocked') }}</option>
-    <option value="ip_block" {% if user.role=='ip_block' %}selected{% endif %}>{{ _('admin_edit_user.roles.ip_block', default='IP Block') }}</option>
-  </select>
+  <div id="barAssignments"
+       data-add-label="{{ _('admin_edit_user.actions.add', default='Add') }}"
+       data-remove-label="{{ _('admin_edit_user.actions.remove', default='Remove') }}">
+    <select id="role" name="role">
+      <option value="super_admin" {% if user.role=='super_admin' %}selected{% endif %}>{{ _('admin_edit_user.roles.super_admin', default='Super Admin') }}</option>
+      <option value="bar_admin" {% if user.role=='bar_admin' %}selected{% endif %}>{{ _('admin_edit_user.roles.bar_admin', default='Bar Admin') }}</option>
+      <option value="bartender" {% if user.role=='bartender' %}selected{% endif %}>{{ _('admin_edit_user.roles.bartender', default='Bartender') }}</option>
+      <option value="display" {% if user.role=='display' %}selected{% endif %}>{{ _('admin_edit_user.roles.display', default='Display') }}</option>
+      <option value="customer" {% if user.role=='customer' %}selected{% endif %}>{{ _('admin_edit_user.roles.customer', default='Customer') }}</option>
+      <option value="blocked" {% if user.role=='blocked' %}selected{% endif %}>{{ _('admin_edit_user.roles.blocked', default='Blocked') }}</option>
+      <option value="ip_block" {% if user.role=='ip_block' %}selected{% endif %}>{{ _('admin_edit_user.roles.ip_block', default='IP Block') }}</option>
+    </select>
 
-  <h2>{{ _('admin_edit_user.sections.assigned', default='Assigned Bars') }}</h2>
-  <div class="toolbar-actions">
-    <div class="bars-search" role="search" aria-label="{{ _('admin_edit_user.assigned_search.aria', default='Search assigned bars') }}" onsubmit="return false">
-      <i class="bi bi-search" aria-hidden="true"></i>
-      <input id="assignedBarSearch" type="search" inputmode="search" autocomplete="off"
-             placeholder="{{ _('admin_edit_user.assigned_search.placeholder', default='Search bars by name…') }}" aria-label="{{ _('admin_edit_user.assigned_search.input_aria', default='Search assigned bars by name') }}">
-      <button class="clear" type="button" aria-label="{{ _('admin_edit_user.assigned_search.clear', default='Clear search') }}">
-        <i class="bi bi-x-circle" aria-hidden="true"></i>
-      </button>
+    <h2>{{ _('admin_edit_user.sections.assigned', default='Assigned Bars') }}</h2>
+    <div class="toolbar-actions">
+      <div class="bars-search" role="search" aria-label="{{ _('admin_edit_user.assigned_search.aria', default='Search assigned bars') }}" onsubmit="return false">
+        <i class="bi bi-search" aria-hidden="true"></i>
+        <input id="assignedBarSearch" type="search" inputmode="search" autocomplete="off"
+               placeholder="{{ _('admin_edit_user.assigned_search.placeholder', default='Search bars by name…') }}" aria-label="{{ _('admin_edit_user.assigned_search.input_aria', default='Search assigned bars by name') }}">
+        <button class="clear" type="button" aria-label="{{ _('admin_edit_user.assigned_search.clear', default='Clear search') }}">
+          <i class="bi bi-x-circle" aria-hidden="true"></i>
+        </button>
+      </div>
     </div>
-  </div>
-  <div class="table-card">
-    <table class="bars-table">
-      <thead>
-        <tr>
-          <th>{{ _('admin_edit_user.table.headers.number', default='No.') }}</th>
-          <th>{{ _('admin_edit_user.table.headers.name', default='Name') }}</th>
-          <th>{{ _('admin_edit_user.table.headers.city', default='City') }}</th>
-          <th class="actions">{{ _('admin_edit_user.table.headers.actions', default='Actions') }}</th>
-        </tr>
-      </thead>
-      <tbody id="assignedBars">
-        {% for b in bars if b.id in user.bar_ids %}
-        <tr data-name="{{ b.name }}">
-          <td>{{ "%03d"|format(b.id) }}</td>
-          <td>{{ b.name }}</td>
-          <td>{{ b.city }}</td>
-          <td class="actions">
-            <div class="actions-group">
-              <button type="button" class="btn-danger-soft js-remove-bar" data-bar-id="{{ b.id }}">{{ _('admin_edit_user.actions.remove', default='Remove') }}</button>
-            </div>
-            <input type="checkbox" name="bar_ids" value="{{ b.id }}" checked hidden>
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
-
-  <h2>{{ _('admin_edit_user.sections.assign', default='Assign a Bar') }}</h2>
-  <div class="toolbar-actions">
-    <div class="bars-search" role="search" aria-label="{{ _('admin_edit_user.available_search.aria', default='Search available bars') }}" onsubmit="return false">
-      <i class="bi bi-search" aria-hidden="true"></i>
-      <input id="availableBarSearch" type="search" inputmode="search" autocomplete="off"
-             placeholder="{{ _('admin_edit_user.available_search.placeholder', default='Search bars by name…') }}" aria-label="{{ _('admin_edit_user.available_search.input_aria', default='Search available bars by name') }}">
-      <button class="clear" type="button" aria-label="{{ _('admin_edit_user.available_search.clear', default='Clear search') }}">
-        <i class="bi bi-x-circle" aria-hidden="true"></i>
-      </button>
+    <div class="table-card">
+      <table class="bars-table">
+        <thead>
+          <tr>
+            <th>{{ _('admin_edit_user.table.headers.number', default='No.') }}</th>
+            <th>{{ _('admin_edit_user.table.headers.name', default='Name') }}</th>
+            <th>{{ _('admin_edit_user.table.headers.city', default='City') }}</th>
+            <th class="actions">{{ _('admin_edit_user.table.headers.actions', default='Actions') }}</th>
+          </tr>
+        </thead>
+        <tbody id="assignedBars">
+          {% for b in bars if b.id in user.bar_ids %}
+          <tr data-name="{{ b.name }}">
+            <td>{{ "%03d"|format(b.id) }}</td>
+            <td>{{ b.name }}</td>
+            <td>{{ b.city }}</td>
+            <td class="actions">
+              <div class="actions-group">
+                <button type="button" class="btn-danger-soft js-remove-bar" data-bar-id="{{ b.id }}">{{ _('admin_edit_user.actions.remove', default='Remove') }}</button>
+              </div>
+              <input type="checkbox" name="bar_ids" value="{{ b.id }}" checked hidden>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
     </div>
-  </div>
-  <div class="table-card">
-    <table class="bars-table">
-      <thead>
-        <tr>
-          <th>{{ _('admin_edit_user.table.headers.number', default='No.') }}</th>
-          <th>{{ _('admin_edit_user.table.headers.name', default='Name') }}</th>
-          <th>{{ _('admin_edit_user.table.headers.city', default='City') }}</th>
-          <th class="actions">{{ _('admin_edit_user.table.headers.actions', default='Actions') }}</th>
-        </tr>
-      </thead>
-      <tbody id="availableBars">
-        {% for b in bars if b.id not in user.bar_ids %}
-        <tr data-name="{{ b.name }}">
-          <td>{{ "%03d"|format(b.id) }}</td>
-          <td>{{ b.name }}</td>
-          <td>{{ b.city }}</td>
-          <td class="actions">
-            <div class="actions-group">
-              <button type="button" class="btn-outline js-add-bar" data-bar-id="{{ b.id }}">{{ _('admin_edit_user.actions.add', default='Add') }}</button>
-            </div>
-            <input type="checkbox" name="bar_ids" value="{{ b.id }}" hidden>
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
 
-  <label for="add_credit">{{ _('admin_edit_user.form.add_credit', default='Add Credit') }}</label>
-  <input id="add_credit" name="add_credit" type="number" step="0.01" value="0">
+    <h2>{{ _('admin_edit_user.sections.assign', default='Assign a Bar') }}</h2>
+    <div class="toolbar-actions">
+      <div class="bars-search" role="search" aria-label="{{ _('admin_edit_user.available_search.aria', default='Search available bars') }}" onsubmit="return false">
+        <i class="bi bi-search" aria-hidden="true"></i>
+        <input id="availableBarSearch" type="search" inputmode="search" autocomplete="off"
+               placeholder="{{ _('admin_edit_user.available_search.placeholder', default='Search bars by name…') }}" aria-label="{{ _('admin_edit_user.available_search.input_aria', default='Search available bars by name') }}">
+        <button class="clear" type="button" aria-label="{{ _('admin_edit_user.available_search.clear', default='Clear search') }}">
+          <i class="bi bi-x-circle" aria-hidden="true"></i>
+        </button>
+      </div>
+    </div>
+    <div class="table-card">
+      <table class="bars-table">
+        <thead>
+          <tr>
+            <th>{{ _('admin_edit_user.table.headers.number', default='No.') }}</th>
+            <th>{{ _('admin_edit_user.table.headers.name', default='Name') }}</th>
+            <th>{{ _('admin_edit_user.table.headers.city', default='City') }}</th>
+            <th class="actions">{{ _('admin_edit_user.table.headers.actions', default='Actions') }}</th>
+          </tr>
+        </thead>
+        <tbody id="availableBars">
+          {% for b in bars if b.id not in user.bar_ids %}
+          <tr data-name="{{ b.name }}">
+            <td>{{ "%03d"|format(b.id) }}</td>
+            <td>{{ b.name }}</td>
+            <td>{{ b.city }}</td>
+            <td class="actions">
+              <div class="actions-group">
+                <button type="button" class="btn-outline js-add-bar" data-bar-id="{{ b.id }}">{{ _('admin_edit_user.actions.add', default='Add') }}</button>
+              </div>
+              <input type="checkbox" name="bar_ids" value="{{ b.id }}" hidden>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
 
-  <label for="remove_credit">{{ _('admin_edit_user.form.remove_credit', default='Remove Credit') }}</label>
-  <input id="remove_credit" name="remove_credit" type="number" step="0.01" value="0">
+    <label for="add_credit">{{ _('admin_edit_user.form.add_credit', default='Add Credit') }}</label>
+    <input id="add_credit" name="add_credit" type="number" step="0.01" value="0">
+
+    <label for="remove_credit">{{ _('admin_edit_user.form.remove_credit', default='Remove Credit') }}</label>
+    <input id="remove_credit" name="remove_credit" type="number" step="0.01" value="0">
+  </div>
   {% else %}
   <select id="role" name="role">
     <option value="bar_admin" {% if user.role=='bar_admin' %}selected{% endif %}>{{ _('admin_edit_user.roles.bar_admin', default='Bar Admin') }}</option>
@@ -155,93 +159,8 @@
 </div>
 {% endif %}
 
-<script>
-{% set admin_edit_user_labels = {
-  'add': _('admin_edit_user.actions.add', default='Add'),
-  'remove': _('admin_edit_user.actions.remove', default='Remove')
-} %}
-(function(){
-  const assignedSearch = document.getElementById('assignedBarSearch');
-  const availableSearch = document.getElementById('availableBarSearch');
-  const assigned = document.getElementById('assignedBars');
-  const available = document.getElementById('availableBars');
-  if(!assigned || !available) return;
-  const norm = s => (s||'').toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g,'').trim();
-  function debounce(fn,ms){let t;return (...a)=>{clearTimeout(t);t=setTimeout(()=>fn.apply(this,a),ms)}}
-  function setupSearch(input, tbody){
-    if(!input) return ()=>{};
-    const apply = () => {
-      const q = norm(input.value);
-      Array.from(tbody.querySelectorAll('tr')).forEach(tr => {
-        const name = tr.dataset.name || '';
-        tr.style.display = !q || norm(name).includes(q) ? '' : 'none';
-      });
-    };
-    input.addEventListener('input', debounce(apply,120));
-    input.closest('.bars-search')?.querySelector('.clear')?.addEventListener('click', () => {
-      input.value=''; apply(); input.focus();
-    });
-    return apply;
-  }
-
-  const applyAssigned = setupSearch(assignedSearch, assigned);
-  const applyAvailable = setupSearch(availableSearch, available);
-
-  function moveRow(tr, toAssigned){
-    const checkbox = tr.querySelector('input[name="bar_ids"]');
-    const btn = tr.querySelector('button');
-    if(toAssigned){
-      checkbox.checked = true;
-      btn.textContent = {{ admin_edit_user_labels.remove|tojson }};
-      btn.classList.remove('btn-outline');
-      btn.classList.add('btn-danger-soft','js-remove-bar');
-      btn.classList.remove('js-add-bar');
-      assigned.appendChild(tr);
-    } else {
-      checkbox.checked = false;
-      btn.textContent = {{ admin_edit_user_labels.add|tojson }};
-      btn.classList.remove('btn-danger-soft');
-      btn.classList.add('btn-outline','js-add-bar');
-      btn.classList.remove('js-remove-bar');
-      available.appendChild(tr);
-    }
-    applyAssigned();
-    applyAvailable();
-  }
-
-  assigned.addEventListener('click', e => {
-    const btn = e.target.closest('.js-remove-bar');
-    if(!btn) return;
-    e.preventDefault();
-    moveRow(btn.closest('tr'), false);
-  });
-
-  available.addEventListener('click', e => {
-    const btn = e.target.closest('.js-add-bar');
-    if(!btn) return;
-    e.preventDefault();
-    moveRow(btn.closest('tr'), true);
-  });
-
-  const deleteBtn = document.querySelector('.js-delete-user');
-  const blocker = document.getElementById('deleteBlocker');
-  const cancelBtn = document.querySelector('.js-cancel-delete');
-  const confirmBtn = document.querySelector('.js-confirm-delete');
-  const deleteForm = document.getElementById('delete-user-{{ user.id }}');
-  deleteBtn?.addEventListener('click', e => {
-    e.preventDefault();
-    if(blocker) blocker.hidden = false;
-  });
-  cancelBtn?.addEventListener('click', () => {
-    if(blocker) blocker.hidden = true;
-  });
-  confirmBtn?.addEventListener('click', () => {
-    deleteForm?.submit();
-  });
-  const errBlocker = document.getElementById('errorBlocker');
-  errBlocker?.querySelector('.js-close-error')?.addEventListener('click', () => {
-    errBlocker.hidden = true;
-  });
-})();
-</script>
+{% block scripts %}
+{{ super() }}
+<script src="/static/js/admin-edit-user.js" defer></script>
+{% endblock %}
 {% endblock %}

--- a/templates/admin_new_notification.html
+++ b/templates/admin_new_notification.html
@@ -1,4 +1,8 @@
 {% extends "layout.html" %}
+{% block page_styles %}
+{{ super() }}
+<link rel="stylesheet" href="/static/css/pages/admin-new-notification.css">
+{% endblock %}
 {% block content %}
 {% set subject_map = subject_translations if subject_translations is defined else {} %}
 {% set body_map = body_translations if body_translations is defined else {} %}
@@ -14,7 +18,15 @@
   {% if error %}
   <p class="alert-danger">{{ error }}</p>
   {% endif %}
-  <form class="form" method="post" action="/admin/notifications" enctype="multipart/form-data">
+  <form id="notificationForm"
+        class="form"
+        method="post"
+        action="/admin/notifications"
+        enctype="multipart/form-data"
+        data-select-user="{{ _('admin_new_notification.alerts.select_user', default='Please select a user.') }}"
+        data-select-bar="{{ _('admin_new_notification.alerts.select_bar', default='Please select a bar.') }}"
+        data-select-label="{{ _('admin_new_notification.actions.select', default='Select') }}"
+        data-selected-label="{{ _('admin_new_notification.actions.selected', default='Selected') }}">
     <label>{{ _('admin_new_notification.form.target.label', default='Target') }}
       <select name="target" id="target" required>
         <option value="all">{{ _('admin_new_notification.form.target.options.all', default='All Users') }}</option>
@@ -135,85 +147,5 @@
 
 {% block scripts %}
 {{ super() }}
-<script>
-(function(){
-  const target = document.getElementById('target');
-  const userSection = document.getElementById('userSection');
-  const barSection = document.getElementById('barSection');
-  const userInput = document.getElementById('user_id');
-  const barInput = document.getElementById('bar_id');
-  const form = document.querySelector('form');
-  const texts = {{ {
-    'select_user': _('admin_new_notification.alerts.select_user', default='Please select a user.'),
-    'select_bar': _('admin_new_notification.alerts.select_bar', default='Please select a bar.'),
-    'select': _('admin_new_notification.actions.select', default='Select'),
-    'selected': _('admin_new_notification.actions.selected', default='Selected')
-  }|tojson }};
-  function updateTarget(){
-    const val = target.value;
-    userSection.hidden = val !== 'user';
-    barSection.hidden = val !== 'bar';
-    userInput.disabled = val !== 'user';
-    barInput.disabled = val !== 'bar';
-    if(val !== 'user') userInput.value = '';
-    if(val !== 'bar') barInput.value = '';
-  }
-  target.addEventListener('change', updateTarget);
-  updateTarget();
-  form.addEventListener('submit', e => {
-    const val = target.value;
-    if((val === 'user' && !userInput.value) || (val === 'bar' && !barInput.value)){
-      e.preventDefault();
-      alert(val === 'user' ? texts.select_user : texts.select_bar);
-    }
-  });
-  const norm = s => (s||'').toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g,'').trim();
-  function debounce(fn,ms){let t;return(...a)=>{clearTimeout(t);t=setTimeout(()=>fn.apply(this,a),ms);}}
-  function setupSearch(input, tbody){
-    if(!input) return;
-    const apply = () => {
-      const q = norm(input.value);
-      Array.from(tbody.querySelectorAll('tr')).forEach(tr=>{
-        const name = tr.dataset.name || '';
-        tr.style.display = !q || norm(name).includes(q) ? '' : 'none';
-      });
-    };
-    input.addEventListener('input', debounce(apply,120));
-    input.closest('.users-search, .bars-search')?.querySelector('.clear')?.addEventListener('click', () => {
-      input.value=''; apply(); input.focus();
-    });
-  }
-  setupSearch(document.getElementById('userSearch'), document.getElementById('userRows'));
-  setupSearch(document.getElementById('barSearch'), document.getElementById('barRows'));
-  document.getElementById('userRows')?.addEventListener('click', e => {
-    const btn = e.target.closest('.js-pick-user');
-    if(!btn) return;
-    e.preventDefault();
-    userInput.value = btn.dataset.userId;
-    document.querySelectorAll('.js-pick-user').forEach(b=>b.textContent=texts.select);
-    btn.textContent=texts.selected;
-  });
-  document.getElementById('barRows')?.addEventListener('click', e => {
-    const btn = e.target.closest('.js-pick-bar');
-    if(!btn) return;
-    e.preventDefault();
-    barInput.value = btn.dataset.barId;
-    document.querySelectorAll('.js-pick-bar').forEach(b=>b.textContent=texts.select);
-    btn.textContent=texts.selected;
-  });
-})();
-</script>
-{% endblock %}
-
-{% block styles %}
-{{ super() }}
-<style>
-.translation-panel{border:1px dashed rgba(15,23,42,.25);border-radius:12px;padding:16px;margin-bottom:var(--space-3,12px);display:flex;flex-direction:column;gap:12px;}
-.translation-panel label{display:flex;flex-direction:column;font-weight:500;gap:6px;}
-.translation-panel input,.translation-panel textarea{width:100%;}
-.translation-panel textarea{min-height:96px;}
-.translation-help{margin:0;font-size:.9rem;opacity:.75;}
-.translation-note{margin:0;font-size:.85rem;color:#475569;}
-.translation-label{margin:0;font-weight:600;}
-</style>
+<script src="/static/js/admin-new-notification.js" defer></script>
 {% endblock %}

--- a/templates/bar_edit_product.html
+++ b/templates/bar_edit_product.html
@@ -1,4 +1,8 @@
 {% extends "layout.html" %}
+{% block page_styles %}
+{{ super() }}
+<link rel="stylesheet" href="/static/css/pages/bar-edit-product.css">
+{% endblock %}
 {% block content %}
 {% set fallback_img = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCA0MDAgMjI1Jz48cmVjdCB3aWR0aD0nNDAwJyBoZWlnaHQ9JzIyNScgZmlsbD0nJTIzZjFmM2Y1Jy8+PC9zdmc+" %}
 {% set preview_name = product_name(product) %}
@@ -44,16 +48,4 @@
     </div>
   </div>
 </section>
-<style>
-.product-edit{max-width:720px;margin-inline:auto;}
-.product-edit .card{max-height:none;}
-.product-edit .card__body{display:flex;}
-.product-edit .form{display:flex;flex-direction:column;gap:var(--space-5,24px);width:100%;}
-.product-edit .form-field{display:flex;flex-direction:column;gap:var(--space-2,12px);}
-.product-edit .field-action{align-self:flex-start;}
-.product-edit .locked-field .description-preview{margin:0;padding:12px 16px;border-radius:var(--radius-xl,16px);background:var(--surface-strong,#f3f4f6);font-size:0.95rem;line-height:1.5;}
-.product-edit .locked-field .description-preview:empty::before{content:"";}
-.product-edit .photo-preview{border-radius:var(--radius-xl,16px);overflow:hidden;max-width:200px;}
-.product-edit .photo-preview img{display:block;width:100%;height:auto;}
-</style>
 {% endblock %}


### PR DESCRIPTION
## Summary
- extract inline styles into dedicated CSS files for the admin edit bar options and bar product templates
- move the admin edit user and new notification behaviours into standalone JavaScript modules and hook them up from the templates
- document the new asset locations in `AGENTS.md`

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da51473bc48320859ac4b6df6328cb