### PR TITLE
Refine admin inline asset usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@
   - `templates/admin_notification_view.html` also imports `/static/css/pages/admin-notification-view.css` for action spacing and hidden delete form styling.
   - `templates/admin_audit_logs.html` imports `/static/js/admin-audit-logs.js` and `/static/css/pages/admin-audit-logs.css` to keep the filter form responsive without inline styles.
   - `templates/admin_ip_block.html` imports `/static/js/admin-ip-block.js` for delete confirmation handling.
+  - `templates/admin_new_bar.html` imports `/static/css/pages/admin-new-bar.css` for map sizing alongside Leaflet assets.
 - Footer marketing pages (About, Help Center, For Bars, Terms) live in `templates/about.html`, `templates/help_center.html`, `templates/for_bars.html`, and `templates/terms.html`; they share the `.static-page` styles defined in `static/css/components.css`.
   - Support contact details for these static pages pull from Jinja globals defined in `main.py` (`SUPPORT_EMAIL`, `SUPPORT_NUMBER`, `TERMS_VERSION`, etc.); update those constants to change emails, phone numbers, or term dates sitewide.
   - The About page intro copy reads "Built and operated by Siply..." followed by "We’re building a modern ordering experience..." to highlight Siply's role and hospitality focus.

--- a/static/css/pages/admin-new-bar.css
+++ b/static/css/pages/admin-new-bar.css
@@ -1,0 +1,4 @@
+.editbar .map-card #map,
+.editbar .map-card .admin-new-bar__map {
+  height: 400px;
+}

--- a/static/js/admin-bar-users.js
+++ b/static/js/admin-bar-users.js
@@ -1,4 +1,11 @@
 (function () {
+  const searchForm = document.querySelector('.users-search');
+  if (searchForm) {
+    searchForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+    });
+  }
+
   const input = document.getElementById('userSearch');
   const tableBody = document.querySelector('.users-table tbody');
 

--- a/templates/admin_bar_users.html
+++ b/templates/admin_bar_users.html
@@ -25,7 +25,7 @@
       </form>
     </details>
     <div class="toolbar-actions">
-      <form class="users-search" role="search" aria-label="{{ _('admin_bar_users.search.aria', default='Search users') }}" onsubmit="return false">
+      <form class="users-search" role="search" aria-label="{{ _('admin_bar_users.search.aria', default='Search users') }}">
         <i class="bi bi-search" aria-hidden="true"></i>
         <input id="userSearch" type="search" inputmode="search" autocomplete="off"
                placeholder="{{ _('admin_bar_users.search.placeholder', default='Search users by name or email…') }}" aria-label="{{ _('admin_bar_users.search.input_aria', default='Search users by name or email') }}">
@@ -60,7 +60,7 @@
             <div class="actions-group">
               <button type="button" class="btn-danger-soft js-remove-user" data-user-id="{{ u.id }}">{{ _('admin_bar_users.actions.remove', default='Remove') }}</button>
             </div>
-            <form id="remove_{{ u.id }}" method="post" action="/admin/bars/{{ bar.id }}/users" style="display:none">
+            <form id="remove_{{ u.id }}" method="post" action="/admin/bars/{{ bar.id }}/users" hidden>
               <input type="hidden" name="action" value="remove">
               <input type="hidden" name="user_id" value="{{ u.id }}">
             </form>

--- a/templates/admin_new_bar.html
+++ b/templates/admin_new_bar.html
@@ -1,13 +1,17 @@
 {% extends "layout.html" %}
-{% block content %}
+{% block page_styles %}
+{{ super() }}
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
+<link rel="stylesheet" href="/static/css/pages/admin-new-bar.css">
+{% endblock %}
+{% block content %}
 <section class="editbar">
   <a class="back-link" href="/admin/bars"><i class="bi bi-chevron-left" aria-hidden="true"></i> {{ _('admin_new_bar.back', default='Back to Bars') }}</a>
   <h1>{{ _('admin_new_bar.title', default='Create New Bar') }}</h1>
   {% if error %}<p class="error">{{ error }}</p>{% endif %}
 
   <div class="card map-card">
-    <div id="map" style="height:400px;"></div>
+    <div id="map" class="admin-new-bar__map"></div>
   </div>
 
   <form method="post" action="/admin/bars/new" enctype="multipart/form-data" class="editbar-form">
@@ -123,7 +127,10 @@
     </div>
   </form>
 </section>
+{% endblock %}
 
+{% block scripts %}
+{{ super() }}
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script src="/static/js/admin-new-bar.js" defer></script>
 {% endblock %}

--- a/templates/admin_notifications.html
+++ b/templates/admin_notifications.html
@@ -56,7 +56,7 @@
               <a href="/admin/notifications/{{ n.id }}" class="btn-outline">{{ _('admin_notifications.sent.actions.view', default='View') }}</a>
               <button type="button" class="btn-danger-soft js-delete-note" data-note-id="{{ n.id }}">{{ _('admin_notifications.sent.actions.delete', default='Delete') }}</button>
             </div>
-            <form id="delete-note-{{ n.id }}" method="post" action="/admin/notifications/{{ n.id }}/delete" style="display:none;"></form>
+            <form id="delete-note-{{ n.id }}" method="post" action="/admin/notifications/{{ n.id }}/delete" hidden></form>
           </td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
## Summary
- load the admin new bar map styling from a dedicated stylesheet and move Leaflet assets into the head/scripts blocks
- replace inline styles with semantic hidden forms on the admin bar users and notifications pages and prevent the search form from submitting via JavaScript
- document the new stylesheet in AGENTS.md for quicker reference

## Testing
- pytest tests/test_admin_delete_user_notifications.py::test_delete_user_removes_notifications_and_logs -q
- pytest tests/test_admin_notification_view_delete.py::test_view_and_delete_notification -q *(fails: sqlalchemy.exc.InvalidRequestError: Could not refresh instance '<AuditLog at 0x7fa6afa4af50>')*


------
https://chatgpt.com/codex/tasks/task_e_68da72a9fc9c8320b92447f74a446a29