### PR TITLE
Separate bar category inline assets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,9 @@
   - `templates/admin_edit_bar.html` imports `/static/css/pages/admin-edit-bar.css` and `/static/js/admin-edit-bar.js` (Leaflet assets stay on the CDN).
   - `templates/order_history.html` imports `/static/css/pages/order-history.css` and `/static/js/order-history.js` alongside `orders.js`.
   - `templates/admin_edit_welcome.html` imports `/static/css/pages/admin-edit-welcome.css` and `/static/js/admin-edit-welcome.js`.
+  - `templates/bar_new_category.html` imports `/static/css/pages/bar-new-category.css` and `/static/js/bar-new-category.js`.
+  - `templates/bar_edit_category.html` imports `/static/css/pages/bar-edit-category.css`.
+  - `templates/bar_manage_categories.html` imports `/static/css/pages/bar-manage-categories.css` and `/static/js/bar-manage-categories.js`.
 - Footer marketing pages (About, Help Center, For Bars, Terms) live in `templates/about.html`, `templates/help_center.html`, `templates/for_bars.html`, and `templates/terms.html`; they share the `.static-page` styles defined in `static/css/components.css`.
   - Support contact details for these static pages pull from Jinja globals defined in `main.py` (`SUPPORT_EMAIL`, `SUPPORT_NUMBER`, `TERMS_VERSION`, etc.); update those constants to change emails, phone numbers, or term dates sitewide.
   - The About page intro copy reads "Built and operated by Siply..." followed by "We’re building a modern ordering experience..." to highlight Siply's role and hospitality focus.

--- a/static/css/pages/bar-edit-category.css
+++ b/static/css/pages/bar-edit-category.css
@@ -1,0 +1,42 @@
+.category-edit {
+  max-width: 720px;
+  margin-inline: auto;
+}
+
+.category-edit .card {
+  max-height: none;
+}
+
+.category-edit .card__body {
+  display: flex;
+}
+
+.category-edit .form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5, 24px);
+  width: 100%;
+}
+
+.category-edit .form-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2, 12px);
+}
+
+.category-edit .field-action {
+  align-self: flex-start;
+}
+
+.category-edit .locked-field .description-preview {
+  margin: 0;
+  padding: 12px 16px;
+  border-radius: var(--radius-xl, 16px);
+  background: var(--surface-strong, #f3f4f6);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.category-edit .locked-field .description-preview:empty::before {
+  content: "";
+}

--- a/static/css/pages/bar-manage-categories.css
+++ b/static/css/pages/bar-manage-categories.css
@@ -1,0 +1,3 @@
+.menu-table th.index-column {
+  width: 56px;
+}

--- a/static/css/pages/bar-new-category.css
+++ b/static/css/pages/bar-new-category.css
@@ -1,0 +1,62 @@
+.translation-control {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: var(--space-3, 12px);
+}
+
+.translation-control label {
+  flex: 1;
+}
+
+.translation-toggle {
+  align-self: flex-start;
+  margin-top: auto;
+}
+
+.translation-panel {
+  border: 1px dashed rgba(15, 23, 42, 0.25);
+  border-radius: 12px;
+  padding: 16px;
+  margin-bottom: var(--space-3, 12px);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.translation-panel label {
+  display: flex;
+  flex-direction: column;
+  font-weight: 500;
+  gap: 6px;
+}
+
+.translation-panel input,
+.translation-panel textarea {
+  width: 100%;
+}
+
+.translation-panel textarea {
+  min-height: 96px;
+}
+
+.translation-help {
+  margin: 0;
+  font-size: 0.9rem;
+  opacity: 0.75;
+}
+
+@media (min-width: 600px) {
+  .translation-control {
+    flex-direction: row;
+    align-items: flex-end;
+  }
+
+  .translation-control label {
+    flex: 1;
+  }
+
+  .translation-toggle {
+    margin-left: 16px;
+  }
+}

--- a/static/js/bar-manage-categories.js
+++ b/static/js/bar-manage-categories.js
@@ -1,0 +1,61 @@
+(function () {
+  const searchForm = document.querySelector('.menu-search');
+  const input = document.getElementById('categorySearch');
+  const clearBtn = document.querySelector('.menu-search .clear');
+  const tbody = document.querySelector('.menu-table tbody');
+
+  searchForm?.addEventListener('submit', (event) => {
+    event.preventDefault();
+  });
+
+  if (!input) return;
+
+  const rows = tbody ? Array.from(tbody.rows) : [];
+  const normalise = (value) => (value || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim();
+
+  const applyFilter = () => {
+    const query = normalise(input.value);
+    rows.forEach((row) => {
+      const nameCell = row.cells && row.cells[1] ? row.cells[1].textContent : '';
+      const isMatch = !query || normalise(nameCell).includes(query);
+      row.style.display = isMatch ? '' : 'none';
+    });
+  };
+
+  const debounce = (fn, ms) => {
+    let timeoutId;
+    return (...args) => {
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => fn.apply(null, args), ms);
+    };
+  };
+
+  const debouncedFilter = debounce(applyFilter, 120);
+
+  input.addEventListener('input', debouncedFilter);
+  clearBtn?.addEventListener('click', () => {
+    input.value = '';
+    applyFilter();
+    input.focus();
+  });
+
+  const params = new URLSearchParams(window.location.search);
+  const initialQuery = params.get('q');
+  if (initialQuery) {
+    input.value = initialQuery;
+    applyFilter();
+  }
+
+  document.querySelectorAll('form[data-confirm-message]').forEach((form) => {
+    form.addEventListener('submit', (event) => {
+      const message = form.dataset.confirmMessage;
+      if (message && !window.confirm(message)) {
+        event.preventDefault();
+      }
+    });
+  });
+})();

--- a/static/js/bar-new-category.js
+++ b/static/js/bar-new-category.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.translation-toggle').forEach((button) => {
+    button.addEventListener('click', () => {
+      const targetId = button.dataset.translationTarget;
+      if (!targetId) return;
+
+      const panel = document.getElementById(targetId);
+      if (!panel) return;
+
+      const isExpanded = button.getAttribute('aria-expanded') === 'true';
+      const nextState = !isExpanded;
+      button.setAttribute('aria-expanded', String(nextState));
+
+      if (nextState) {
+        panel.removeAttribute('hidden');
+      } else {
+        panel.setAttribute('hidden', '');
+      }
+    });
+  });
+});

--- a/templates/bar_edit_category.html
+++ b/templates/bar_edit_category.html
@@ -1,4 +1,10 @@
 {% extends "layout.html" %}
+
+{% block page_styles %}
+{{ super() }}
+<link rel="stylesheet" href="/static/css/pages/bar-edit-category.css">
+{% endblock %}
+
 {% block content %}
 <a class="back-link" href="/bar/{{ bar.id }}/categories">
   <i class="bi bi-chevron-left" aria-hidden="true"></i>
@@ -30,15 +36,5 @@
     </div>
   </div>
 </section>
-<style>
-.category-edit{max-width:720px;margin-inline:auto;}
-.category-edit .card{max-height:none;}
-.category-edit .card__body{display:flex;}
-.category-edit .form{display:flex;flex-direction:column;gap:var(--space-5,24px);width:100%;}
-.category-edit .form-field{display:flex;flex-direction:column;gap:var(--space-2,12px);}
-.category-edit .field-action{align-self:flex-start;}
-.category-edit .locked-field .description-preview{margin:0;padding:12px 16px;border-radius:var(--radius-xl,16px);background:var(--surface-strong,#f3f4f6);font-size:0.95rem;line-height:1.5;}
-.category-edit .locked-field .description-preview:empty::before{content:"";}
-</style>
 {% endblock %}
 

--- a/templates/bar_manage_categories.html
+++ b/templates/bar_manage_categories.html
@@ -1,4 +1,10 @@
 {% extends "layout.html" %}
+
+{% block page_styles %}
+{{ super() }}
+<link rel="stylesheet" href="/static/css/pages/bar-manage-categories.css">
+{% endblock %}
+
 {% block content %}
 <section class="menu-page">
   <header class="menu-toolbar">
@@ -11,7 +17,7 @@
       <p class="subtitle">{{ _('bar_categories.manage.subtitle', default='Create, edit and organize menu categories for this venue.') }}</p>
     </div>
     <div class="toolbar-actions">
-      <form class="menu-search" role="search" aria-label="{{ _('bar_categories.manage.search.aria', default='Search categories') }}" onsubmit="return false">
+      <form class="menu-search" role="search" aria-label="{{ _('bar_categories.manage.search.aria', default='Search categories') }}">
         <i class="bi bi-search" aria-hidden="true"></i>
         <input id="categorySearch" type="search" inputmode="search" autocomplete="off" placeholder="{{ _('bar_categories.manage.search.placeholder', default='Search categories…') }}" aria-label="{{ _('bar_categories.manage.search.input_aria', default='Search categories by name') }}">
         <button class="clear" type="button" aria-label="{{ _('bar_categories.manage.search.clear', default='Clear search') }}">
@@ -27,7 +33,7 @@
     <table class="menu-table">
       <thead>
         <tr>
-          <th style="width:56px">#</th>
+          <th class="index-column">#</th>
           <th>{{ _('bar_categories.manage.table.headers.name', default='Name') }}</th>
           <th>{{ _('bar_categories.manage.table.headers.description', default='Description') }}</th>
           <th class="actions">{{ _('bar_categories.manage.table.headers.actions', default='Actions') }}</th>
@@ -47,7 +53,7 @@
               <a href="/bar/{{ bar.id }}/categories/{{ category.id }}/edit" class="btn-outline">{{ _('bar_categories.manage.actions.edit', default='Edit') }}</a>
               <button type="submit" form="delete_{{ category.id }}" class="btn-danger-soft">{{ _('bar_categories.manage.actions.delete', default='Delete') }}</button>
             </div>
-            <form id="delete_{{ category.id }}" method="post" action="/bar/{{ bar.id }}/categories/{{ category.id }}/delete" style="display:none" onsubmit="return confirm(&quot;{{ _('bar_categories.manage.confirm_delete', default='Are you sure you want to delete this category?')|replace('"', '\\"') }}&quot;);"></form>
+            <form id="delete_{{ category.id }}" method="post" action="/bar/{{ bar.id }}/categories/{{ category.id }}/delete" hidden data-confirm-message="{{ _('bar_categories.manage.confirm_delete', default='Are you sure you want to delete this category?') }}"></form>
           </td>
         </tr>
         {% endfor %}
@@ -58,33 +64,9 @@
   <p>{{ _('bar_categories.manage.empty', default='No categories yet.') }}</p>
   {% endif %}
 </section>
+{% endblock %}
 
-<script>
-(function(){
-  const input = document.getElementById('categorySearch');
-  const clearBtn = document.querySelector('.menu-search .clear');
-  const tbody = document.querySelector('.menu-table tbody');
-  if(!input || !tbody) return;
-
-  const rows = Array.from(tbody.rows);
-  const norm = s => (s||'').toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g,'').trim();
-
-  function applyFilter(){
-    const q = norm(input.value);
-    rows.forEach(tr=>{
-      const nameCell = tr.cells && tr.cells[1] ? tr.cells[1].textContent : '';
-      const match = !q || norm(nameCell).includes(q);
-      tr.style.display = match ? '' : 'none';
-    });
-  }
-  function debounce(fn,ms){let t;return (...a)=>{clearTimeout(t);t=setTimeout(()=>fn.apply(this,a),ms)}}
-  const run = debounce(applyFilter,120);
-
-  input.addEventListener('input', run);
-  clearBtn?.addEventListener('click', ()=>{ input.value=''; applyFilter(); input.focus(); });
-
-  const qs = new URLSearchParams(location.search);
-  const q = qs.get('q'); if(q){ input.value=q; applyFilter(); }
-})();
-</script>
+{% block scripts %}
+{{ super() }}
+<script src="/static/js/bar-manage-categories.js" defer></script>
 {% endblock %}

--- a/templates/bar_new_category.html
+++ b/templates/bar_new_category.html
@@ -1,4 +1,10 @@
 {% extends "layout.html" %}
+
+{% block page_styles %}
+{{ super() }}
+<link rel="stylesheet" href="/static/css/pages/bar-new-category.css">
+{% endblock %}
+
 {% block content %}
 {% set form_data = form_values if form_values is defined else {} %}
 {% set name_map = form_data.get('name_translations', {}) %}
@@ -43,42 +49,9 @@
   </label>
   <button class="btn btn--primary" type="submit">{{ _('bar_categories.form.create', default='Create') }}</button>
 </form>
-<style>
-.translation-control{display:flex;flex-direction:column;gap:8px;margin-bottom:var(--space-3,12px);}
-.translation-control label{flex:1;}
-.translation-toggle{align-self:flex-start;margin-top:auto;}
-.translation-panel{border:1px dashed rgba(15,23,42,.25);border-radius:12px;padding:16px;margin-bottom:var(--space-3,12px);display:flex;flex-direction:column;gap:12px;}
-.translation-panel label{display:flex;flex-direction:column;font-weight:500;gap:6px;}
-.translation-panel input,.translation-panel textarea{width:100%;}
-.translation-panel textarea{min-height:96px;}
-.translation-help{margin:0;font-size:.9rem;opacity:.75;}
-@media (min-width:600px){
-  .translation-control{flex-direction:row;align-items:flex-end;}
-  .translation-control label{flex:1;}
-  .translation-toggle{margin-left:16px;}
-}
-</style>
 {% endblock %}
 
 {% block scripts %}
 {{ super() }}
-<script>
-  document.addEventListener('DOMContentLoaded', () => {
-    document.querySelectorAll('.translation-toggle').forEach((btn) => {
-      btn.addEventListener('click', () => {
-        const targetId = btn.getAttribute('data-translation-target');
-        const target = targetId ? document.getElementById(targetId) : null;
-        if (!target) return;
-        const expanded = btn.getAttribute('aria-expanded') === 'true';
-        const next = !expanded;
-        btn.setAttribute('aria-expanded', String(next));
-        if (next) {
-          target.removeAttribute('hidden');
-        } else {
-          target.setAttribute('hidden', '');
-        }
-      });
-    });
-  });
-</script>
+<script src="/static/js/bar-new-category.js" defer></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- extract the bar category create/edit page styles into dedicated CSS files and load them via `page_styles`
- move the category translation toggles and management filtering scripts into standalone JS modules, wiring up form confirm handling
- document the new asset locations in `AGENTS.md`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da57b5c3d4832098edfaa0dadb3b8e