### PR TITLE
Separate inline assets on admin pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,10 @@
   - `templates/bar_manage_categories.html` imports `/static/css/pages/bar-manage-categories.css` and `/static/js/bar-manage-categories.js`.
   - `templates/admin_edit_bar_description.html` imports `/static/css/pages/admin-edit-bar-description.css`.
   - `templates/admin_analytics.html` imports `/static/css/pages/admin-analytics.css` and `/static/js/admin-analytics.js` (Chart.js stays on the CDN and page data hydrates via `#adminAnalyticsData`).
+  - `templates/admin_dashboard.html` imports `/static/js/admin-dashboard.js` to handle the delete-all-orders confirmation without inline handlers.
   - `templates/admin_notifications.html` imports `/static/js/admin-notifications.js` for delete confirmation handling.
   - `templates/admin_bars.html` imports `/static/js/admin-bars.js` for table filtering and deletion confirmation.
+  - `templates/admin_bars.html` also imports `/static/css/pages/admin-bars.css` to keep hidden delete forms out of the layout flow.
   - `templates/admin_bar_users.html` imports `/static/js/admin-bar-users.js` for staff filtering and removal confirmation dialogs.
   - `templates/admin_notification_view.html` imports `/static/js/admin-notification-view.js` for delete confirmation handling.
   - `templates/admin_notification_view.html` also imports `/static/css/pages/admin-notification-view.css` for action spacing and hidden delete form styling.

--- a/static/css/pages/admin-bars.css
+++ b/static/css/pages/admin-bars.css
@@ -1,0 +1,3 @@
+.admin-bars__delete-form {
+  display: none;
+}

--- a/static/js/admin-bars.js
+++ b/static/js/admin-bars.js
@@ -31,6 +31,9 @@
   const runFilter = debounce(applyFilter, 120);
 
   input.addEventListener('input', runFilter);
+  document.querySelector('.bars-search')?.addEventListener('submit', (event) => {
+    event.preventDefault();
+  });
   document.querySelector('.bars-search .clear')?.addEventListener('click', () => {
     input.value = '';
     applyFilter();

--- a/static/js/admin-dashboard.js
+++ b/static/js/admin-dashboard.js
@@ -1,0 +1,19 @@
+(function(){
+  function init(){
+    const form = document.querySelector('.admin-dashboard__clear-orders');
+    if(!form) return;
+
+    const message = form.dataset.confirmMessage || 'Delete all orders?';
+    form.addEventListener('submit', (event) => {
+      if(!window.confirm(message)){
+        event.preventDefault();
+      }
+    });
+  }
+
+  if(document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/static/js/admin-users.js
+++ b/static/js/admin-users.js
@@ -35,7 +35,14 @@
     const run = debounce(applyFilter, 120);
     input.addEventListener('input', run);
 
-    const clearButton = document.querySelector('.users-search .clear');
+    const form = document.querySelector('.users-search');
+    if(form){
+      form.addEventListener('submit', (event) => {
+        event.preventDefault();
+      });
+    }
+
+    const clearButton = form ? form.querySelector('.clear') : document.querySelector('.users-search .clear');
     if(clearButton){
       clearButton.addEventListener('click', () => {
         input.value = '';

--- a/templates/admin_bars.html
+++ b/templates/admin_bars.html
@@ -1,4 +1,8 @@
 {% extends "layout.html" %}
+{% block page_styles %}
+{{ super() }}
+<link rel="stylesheet" href="/static/css/pages/admin-bars.css">
+{% endblock %}
 {% block content %}
 <section class="bars-page"> <!-- CHANGED -->
   <header class="bars-toolbar"> <!-- CHANGED -->
@@ -8,7 +12,7 @@
       <p class="subtitle">{{ _('admin_bars.subtitle', default='Create, edit and manage venues on the platform.') }}</p> <!-- CHANGED -->
     </div>
     <div class="toolbar-actions"> <!-- CHANGED -->
-      <form class="bars-search" role="search" aria-label="{{ _('admin_bars.search.aria', default='Search bars') }}" onsubmit="return false"> <!-- CHANGED -->
+      <form class="bars-search" role="search" aria-label="{{ _('admin_bars.search.aria', default='Search bars') }}"> <!-- CHANGED -->
         <i class="bi bi-search" aria-hidden="true"></i>
         <input id="barsSearch" type="search" inputmode="search" autocomplete="off"
                placeholder="{{ _('admin_bars.search.placeholder', default='Search bars by name…') }}" aria-label="{{ _('admin_bars.search.input_aria', default='Search bars by name') }}">
@@ -47,9 +51,9 @@
             </div>
             <form
               id="delete-bar-{{ bar.id }}"
+              class="admin-bars__delete-form"
               method="post"
               action="{{ request.url_for('delete_bar', bar_id=bar.id) }}"
-              style="display:none;"
             ></form>
           </td>
         </tr>

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -77,12 +77,22 @@
       <article class="card quick-card danger"><!-- CHANGED -->
         <h3 class="card-title"><i class="bi bi-exclamation-octagon"></i> {{ _('admin_dashboard.cards.danger.title', default='Danger Zone') }}</h3>
         <p>{{ _('admin_dashboard.cards.danger.description', default='Delete all orders for a clean slate.') }}</p><!-- CHANGED -->
-        <form method="post" action="/admin/orders/clear" onsubmit="return confirm({{ _('admin_dashboard.danger.confirm', default='Delete all orders?')|tojson }});">
+        <form
+          method="post"
+          action="/admin/orders/clear"
+          class="admin-dashboard__clear-orders"
+          data-confirm-message="{{ _('admin_dashboard.danger.confirm', default='Delete all orders?')|e }}"
+        >
           <button class="btn btn--danger" type="submit">{{ _('admin_dashboard.cards.danger.action', default='Delete All Orders') }}</button>
         </form>
       </article>
     </div>
   </section>
 </section>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script src="/static/js/admin-dashboard.js" defer></script>
 {% endblock %}
 

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -13,7 +13,7 @@
         <input type="password" name="password" placeholder="{{ _('admin_users.create.password_placeholder', default='Password') }}" required>
         <button class="btn btn--primary" type="submit">{{ _('admin_users.create.submit', default='Add User') }}</button>
       </form>
-      <form class="users-search" role="search" aria-label="{{ _('admin_users.search.aria', default='Search users') }}" onsubmit="return false">
+      <form class="users-search" role="search" aria-label="{{ _('admin_users.search.aria', default='Search users') }}">
         <i class="bi bi-search" aria-hidden="true"></i>
         <input id="userSearch" type="search" inputmode="search" autocomplete="off"
                placeholder="{{ _('admin_users.search.placeholder', default='Search users by name or email…') }}" aria-label="{{ _('admin_users.search.input_aria', default='Search users by name or email') }}">


### PR DESCRIPTION
## Summary
- move admin bars and users search forms off inline handlers and add a dedicated stylesheet for hidden delete forms
- add an admin dashboard script that drives the delete-all-orders confirmation dialog via data attributes
- document the new assets in AGENTS.md for easier discovery

## Testing
- pytest *(fails: existing InvalidRequestError refresh failures and run interrupted after multiple failures)*

------
https://chatgpt.com/codex/tasks/task_e_68da7be633b08320aea61357dc661831