### PR TITLE
Extract inline admin assets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,9 @@
   - `templates/bar_edit_category.html` imports `/static/css/pages/bar-edit-category.css`.
   - `templates/bar_edit_category_description.html`, `templates/bar_edit_category_name.html`, and `templates/bar_edit_product_description.html` import `/static/css/pages/translation-editor.css`.
   - `templates/bar_manage_categories.html` imports `/static/css/pages/bar-manage-categories.css` and `/static/js/bar-manage-categories.js`.
+  - `templates/admin_edit_bar_description.html` imports `/static/css/pages/admin-edit-bar-description.css`.
+  - `templates/admin_analytics.html` imports `/static/css/pages/admin-analytics.css` and `/static/js/admin-analytics.js` (Chart.js stays on the CDN and page data hydrates via `#adminAnalyticsData`).
+  - `templates/admin_notifications.html` imports `/static/js/admin-notifications.js` for delete confirmation handling.
 - Footer marketing pages (About, Help Center, For Bars, Terms) live in `templates/about.html`, `templates/help_center.html`, `templates/for_bars.html`, and `templates/terms.html`; they share the `.static-page` styles defined in `static/css/components.css`.
   - Support contact details for these static pages pull from Jinja globals defined in `main.py` (`SUPPORT_EMAIL`, `SUPPORT_NUMBER`, `TERMS_VERSION`, etc.); update those constants to change emails, phone numbers, or term dates sitewide.
   - The About page intro copy reads "Built and operated by Siply..." followed by "We’re building a modern ordering experience..." to highlight Siply's role and hospitality focus.

--- a/static/css/pages/admin-analytics.css
+++ b/static/css/pages/admin-analytics.css
@@ -1,0 +1,47 @@
+.tab-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: var(--space-4, 16px);
+}
+
+.tab-nav a {
+  cursor: pointer;
+  text-decoration: none;
+  color: inherit;
+  padding-bottom: 0.25rem;
+  border-bottom: 2px solid transparent;
+}
+
+.tab-nav a.active {
+  font-weight: 600;
+  border-bottom-color: currentColor;
+}
+
+.tab-content {
+  display: none;
+  margin-top: 1rem;
+}
+
+.tab-content.active {
+  display: block;
+}
+
+.dashboard-actions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-4, 16px);
+  margin-block: var(--space-4, 16px);
+}
+
+.dashboard-actions .card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+@media (max-width: 600px) {
+  .tab-nav {
+    gap: 0.75rem;
+  }
+}

--- a/static/css/pages/admin-edit-bar-description.css
+++ b/static/css/pages/admin-edit-bar-description.css
@@ -1,0 +1,66 @@
+.description-editor {
+  max-width: 720px;
+  margin-inline: auto;
+  padding-block: var(--space-6, 24px);
+}
+
+.description-editor .back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  text-decoration: none;
+  opacity: 0.8;
+  margin-bottom: var(--space-2, 8px);
+}
+
+.description-editor .back-link:hover {
+  opacity: 1;
+}
+
+.description-editor .intro {
+  margin: var(--space-2, 8px) 0 var(--space-5, 20px);
+  opacity: 0.85;
+}
+
+.description-editor .field-group {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: var(--space-4, 16px);
+}
+
+.description-editor textarea {
+  min-height: 110px;
+  padding: 12px 14px;
+  border-radius: var(--radius-xl, 16px);
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.description-editor textarea:focus {
+  outline: 2px solid rgba(91, 45, 238, 0.25);
+  outline-offset: 2px;
+}
+
+.description-editor .help {
+  margin-top: 6px;
+  opacity: 0.7;
+  font-size: 0.875rem;
+}
+
+.description-editor .form-actions {
+  margin-top: var(--space-5, 20px);
+  display: flex;
+  justify-content: flex-end;
+}
+
+.description-editor .alert {
+  margin-bottom: var(--space-4, 16px);
+  padding: 12px 14px;
+  border-radius: var(--radius-lg, 12px);
+}
+
+.alert-danger {
+  background: #fee2e2;
+  color: #991b1b;
+}

--- a/static/js/admin-analytics.js
+++ b/static/js/admin-analytics.js
@@ -1,0 +1,110 @@
+(function () {
+  const dataEl = document.getElementById('adminAnalyticsData');
+  if (!dataEl) {
+    return;
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(dataEl.textContent);
+  } catch (error) {
+    console.error('Failed to parse analytics data', error);
+    return;
+  }
+
+  const {
+    dailyLabels = [],
+    dailyGmv = [],
+    dailyOrders = [],
+    chartLabels = {},
+    revenueBars = [],
+    hourlyLabels = [],
+    hourlyOrders = []
+  } = payload || {};
+
+  if (typeof Chart === 'undefined') {
+    return;
+  }
+
+  const gmvCanvas = document.getElementById('gmvChart');
+  if (gmvCanvas) {
+    new Chart(gmvCanvas, {
+      type: 'line',
+      data: {
+        labels: dailyLabels,
+        datasets: [
+          { label: chartLabels.gmv, data: dailyGmv, borderColor: '#0d6efd', fill: false },
+          { label: chartLabels.orders, data: dailyOrders, borderColor: '#6c757d', fill: false, yAxisID: 'y1' }
+        ]
+      },
+      options: {
+        scales: {
+          y: { beginAtZero: true },
+          y1: { beginAtZero: true, position: 'right' }
+        }
+      }
+    });
+  }
+
+  const revenueCanvas = document.getElementById('revenueChart');
+  if (revenueCanvas && Array.isArray(revenueBars) && revenueBars.length) {
+    const revLabels = revenueBars.map((row) => row.bar);
+    const revGmv = revenueBars.map((row) => row.gmv);
+    const revCommission = revenueBars.map((row) => row.commission);
+    const revNet = revenueBars.map((row) => row.net);
+
+    new Chart(revenueCanvas, {
+      type: 'bar',
+      data: {
+        labels: revLabels,
+        datasets: [
+          { label: chartLabels.gmv, data: revGmv, backgroundColor: '#0d6efd' },
+          { label: chartLabels.commission, data: revCommission, backgroundColor: '#dc3545' },
+          { label: chartLabels.net, data: revNet, backgroundColor: '#198754' }
+        ]
+      },
+      options: {
+        scales: {
+          y: { beginAtZero: true }
+        }
+      }
+    });
+  }
+
+  const ordersCanvas = document.getElementById('ordersChart');
+  if (ordersCanvas) {
+    new Chart(ordersCanvas, {
+      type: 'line',
+      data: {
+        labels: hourlyLabels,
+        datasets: [
+          { label: chartLabels.orders_per_hour, data: hourlyOrders, borderColor: '#0d6efd', fill: false }
+        ]
+      },
+      options: {
+        scales: {
+          y: { beginAtZero: true }
+        }
+      }
+    });
+  }
+
+  document.querySelectorAll('.tab-nav a').forEach((link) => {
+    link.addEventListener('click', (event) => {
+      event.preventDefault();
+      const targetId = link.dataset.tab;
+      if (!targetId) {
+        return;
+      }
+
+      document.querySelectorAll('.tab-nav a').forEach((item) => item.classList.remove('active'));
+      document.querySelectorAll('.tab-content').forEach((section) => section.classList.remove('active'));
+
+      link.classList.add('active');
+      const targetSection = document.getElementById(targetId);
+      if (targetSection) {
+        targetSection.classList.add('active');
+      }
+    });
+  });
+})();

--- a/static/js/admin-notifications.js
+++ b/static/js/admin-notifications.js
@@ -1,0 +1,34 @@
+(function () {
+  const blocker = document.getElementById('deleteBlocker');
+  if (!blocker) {
+    return;
+  }
+
+  const cancelBtn = blocker.querySelector('.js-cancel-delete');
+  const confirmBtn = blocker.querySelector('.js-confirm-delete');
+  let targetForm = null;
+
+  document.querySelectorAll('.js-delete-note').forEach((btn) => {
+    btn.addEventListener('click', (event) => {
+      event.preventDefault();
+      const id = btn.dataset.noteId;
+      targetForm = document.getElementById(`delete-note-${id}`);
+      blocker.hidden = false;
+    });
+  });
+
+  if (cancelBtn) {
+    cancelBtn.addEventListener('click', () => {
+      blocker.hidden = true;
+      targetForm = null;
+    });
+  }
+
+  if (confirmBtn) {
+    confirmBtn.addEventListener('click', () => {
+      if (targetForm) {
+        targetForm.submit();
+      }
+    });
+  }
+})();

--- a/templates/admin_analytics.html
+++ b/templates/admin_analytics.html
@@ -1,5 +1,16 @@
 {% extends "layout.html" %}
+{% block page_styles %}
+{{ super() }}
+<link rel="stylesheet" href="/static/css/pages/admin-analytics.css">
+{% endblock %}
 {% block content %}
+{% set chart_labels = {
+  'gmv': _('admin_analytics.charts.gmv', default='GMV'),
+  'orders': _('admin_analytics.charts.orders', default='# Orders'),
+  'commission': _('admin_analytics.charts.commission', default='Commission'),
+  'net': _('admin_analytics.charts.net', default='Net'),
+  'orders_per_hour': _('admin_analytics.charts.orders_per_hour', default='Orders/hour')
+} %}
 <a class="back-link" href="/dashboard"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_analytics.back', default='Back to dashboard') }}</a>
 <h1>{{ _('admin_analytics.title', default='Analytics') }}</h1>
 <div class="dashboard-info">
@@ -131,80 +142,20 @@
   <div id="exports" class="tab-content">
     <p>{{ _('admin_analytics.exports.message', default='CSV exports and scheduled reports will be available soon.') }}</p>
   </div>
-<style>
-.tab-nav a{margin-right:1rem;cursor:pointer;}
-.tab-nav a.active{font-weight:bold;}
-.tab-content{display:none;margin-top:1rem;}
-.tab-content.active{display:block;}
-</style>
+  <script type="application/json" id="adminAnalyticsData">
+    {{ {
+      'dailyLabels': stats.daily_labels,
+      'dailyGmv': stats.daily_gmv,
+      'dailyOrders': stats.daily_orders,
+      'chartLabels': chart_labels,
+      'revenueBars': stats.revenue_bars,
+      'hourlyLabels': stats.hourly_labels,
+      'hourlyOrders': stats.hourly_orders
+    }|tojson }}
+  </script>
 {% endblock %}
 {% block scripts %}
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-{% set chart_labels = {
-  'gmv': _('admin_analytics.charts.gmv', default='GMV'),
-  'orders': _('admin_analytics.charts.orders', default='# Orders'),
-  'commission': _('admin_analytics.charts.commission', default='Commission'),
-  'net': _('admin_analytics.charts.net', default='Net'),
-  'orders_per_hour': _('admin_analytics.charts.orders_per_hour', default='Orders/hour')
-} %}
-<script>
-const labels = {{ stats.daily_labels|tojson }};
-const gmv = {{ stats.daily_gmv|tojson }};
-const orders = {{ stats.daily_orders|tojson }};
-const ctx = document.getElementById('gmvChart');
-const chartLabels = {{ chart_labels|tojson }};
-new Chart(ctx, {
-  type: 'line',
-  data: {
-    labels: labels,
-    datasets: [
-      {label: chartLabels.gmv, data: gmv, borderColor: '#0d6efd', fill: false},
-        {label: chartLabels.orders, data: orders, borderColor: '#6c757d', fill: false, yAxisID: 'y1'}
-    ]
-  },
-  options: {
-    scales: {
-      y: {beginAtZero: true},
-      y1: {beginAtZero: true, position: 'right'}
-    }
-  }
-});
-
-const revData = {{ stats.revenue_bars|tojson }};
-if (revData.length) {
-  const revLabels = revData.map(r=>r.bar);
-  const revGmv = revData.map(r=>r.gmv);
-  const revComm = revData.map(r=>r.commission);
-  const revNet = revData.map(r=>r.net);
-  new Chart(document.getElementById('revenueChart'), {
-    type: 'bar',
-    data: {labels: revLabels, datasets: [
-      {label: chartLabels.gmv, data: revGmv, backgroundColor: '#0d6efd'},
-        {label: chartLabels.commission, data: revComm, backgroundColor: '#dc3545'},
-        {label: chartLabels.net, data: revNet, backgroundColor: '#198754'}
-    ]},
-    options: {scales: {y: {beginAtZero: true}}}
-  });
-}
-
-const hourLabels = {{ stats.hourly_labels|tojson }};
-const hourOrders = {{ stats.hourly_orders|tojson }};
-new Chart(document.getElementById('ordersChart'), {
-  type: 'line',
-  data: {labels: hourLabels, datasets: [
-      {label: chartLabels.orders_per_hour, data: hourOrders, borderColor: '#0d6efd', fill: false}
-  ]},
-  options: {scales: {y: {beginAtZero: true}}}
-});
-
-document.querySelectorAll('.tab-nav a').forEach(a=>{
-  a.addEventListener('click', e=>{
-    e.preventDefault();
-    document.querySelectorAll('.tab-nav a').forEach(el=>el.classList.remove('active'));
-    document.querySelectorAll('.tab-content').forEach(el=>el.classList.remove('active'));
-    a.classList.add('active');
-    document.getElementById(a.dataset.tab).classList.add('active');
-  });
-});
-</script>
+{{ super() }}
+<script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
+<script src="/static/js/admin-analytics.js" defer></script>
 {% endblock %}

--- a/templates/admin_edit_bar_description.html
+++ b/templates/admin_edit_bar_description.html
@@ -1,4 +1,8 @@
 {% extends "layout.html" %}
+{% block page_styles %}
+{{ super() }}
+<link rel="stylesheet" href="/static/css/pages/admin-edit-bar-description.css">
+{% endblock %}
 {% block content %}
 <section class="description-editor">
   <a class="back-link" href="/admin/bars/edit/{{ bar.id }}/info"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_edit_bar_description.back', default='Back to bar info') }}</a>
@@ -20,17 +24,4 @@
     </div>
   </form>
 </section>
-<style>
-.description-editor{max-width:720px;margin-inline:auto;padding-block:var(--space-6,24px);}
-.description-editor .back-link{display:inline-flex;align-items:center;gap:8px;text-decoration:none;opacity:.8;margin-bottom:var(--space-2,8px);}
-.description-editor .back-link:hover{opacity:1;}
-.description-editor .intro{margin:var(--space-2,8px) 0 var(--space-5,20px);opacity:.85;}
-.description-editor .field-group{display:flex;flex-direction:column;margin-bottom:var(--space-4,16px);}
-.description-editor textarea{min-height:110px;padding:12px 14px;border-radius:var(--radius-xl,16px);border:1px solid rgba(15,23,42,.12);font-size:1rem;line-height:1.5;}
-.description-editor textarea:focus{outline:2px solid rgba(91,45,238,.25);outline-offset:2px;}
-.description-editor .help{margin-top:6px;opacity:.7;font-size:.875rem;}
-.description-editor .form-actions{margin-top:var(--space-5,20px);display:flex;justify-content:flex-end;}
-.description-editor .alert{margin-bottom:var(--space-4,16px);padding:12px 14px;border-radius:var(--radius-lg,12px);}
-.alert-danger{background:#fee2e2;color:#991b1b;}
-</style>
 {% endblock %}

--- a/templates/admin_notifications.html
+++ b/templates/admin_notifications.html
@@ -74,32 +74,10 @@
     </div>
   </div>
 </div>
+{% endblock %}
 
-<script>
-(function(){
-  const blocker = document.getElementById('deleteBlocker');
-  const cancelBtn = document.querySelector('.js-cancel-delete');
-  const confirmBtn = document.querySelector('.js-confirm-delete');
-  let targetForm = null;
-
-  document.querySelectorAll('.js-delete-note').forEach(btn => {
-    btn.addEventListener('click', e => {
-      e.preventDefault();
-      const id = btn.dataset.noteId;
-      targetForm = document.getElementById('delete-note-' + id);
-      if(blocker) blocker.hidden = false;
-    });
-  });
-
-  cancelBtn?.addEventListener('click', () => {
-    if(blocker) blocker.hidden = true;
-    targetForm = null;
-  });
-
-  confirmBtn?.addEventListener('click', () => {
-    if(targetForm) targetForm.submit();
-  });
-})();
-</script>
+{% block scripts %}
+{{ super() }}
+<script src="/static/js/admin-notifications.js" defer></script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- move the admin bar description editor styles into `admin-edit-bar-description.css` and load them via the template
- extract the admin analytics tab styling and chart bootstrapping into dedicated CSS/JS assets fed by template JSON
- shift the admin notifications delete-confirm behaviour into `admin-notifications.js`

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da6201af288320a8a0c06b05291338