### PR TITLE
Move image fallbacks to scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,9 @@
 - Body uses a column flex layout with `min-height: 100dvh` and grows `<main>` so the footer always anchors to the bottom even on sparse pages.
 - Display orders page uses `/static/css/pages/display-orders.css` for layout adjustments and `/static/js/display-page.js` to bootstrap `initDisplay` via the `data-bar-id` attribute.
 - Bartender and bar admin order dashboards share `/static/css/pages/bar-orders.css` for layout and `/static/js/bar-orders.js` to bootstrap `initBartender` (reading the `data-bar-id` attribute) and handle pause toggles.
-- `templates/bar_detail.html` imports `/static/js/bar-detail.js` to sync pause state and choose the best directions link.
+- `templates/bar_detail.html` imports `/static/js/bar-detail.js` to sync pause state, choose the best directions link, and apply fallback imagery when bar assets fail to load.
+- `templates/home.html` loads `/static/js/home.js` to attach fallback handlers to hero and bar card images.
+- `templates/search.html` relies on `/static/js/search.js` for filtering, card metadata rendering, and image fallback handling instead of inline events.
 - Wallet top-up page `templates/topup.html` imports `/static/js/topup.js` for preset amounts and checkout redirects.
 - Admin payments search logic now lives in `/static/js/admin-payments.js`; templates only render markup.
 - Admin users search filtering now runs through `/static/js/admin-users.js` loaded with `defer`.

--- a/static/js/bar-detail.js
+++ b/static/js/bar-detail.js
@@ -11,6 +11,34 @@
 })();
 
 (function () {
+  const images = document.querySelectorAll('img[data-fallback-src]');
+  if (!images.length) {
+    return;
+  }
+
+  images.forEach((img) => {
+    const fallbackSrc = img.dataset.fallbackSrc;
+    if (!fallbackSrc) {
+      return;
+    }
+
+    const handleError = () => {
+      if (img.dataset.fallbackApplied === 'true') {
+        return;
+      }
+      img.dataset.fallbackApplied = 'true';
+      img.src = fallbackSrc;
+    };
+
+    img.addEventListener('error', handleError, { once: true });
+
+    if (img.complete && img.naturalWidth === 0) {
+      handleError();
+    }
+  });
+})();
+
+(function () {
   const directionsLink = document.querySelector('.bar-directions');
   if (!directionsLink) {
     return;

--- a/static/js/home.js
+++ b/static/js/home.js
@@ -1,0 +1,23 @@
+(function () {
+  const images = document.querySelectorAll('img[data-fallback-src]');
+  images.forEach((img) => {
+    const fallbackSrc = img.dataset.fallbackSrc;
+    if (!fallbackSrc) {
+      return;
+    }
+
+    const handleError = () => {
+      if (img.dataset.fallbackApplied === 'true') {
+        return;
+      }
+      img.dataset.fallbackApplied = 'true';
+      img.src = fallbackSrc;
+    };
+
+    img.addEventListener('error', handleError, { once: true });
+
+    if (img.complete && img.naturalWidth === 0) {
+      handleError();
+    }
+  });
+})();

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -14,6 +14,30 @@ function toKm(v) {
 
 const norm = s => (s || '').normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
 
+function applyImageFallback(root = document) {
+  const images = root.querySelectorAll('img[data-fallback-src]');
+  images.forEach((img) => {
+    const fallbackSrc = img.dataset.fallbackSrc;
+    if (!fallbackSrc) {
+      return;
+    }
+
+    const handleError = () => {
+      if (img.dataset.fallbackApplied === 'true') {
+        return;
+      }
+      img.dataset.fallbackApplied = 'true';
+      img.src = fallbackSrc;
+    };
+
+    img.addEventListener('error', handleError, { once: true });
+
+    if (img.complete && img.naturalWidth === 0) {
+      handleError();
+    }
+  });
+}
+
 function haversineKm(lat1, lon1, lat2, lon2) {
   const R = 6371;
   const toRad = d => d * Math.PI / 180;
@@ -93,6 +117,8 @@ function applyFilters(bars, state) {
 }
 
 document.addEventListener('DOMContentLoaded', async () => {
+  applyImageFallback();
+
   const searchInput = document.getElementById('barSearch');
   const filterBtn = document.getElementById('filterBtn');
   const filterOverlay = document.getElementById('filterOverlay');

--- a/templates/bar_detail.html
+++ b/templates/bar_detail.html
@@ -4,7 +4,7 @@
 <section class="bar-detail" data-latitude="{{ bar.latitude }}" data-longitude="{{ bar.longitude }}" data-rating="{{ bar.rating or '' }}" data-distance_km="{{ bar.distance_km or '' }}" data-ordering-paused="{{ 'true' if bar.ordering_paused else 'false' }}" itemscope itemtype="https://schema.org/BarOrPub">
   <div class="bar-cover-wrapper">
     {% if bar.photo_url %}
-    <img class="bar-cover" src="{{ bar.photo_url }}" alt="{{ bar.name }} photo" itemprop="image" loading="lazy" decoding="async" width="400" height="225" srcset="{{ bar.photo_url }} 400w, {{ bar.photo_url }} 800w" sizes="(max-width: 600px) 100vw, 400px" onerror="this.src='{{ fallback_img }}';this.onerror=null;">
+    <img class="bar-cover" src="{{ bar.photo_url }}" alt="{{ bar.name }} photo" itemprop="image" loading="lazy" decoding="async" width="400" height="225" srcset="{{ bar.photo_url }} 400w, {{ bar.photo_url }} 800w" sizes="(max-width: 600px) 100vw, 400px" data-fallback-src="{{ fallback_img }}">
     {% else %}
     <img class="bar-cover" src="{{ fallback_img }}" alt="" loading="lazy" width="400" height="225">
     {% endif %}
@@ -92,7 +92,7 @@
       <li>
         <article class="product-card">
           <div class="thumb-wrapper">
-            <img class="thumb" src="{{ product.photo_url }}" alt="{{ display_name }} photo" itemprop="image" loading="lazy" decoding="async" width="400" height="225" srcset="{{ product.photo_url }} 400w, {{ product.photo_url }} 800w" sizes="(max-width: 600px) 100vw, 400px" onerror="this.src='{{ fallback_img }}';this.onerror=null;">
+            <img class="thumb" src="{{ product.photo_url }}" alt="{{ display_name }} photo" itemprop="image" loading="lazy" decoding="async" width="400" height="225" srcset="{{ product.photo_url }} 400w, {{ product.photo_url }} 800w" sizes="(max-width: 600px) 100vw, 400px" data-fallback-src="{{ fallback_img }}">
           </div>
           <h3 class="title">{{ display_name }}</h3>
           <div class="card-body">

--- a/templates/home.html
+++ b/templates/home.html
@@ -35,7 +35,7 @@
         <a class="bar-card{% if bar.is_open_now %} is-open{% endif %}" href="/bars/{{ bar.id }}" aria-label="{{ _('home.bar_card.open_label', bar_name=bar.name, default='Open {bar_name}') }}" data-name="{{ bar.name|lower }}" data-address="{{ bar.address|lower }}" data-city="{{ bar.city|lower }}" data-state="{{ bar.state|lower }}" data-latitude="{{ bar.latitude }}" data-longitude="{{ bar.longitude }}" data-rating="{{ bar.rating or '' }}" data-distance_km="{{ bar.distance_km or '' }}" data-categories="{{ bar.bar_categories|lower if bar.bar_categories else '' }}" data-open="{{ 'true' if bar.is_open_now else 'false' }}" itemscope itemtype="https://schema.org/BarOrPub">
         <div class="thumb-wrapper">
         {% if bar.photo_url %}
-        <img class="thumb" src="{{ bar.photo_url }}" alt="{{ bar.name }} photo" itemprop="image" loading="lazy" decoding="async" width="400" height="225" srcset="{{ bar.photo_url }} 400w, {{ bar.photo_url }} 800w" sizes="(max-width: 600px) 100vw, 400px" onerror="this.src='{{ fallback_img }}';this.onerror=null;">
+        <img class="thumb" src="{{ bar.photo_url }}" alt="{{ bar.name }} photo" itemprop="image" loading="lazy" decoding="async" width="400" height="225" srcset="{{ bar.photo_url }} 400w, {{ bar.photo_url }} 800w" sizes="(max-width: 600px) 100vw, 400px" data-fallback-src="{{ fallback_img }}">
         {% else %}
         <img class="thumb" src="{{ fallback_img }}" alt="" loading="lazy" width="400" height="225">
         {% endif %}
@@ -76,10 +76,10 @@
           <a class="bar-card{% if bar.is_open_now %} is-open{% endif %}" href="/bars/{{ bar.id }}" aria-label="{{ _('home.bar_card.open_label', bar_name=bar.name, default='Open {bar_name}') }}" data-name="{{ bar.name|lower }}" data-address="{{ bar.address|lower }}" data-city="{{ bar.city|lower }}" data-state="{{ bar.state|lower }}" data-latitude="{{ bar.latitude }}" data-longitude="{{ bar.longitude }}" data-rating="{{ bar.rating or '' }}" data-distance_km="{{ bar.distance_km or '' }}" data-categories="{{ bar.bar_categories|lower if bar.bar_categories else '' }}" data-open="{{ 'true' if bar.is_open_now else 'false' }}" itemscope itemtype="https://schema.org/BarOrPub">
         <div class="thumb-wrapper">
         {% if bar.photo_url %}
-        <img class="thumb" src="{{ bar.photo_url }}" alt="{{ bar.name }} photo" itemprop="image" loading="lazy" decoding="async" width="400" height="225" srcset="{{ bar.photo_url }} 400w, {{ bar.photo_url }} 800w" sizes="(max-width: 600px) 100vw, 400px" {% if not recent_bars and loop.first %}fetchpriority="high"{% endif %} onerror="this.src='{{ fallback_img }}';this.onerror=null;">
-        {% else %}
+        <img class="thumb" src="{{ bar.photo_url }}" alt="{{ bar.name }} photo" itemprop="image" loading="lazy" decoding="async" width="400" height="225" srcset="{{ bar.photo_url }} 400w, {{ bar.photo_url }} 800w" sizes="(max-width: 600px) 100vw, 400px" {% if not recent_bars and loop.first %}fetchpriority="high"{% endif %} data-fallback-src="{{ fallback_img }}">
+{% else %}
         <img class="thumb" src="{{ fallback_img }}" alt="" loading="lazy" width="400" height="225">
-        {% endif %}
+{% endif %}
         </div>
         {% if bar.is_open_now %}
         <span class="status status-open">{{ _('home.bar_card.status_open', default='Open now') }}</span>
@@ -126,5 +126,10 @@
   </ul>
 </section>
 
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="/static/js/home.js" defer></script>
 {% endblock %}
 

--- a/templates/search.html
+++ b/templates/search.html
@@ -37,7 +37,7 @@
               <a class="bar-card{% if bar.is_open_now %} is-open{% endif %}" href="/bars/{{ bar.id }}" aria-label="{{ _('home.bar_card.open_label', bar_name=bar.name, default='Open {bar_name}') }}" data-name="{{ bar.name|lower }}" data-address="{{ bar.address|lower }}" data-city="{{ bar.city|lower }}" data-state="{{ bar.state|lower }}" data-latitude="{{ bar.latitude }}" data-longitude="{{ bar.longitude }}" data-rating="{{ bar.rating or '' }}" data-distance_km="{{ bar.distance_km or '' }}" data-categories="{{ bar.bar_categories|lower if bar.bar_categories else '' }}" data-open="{{ 'true' if bar.is_open_now else 'false' }}" itemscope itemtype="https://schema.org/BarOrPub">
           {% if bar.photo_url %}
             <div class="thumb-wrapper">
-            <img src="{{ bar.photo_url }}" alt="{{ bar.name }} photo" class="thumb" loading="lazy" decoding="async" width="400" height="225" srcset="{{ bar.photo_url }} 400w, {{ bar.photo_url }} 800w" sizes="(max-width: 600px) 100vw, 400px" onerror="this.src='{{ fallback_img }}';this.onerror=null;">
+            <img src="{{ bar.photo_url }}" alt="{{ bar.name }} photo" class="thumb" loading="lazy" decoding="async" width="400" height="225" srcset="{{ bar.photo_url }} 400w, {{ bar.photo_url }} 800w" sizes="(max-width: 600px) 100vw, 400px" data-fallback-src="{{ fallback_img }}">
             </div>
           {% else %}
             <div class="thumb-wrapper">
@@ -87,6 +87,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/search.js" defer></script>
+  {{ super() }}
+  <script src="/static/js/search.js" defer></script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- remove inline image fallback handlers from the home, search, and bar detail templates
- add JavaScript-driven fallback logic (including a new home.js) so broken bar images swap to placeholders without inline code
- document the new script usage in AGENTS.md for future maintainability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da82745afc8320a8038b89380b1d70