### PR TITLE
Separate translation editor CSS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@
   - `templates/admin_edit_welcome.html` imports `/static/css/pages/admin-edit-welcome.css` and `/static/js/admin-edit-welcome.js`.
   - `templates/bar_new_category.html` imports `/static/css/pages/bar-new-category.css` and `/static/js/bar-new-category.js`.
   - `templates/bar_edit_category.html` imports `/static/css/pages/bar-edit-category.css`.
+  - `templates/bar_edit_category_description.html`, `templates/bar_edit_category_name.html`, and `templates/bar_edit_product_description.html` import `/static/css/pages/translation-editor.css`.
   - `templates/bar_manage_categories.html` imports `/static/css/pages/bar-manage-categories.css` and `/static/js/bar-manage-categories.js`.
 - Footer marketing pages (About, Help Center, For Bars, Terms) live in `templates/about.html`, `templates/help_center.html`, `templates/for_bars.html`, and `templates/terms.html`; they share the `.static-page` styles defined in `static/css/components.css`.
   - Support contact details for these static pages pull from Jinja globals defined in `main.py` (`SUPPORT_EMAIL`, `SUPPORT_NUMBER`, `TERMS_VERSION`, etc.); update those constants to change emails, phone numbers, or term dates sitewide.

--- a/static/css/pages/translation-editor.css
+++ b/static/css/pages/translation-editor.css
@@ -1,0 +1,76 @@
+.category-translation-editor,
+.product-translation-editor {
+  max-width: 720px;
+  margin-inline: auto;
+  padding-block: var(--space-6, 24px);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4, 16px);
+}
+
+.category-translation-editor .back-link,
+.product-translation-editor .back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  text-decoration: none;
+  opacity: 0.8;
+}
+
+.category-translation-editor .back-link:hover,
+.product-translation-editor .back-link:hover {
+  opacity: 1;
+}
+
+.category-translation-editor .intro,
+.product-translation-editor .intro {
+  margin: 0;
+  opacity: 0.8;
+}
+
+.translation-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4, 16px);
+}
+
+.translation-form .field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.translation-form input,
+.translation-form textarea {
+  padding: 12px 14px;
+  border-radius: var(--radius-xl, 16px);
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  font-size: 1rem;
+}
+
+.translation-form textarea {
+  min-height: 120px;
+  line-height: 1.5;
+}
+
+.translation-form input:focus,
+.translation-form textarea:focus {
+  outline: 2px solid rgba(91, 45, 238, 0.25);
+  outline-offset: 2px;
+}
+
+.translation-form .form-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: var(--space-4, 16px);
+}
+
+.alert {
+  padding: 12px 14px;
+  border-radius: var(--radius-lg, 12px);
+}
+
+.alert-danger {
+  background: #fee2e2;
+  color: #991b1b;
+}

--- a/templates/bar_edit_category_description.html
+++ b/templates/bar_edit_category_description.html
@@ -1,4 +1,8 @@
 {% extends "layout.html" %}
+{% block page_styles %}
+{{ super() }}
+<link rel="stylesheet" href="/static/css/pages/translation-editor.css">
+{% endblock %}
 {% block content %}
 <section class="category-translation-editor">
   <a class="back-link" href="/bar/{{ bar.id }}/categories/{{ category.id }}/edit"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('bar_categories.edit_description.back', default='Back to category') }}</a>
@@ -19,17 +23,4 @@
     </div>
   </form>
 </section>
-<style>
-.category-translation-editor{max-width:720px;margin-inline:auto;padding-block:var(--space-6,24px);display:flex;flex-direction:column;gap:var(--space-4,16px);}
-.category-translation-editor .back-link{display:inline-flex;align-items:center;gap:8px;text-decoration:none;opacity:.8;}
-.category-translation-editor .back-link:hover{opacity:1;}
-.category-translation-editor .intro{margin:0;opacity:.8;}
-.translation-form{display:flex;flex-direction:column;gap:var(--space-4,16px);}
-.translation-form .field-group{display:flex;flex-direction:column;gap:8px;}
-.translation-form textarea{min-height:120px;padding:12px 14px;border-radius:var(--radius-xl,16px);border:1px solid rgba(15,23,42,.12);font-size:1rem;line-height:1.5;}
-.translation-form textarea:focus{outline:2px solid rgba(91,45,238,.25);outline-offset:2px;}
-.translation-form .form-actions{display:flex;justify-content:flex-end;margin-top:var(--space-4,16px);}
-.alert{padding:12px 14px;border-radius:var(--radius-lg,12px);}
-.alert-danger{background:#fee2e2;color:#991b1b;}
-</style>
 {% endblock %}

--- a/templates/bar_edit_category_name.html
+++ b/templates/bar_edit_category_name.html
@@ -1,4 +1,8 @@
 {% extends "layout.html" %}
+{% block page_styles %}
+{{ super() }}
+<link rel="stylesheet" href="/static/css/pages/translation-editor.css">
+{% endblock %}
 {% block content %}
 <section class="category-translation-editor">
   <a class="back-link" href="/bar/{{ bar.id }}/categories/{{ category.id }}/edit"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('bar_categories.edit_name.back', default='Back to category') }}</a>
@@ -19,17 +23,4 @@
     </div>
   </form>
 </section>
-<style>
-.category-translation-editor{max-width:720px;margin-inline:auto;padding-block:var(--space-6,24px);display:flex;flex-direction:column;gap:var(--space-4,16px);}
-.category-translation-editor .back-link{display:inline-flex;align-items:center;gap:8px;text-decoration:none;opacity:.8;}
-.category-translation-editor .back-link:hover{opacity:1;}
-.category-translation-editor .intro{margin:0;opacity:.8;}
-.translation-form{display:flex;flex-direction:column;gap:var(--space-4,16px);}
-.translation-form .field-group{display:flex;flex-direction:column;gap:8px;}
-.translation-form input,.translation-form textarea{padding:12px 14px;border-radius:var(--radius-xl,16px);border:1px solid rgba(15,23,42,.12);font-size:1rem;}
-.translation-form input:focus,.translation-form textarea:focus{outline:2px solid rgba(91,45,238,.25);outline-offset:2px;}
-.translation-form .form-actions{display:flex;justify-content:flex-end;margin-top:var(--space-4,16px);}
-.alert{padding:12px 14px;border-radius:var(--radius-lg,12px);}
-.alert-danger{background:#fee2e2;color:#991b1b;}
-</style>
 {% endblock %}

--- a/templates/bar_edit_product_description.html
+++ b/templates/bar_edit_product_description.html
@@ -1,4 +1,8 @@
 {% extends "layout.html" %}
+{% block page_styles %}
+{{ super() }}
+<link rel="stylesheet" href="/static/css/pages/translation-editor.css">
+{% endblock %}
 {% block content %}
 <section class="product-translation-editor">
   <a class="back-link" href="/bar/{{ bar.id }}/categories/{{ category.id }}/products/{{ product.id }}/edit"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('bar_products.edit_description.back', default='Back to product') }}</a>
@@ -19,17 +23,4 @@
     </div>
   </form>
 </section>
-<style>
-.product-translation-editor{max-width:720px;margin-inline:auto;padding-block:var(--space-6,24px);display:flex;flex-direction:column;gap:var(--space-4,16px);}
-.product-translation-editor .back-link{display:inline-flex;align-items:center;gap:8px;text-decoration:none;opacity:.8;}
-.product-translation-editor .back-link:hover{opacity:1;}
-.product-translation-editor .intro{margin:0;opacity:.8;}
-.translation-form{display:flex;flex-direction:column;gap:var(--space-4,16px);}
-.translation-form .field-group{display:flex;flex-direction:column;gap:8px;}
-.translation-form textarea{padding:12px 14px;border-radius:var(--radius-xl,16px);border:1px solid rgba(15,23,42,.12);font-size:1rem;min-height:120px;}
-.translation-form textarea:focus{outline:2px solid rgba(91,45,238,.25);outline-offset:2px;}
-.translation-form .form-actions{display:flex;justify-content:flex-end;margin-top:var(--space-4,16px);}
-.alert{padding:12px 14px;border-radius:var(--radius-lg,12px);}
-.alert-danger{background:#fee2e2;color:#991b1b;}
-</style>
 {% endblock %}


### PR DESCRIPTION
## Summary
- move the category and product translation editor templates to load shared page styles instead of inline CSS
- add `/static/css/pages/translation-editor.css` to consolidate layout, form, and alert styling for the editors
- document the new asset mapping in `AGENTS.md` for easier discovery of the shared stylesheet

## Testing
- pytest tests/test_translations.py

------
https://chatgpt.com/codex/tasks/task_e_68da604de06c832099f5ceb4ca1ea762