### PR TITLE
Extract inline assets from key pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@
   - `templates/admin_analytics.html` imports `/static/css/pages/admin-analytics.css` and `/static/js/admin-analytics.js` (Chart.js stays on the CDN and page data hydrates via `#adminAnalyticsData`).
   - `templates/admin_notifications.html` imports `/static/js/admin-notifications.js` for delete confirmation handling.
   - `templates/admin_bars.html` imports `/static/js/admin-bars.js` for table filtering and deletion confirmation.
+  - `templates/admin_bar_users.html` imports `/static/js/admin-bar-users.js` for staff filtering and removal confirmation dialogs.
   - `templates/admin_notification_view.html` imports `/static/js/admin-notification-view.js` for delete confirmation handling.
   - `templates/admin_ip_block.html` imports `/static/js/admin-ip-block.js` for delete confirmation handling.
 - Footer marketing pages (About, Help Center, For Bars, Terms) live in `templates/about.html`, `templates/help_center.html`, `templates/for_bars.html`, and `templates/terms.html`; they share the `.static-page` styles defined in `static/css/components.css`.
@@ -53,6 +54,8 @@
 - Body uses a column flex layout with `min-height: 100dvh` and grows `<main>` so the footer always anchors to the bottom even on sparse pages.
 - Display orders page uses `/static/css/pages/display-orders.css` for layout adjustments and `/static/js/display-page.js` to bootstrap `initDisplay` via the `data-bar-id` attribute.
 - Bartender and bar admin order dashboards share `/static/css/pages/bar-orders.css` for layout and `/static/js/bar-orders.js` to bootstrap `initBartender` (reading the `data-bar-id` attribute) and handle pause toggles.
+- `templates/bar_detail.html` imports `/static/js/bar-detail.js` to sync pause state and choose the best directions link.
+- Wallet top-up page `templates/topup.html` imports `/static/js/topup.js` for preset amounts and checkout redirects.
 - Admin payments search logic now lives in `/static/js/admin-payments.js`; templates only render markup.
 - Admin users search filtering now runs through `/static/js/admin-users.js` loaded with `defer`.
 - Registration username lowercase enforcement is handled by `/static/js/register.js` loaded with `defer`.

--- a/static/js/admin-bar-users.js
+++ b/static/js/admin-bar-users.js
@@ -1,0 +1,85 @@
+(function () {
+  const input = document.getElementById('userSearch');
+  const tableBody = document.querySelector('.users-table tbody');
+
+  if (input && tableBody) {
+    const rows = Array.from(tableBody.rows);
+
+    const normalise = (value) => {
+      return (value || '')
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .trim();
+    };
+
+    const applyFilter = () => {
+      const query = normalise(input.value);
+      rows.forEach((row) => {
+        const nameCell = row.cells[0] ? row.cells[0].textContent : '';
+        const emailCell = row.cells[1] ? row.cells[1].textContent : '';
+        const matches = !query || normalise(nameCell).includes(query) || normalise(emailCell).includes(query);
+        row.style.display = matches ? '' : 'none';
+      });
+    };
+
+    const debounce = (fn, delay) => {
+      let timeoutId;
+      return (...args) => {
+        window.clearTimeout(timeoutId);
+        timeoutId = window.setTimeout(() => fn(...args), delay);
+      };
+    };
+
+    input.addEventListener('input', debounce(applyFilter, 120));
+
+    const clearButton = document.querySelector('.users-search .clear');
+    if (clearButton) {
+      clearButton.addEventListener('click', () => {
+        input.value = '';
+        applyFilter();
+        input.focus();
+      });
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    const presetQuery = params.get('q');
+    if (presetQuery) {
+      input.value = presetQuery;
+      applyFilter();
+    }
+  }
+
+  const blocker = document.getElementById('removeBlocker');
+  const cancelButton = document.querySelector('.js-cancel-remove');
+  const confirmButton = document.querySelector('.js-confirm-remove');
+  let targetForm = null;
+
+  document.querySelectorAll('.js-remove-user').forEach((button) => {
+    button.addEventListener('click', (event) => {
+      event.preventDefault();
+      const userId = button.dataset.userId;
+      targetForm = document.getElementById(`remove_${userId}`);
+      if (blocker) {
+        blocker.hidden = false;
+      }
+    });
+  });
+
+  if (cancelButton) {
+    cancelButton.addEventListener('click', () => {
+      if (blocker) {
+        blocker.hidden = true;
+      }
+      targetForm = null;
+    });
+  }
+
+  if (confirmButton) {
+    confirmButton.addEventListener('click', () => {
+      if (targetForm) {
+        targetForm.submit();
+      }
+    });
+  }
+})();

--- a/static/js/bar-detail.js
+++ b/static/js/bar-detail.js
@@ -1,0 +1,31 @@
+(function () {
+  const barDetail = document.querySelector('.bar-detail');
+  if (!barDetail) {
+    return;
+  }
+
+  const pausedValue = barDetail.dataset.orderingPaused;
+  if (typeof pausedValue !== 'undefined') {
+    window.orderingPaused = pausedValue === 'true';
+  }
+})();
+
+(function () {
+  const directionsLink = document.querySelector('.bar-directions');
+  if (!directionsLink) {
+    return;
+  }
+
+  const appleUrl = directionsLink.getAttribute('data-apple-url');
+  const googleUrl = directionsLink.getAttribute('data-google-url');
+  const userAgent = window.navigator.userAgent || '';
+  const platform = window.navigator.platform || '';
+  const isAppleDevice = /iPad|iPhone|iPod/.test(userAgent) ||
+    (platform === 'MacIntel' && typeof window.navigator.standalone !== 'undefined');
+
+  if (isAppleDevice && appleUrl) {
+    directionsLink.setAttribute('href', appleUrl);
+  } else if (googleUrl) {
+    directionsLink.setAttribute('href', googleUrl);
+  }
+})();

--- a/static/js/topup.js
+++ b/static/js/topup.js
@@ -1,0 +1,67 @@
+(function () {
+  const form = document.getElementById('topupForm');
+  if (!form) {
+    return;
+  }
+
+  const amountInput = document.getElementById('amount');
+  if (!amountInput) {
+    return;
+  }
+
+  const submitBtn = form.querySelector('button[type="submit"]');
+  if (!submitBtn) {
+    return;
+  }
+
+  const invalidAmountMessage = form.dataset.invalidAmountMessage || 'Invalid amount';
+  const errorMessage = form.dataset.errorMessage || 'Unable to start top-up';
+
+  form.querySelectorAll('button[data-amount]').forEach((button) => {
+    button.addEventListener('click', () => {
+      amountInput.value = button.dataset.amount || '';
+    });
+  });
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (submitBtn.disabled) {
+      return;
+    }
+
+    const amount = parseFloat(amountInput.value);
+    const minAmount = parseFloat(amountInput.min) || 0;
+    if (!Number.isFinite(amount) || amount < minAmount) {
+      window.alert(invalidAmountMessage);
+      return;
+    }
+
+    submitBtn.disabled = true;
+    const originalDisplay = submitBtn.style.display;
+    submitBtn.style.display = 'none';
+
+    try {
+      const response = await fetch('/api/topup/init', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ amount })
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        if (data && data.paymentPageUrl) {
+          window.location.replace(data.paymentPageUrl);
+          return;
+        }
+      }
+
+      window.alert(errorMessage);
+      submitBtn.disabled = false;
+      submitBtn.style.display = originalDisplay;
+    } catch (error) {
+      window.alert(errorMessage);
+      submitBtn.disabled = false;
+      submitBtn.style.display = originalDisplay;
+    }
+  });
+})();

--- a/templates/admin_bar_users.html
+++ b/templates/admin_bar_users.html
@@ -82,57 +82,9 @@
   </div>
 </div>
 
-<script>
-(function(){
-  const input = document.getElementById('userSearch');
-  const tbody = document.querySelector('.users-table tbody');
-  if(input && tbody){
-    const rows = Array.from(tbody.rows);
-    const norm = s => (s||'').toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g,'').trim();
+{% endblock %}
 
-    function applyFilter(){
-      const q = norm(input.value);
-      rows.forEach(tr=>{
-        const name = tr.cells && tr.cells[0] ? tr.cells[0].textContent : '';
-        const email = tr.cells && tr.cells[1] ? tr.cells[1].textContent : '';
-        const match = !q || norm(name).includes(q) || norm(email).includes(q);
-        tr.style.display = match ? '' : 'none';
-      });
-    }
-    function debounce(fn,ms){let t;return (...a)=>{clearTimeout(t);t=setTimeout(()=>fn.apply(this,a),ms)}}
-    const run = debounce(applyFilter,120);
-
-    input.addEventListener('input', run);
-    document.querySelector('.users-search .clear')?.addEventListener('click',()=>{
-      input.value=''; applyFilter(); input.focus();
-    });
-
-    const qs = new URLSearchParams(location.search);
-    const q = qs.get('q'); if(q){ input.value=q; applyFilter(); }
-  }
-
-  const blocker = document.getElementById('removeBlocker');
-  const cancelBtn = document.querySelector('.js-cancel-remove');
-  const confirmBtn = document.querySelector('.js-confirm-remove');
-  let targetForm = null;
-
-  document.querySelectorAll('.js-remove-user').forEach(btn => {
-    btn.addEventListener('click', e => {
-      e.preventDefault();
-      const userId = btn.dataset.userId;
-      targetForm = document.getElementById('remove_' + userId);
-      if(blocker) blocker.hidden = false;
-    });
-  });
-
-  cancelBtn?.addEventListener('click', () => {
-    if(blocker) blocker.hidden = true;
-    targetForm = null;
-  });
-
-  confirmBtn?.addEventListener('click', () => {
-    targetForm?.submit();
-  });
-})();
-</script>
+{% block scripts %}
+{{ super() }}
+<script src="/static/js/admin-bar-users.js" defer></script>
 {% endblock %}

--- a/templates/bar_detail.html
+++ b/templates/bar_detail.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 {% block content %}
 {% set fallback_img = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCA0MDAgMjIxJz48cmVjdCB3aWR0aD0nNDAwJyBoZWlnaHQ9JzIyNScgZmlsbD0nJTIzZjFmM2Y1Jy8+PC9zdmc+" %}
-<section class="bar-detail" data-latitude="{{ bar.latitude }}" data-longitude="{{ bar.longitude }}" data-rating="{{ bar.rating or '' }}" data-distance_km="{{ bar.distance_km or '' }}" itemscope itemtype="https://schema.org/BarOrPub">
+<section class="bar-detail" data-latitude="{{ bar.latitude }}" data-longitude="{{ bar.longitude }}" data-rating="{{ bar.rating or '' }}" data-distance_km="{{ bar.distance_km or '' }}" data-ordering-paused="{{ 'true' if bar.ordering_paused else 'false' }}" itemscope itemtype="https://schema.org/BarOrPub">
   <div class="bar-cover-wrapper">
     {% if bar.photo_url %}
     <img class="bar-cover" src="{{ bar.photo_url }}" alt="{{ bar.name }} photo" itemprop="image" loading="lazy" decoding="async" width="400" height="225" srcset="{{ bar.photo_url }} 400w, {{ bar.photo_url }} 800w" sizes="(max-width: 600px) 100vw, 400px" onerror="this.src='{{ fallback_img }}';this.onerror=null;">
@@ -116,27 +116,6 @@
 {% endblock %}
 
 {% block scripts %}
-<script>
-  window.orderingPaused = {{ 'true' if bar.ordering_paused else 'false' }};
-</script>
-<script>
-  (function() {
-    var directionsLink = document.querySelector('.bar-directions');
-    if (!directionsLink) {
-      return;
-    }
-
-    var appleUrl = directionsLink.getAttribute('data-apple-url');
-    var googleUrl = directionsLink.getAttribute('data-google-url');
-    var userAgent = window.navigator.userAgent || '';
-    var platform = window.navigator.platform || '';
-    var isAppleDevice = /iPad|iPhone|iPod/.test(userAgent) || (platform === 'MacIntel' && typeof window.navigator.standalone !== 'undefined');
-
-    if (isAppleDevice && appleUrl) {
-      directionsLink.setAttribute('href', appleUrl);
-    } else if (googleUrl) {
-      directionsLink.setAttribute('href', googleUrl);
-    }
-  })();
-</script>
+{{ super() }}
+<script src="/static/js/bar-detail.js" defer></script>
 {% endblock %}

--- a/templates/topup.html
+++ b/templates/topup.html
@@ -3,7 +3,9 @@
 <div class="auth-card">
   <h1>{{ _('topup.title', default='Top Up Credit') }}</h1>
   <p class="topup-note">{{ _('topup.notice.minimum', default='Minimum top-up is 10 CHF.') }}</p>
-  <form id="topupForm">
+  <form id="topupForm"
+        data-invalid-amount-message="{{ _('topup.alerts.invalid_amount', default='Invalid amount') }}"
+        data-error-message="{{ _('topup.alerts.failed', default='Unable to start top-up') }}">
     <label for="amount">{{ _('topup.form.amount_label', default='Amount') }}
       <input id="amount" name="amount" type="number" min="10" step="0.05" required inputmode="decimal">
     </label>
@@ -15,48 +17,9 @@
     <button class="btn btn--primary" type="submit">{{ _('topup.form.submit', default='Top up with card') }}</button>
   </form>
 </div>
-<script>
-  const amountInput = document.getElementById('amount');
-  document.querySelectorAll('button[data-amount]').forEach(btn => {
-    btn.addEventListener('click', () => {
-      amountInput.value = btn.dataset.amount;
-    });
-  });
-  const form = document.getElementById('topupForm');
-  const submitBtn = form.querySelector('button[type="submit"]');
-  const invalidAmountMessage = {{ _('topup.alerts.invalid_amount', default='Invalid amount')|tojson }};
-  const errorMessage = {{ _('topup.alerts.failed', default='Unable to start top-up')|tojson }};
-  form.addEventListener('submit', async (e) => {
-    e.preventDefault();
-    if (submitBtn.disabled) return;
-    const amount = parseFloat(amountInput.value);
-    if (!Number.isFinite(amount) || amount < 10) {
-      alert(invalidAmountMessage);
-      return;
-    }
-    submitBtn.disabled = true;
-    submitBtn.style.display = 'none';
-    try {
-      const resp = await fetch('/api/topup/init', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ amount })
-      });
-      if (resp.ok) {
-        const data = await resp.json();
-        if (data.paymentPageUrl) {
-          window.location.replace(data.paymentPageUrl);
-          return;
-        }
-      }
-      alert(errorMessage);
-      submitBtn.disabled = false;
-      submitBtn.style.display = '';
-    } catch {
-      alert(errorMessage);
-      submitBtn.disabled = false;
-      submitBtn.style.display = '';
-    }
-  });
-</script>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script src="/static/js/topup.js" defer></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- move the bar detail pause flag and directions logic into `/static/js/bar-detail.js` and expose pause state via data attributes
- extract the wallet top-up preset/checkout code into `/static/js/topup.js`, sourcing copy from data attributes
- shift admin bar user search and confirmation behavior into `/static/js/admin-bar-users.js` and document the new assets in `AGENTS.md`

## Testing
- pytest tests/test_bar_detail_open_status.py tests/test_topup_popup.py

------
https://chatgpt.com/codex/tasks/task_e_68da66842cdc8320804c493332b3afb1