### PR TITLE
Refine admin search forms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@
   - `templates/admin_notification_view.html` imports `/static/js/admin-notification-view.js` for delete confirmation handling.
   - `templates/admin_notification_view.html` also imports `/static/css/pages/admin-notification-view.css` for action spacing and hidden delete form styling.
   - `templates/admin_audit_logs.html` imports `/static/js/admin-audit-logs.js` and `/static/css/pages/admin-audit-logs.css` to keep the filter form responsive without inline styles.
+  - Admin edit user and admin new notification search toolbars now use `<form class="...-search">` wrappers; page scripts prevent submissions so inline handlers are no longer needed.
   - `templates/admin_ip_block.html` imports `/static/js/admin-ip-block.js` for delete confirmation handling.
   - `templates/admin_new_bar.html` imports `/static/css/pages/admin-new-bar.css` for map sizing alongside Leaflet assets.
   - `templates/register_step1.html` imports `/static/css/pages/register-step1.css` to handle the login prompt alignment.

--- a/static/js/admin-edit-user.js
+++ b/static/js/admin-edit-user.js
@@ -69,8 +69,14 @@
       });
     };
 
+    const form = input.closest('.bars-search');
+    form?.addEventListener('submit', (event) => {
+      event.preventDefault();
+      input.focus();
+    });
+
     input.addEventListener('input', debounce(apply, 120));
-    input.closest('.bars-search')
+    form
       ?.querySelector('.clear')
       ?.addEventListener('click', () => {
         input.value = '';

--- a/static/js/admin-new-notification.js
+++ b/static/js/admin-new-notification.js
@@ -87,8 +87,14 @@
       });
     };
 
+    const form = input.closest('.users-search, .bars-search');
+    form?.addEventListener('submit', (event) => {
+      event.preventDefault();
+      input.focus();
+    });
+
     input.addEventListener('input', debounce(apply, 120));
-    input.closest('.users-search, .bars-search')
+    form
       ?.querySelector('.clear')
       ?.addEventListener('click', () => {
         input.value = '';

--- a/templates/admin_edit_user.html
+++ b/templates/admin_edit_user.html
@@ -52,14 +52,14 @@
 
     <h2>{{ _('admin_edit_user.sections.assigned', default='Assigned Bars') }}</h2>
     <div class="toolbar-actions">
-      <div class="bars-search" role="search" aria-label="{{ _('admin_edit_user.assigned_search.aria', default='Search assigned bars') }}" onsubmit="return false">
+      <form class="bars-search" role="search" aria-label="{{ _('admin_edit_user.assigned_search.aria', default='Search assigned bars') }}">
         <i class="bi bi-search" aria-hidden="true"></i>
         <input id="assignedBarSearch" type="search" inputmode="search" autocomplete="off"
                placeholder="{{ _('admin_edit_user.assigned_search.placeholder', default='Search bars by name…') }}" aria-label="{{ _('admin_edit_user.assigned_search.input_aria', default='Search assigned bars by name') }}">
         <button class="clear" type="button" aria-label="{{ _('admin_edit_user.assigned_search.clear', default='Clear search') }}">
           <i class="bi bi-x-circle" aria-hidden="true"></i>
         </button>
-      </div>
+      </form>
     </div>
     <div class="table-card">
       <table class="bars-table">
@@ -91,14 +91,14 @@
 
     <h2>{{ _('admin_edit_user.sections.assign', default='Assign a Bar') }}</h2>
     <div class="toolbar-actions">
-      <div class="bars-search" role="search" aria-label="{{ _('admin_edit_user.available_search.aria', default='Search available bars') }}" onsubmit="return false">
+      <form class="bars-search" role="search" aria-label="{{ _('admin_edit_user.available_search.aria', default='Search available bars') }}">
         <i class="bi bi-search" aria-hidden="true"></i>
         <input id="availableBarSearch" type="search" inputmode="search" autocomplete="off"
                placeholder="{{ _('admin_edit_user.available_search.placeholder', default='Search bars by name…') }}" aria-label="{{ _('admin_edit_user.available_search.input_aria', default='Search available bars by name') }}">
         <button class="clear" type="button" aria-label="{{ _('admin_edit_user.available_search.clear', default='Clear search') }}">
           <i class="bi bi-x-circle" aria-hidden="true"></i>
         </button>
-      </div>
+      </form>
     </div>
     <div class="table-card">
       <table class="bars-table">

--- a/templates/admin_new_notification.html
+++ b/templates/admin_new_notification.html
@@ -37,13 +37,13 @@
 
     <section id="userSection" hidden>
       <h2>{{ _('admin_new_notification.user_section.title', default='Select User') }}</h2>
-      <div class="users-search" role="search" aria-label="{{ _('admin_new_notification.user_section.search.aria', default='Search users') }}" onsubmit="return false">
+      <form class="users-search" role="search" aria-label="{{ _('admin_new_notification.user_section.search.aria', default='Search users') }}">
         <i class="bi bi-search" aria-hidden="true"></i>
         <input id="userSearch" type="search" inputmode="search" autocomplete="off" placeholder="{{ _('admin_new_notification.user_section.search.placeholder', default='Search users…') }}" aria-label="{{ _('admin_new_notification.user_section.search.input_aria', default='Search users') }}">
         <button class="clear" type="button" aria-label="{{ _('admin_new_notification.user_section.search.clear', default='Clear search') }}">
           <i class="bi bi-x-circle" aria-hidden="true"></i>
         </button>
-      </div>
+      </form>
       <div class="table-card">
         <table class="users-table">
           <thead>
@@ -73,13 +73,13 @@
 
     <section id="barSection" hidden>
       <h2>{{ _('admin_new_notification.bar_section.title', default='Select Bar') }}</h2>
-      <div class="bars-search" role="search" aria-label="{{ _('admin_new_notification.bar_section.search.aria', default='Search bars') }}" onsubmit="return false">
+      <form class="bars-search" role="search" aria-label="{{ _('admin_new_notification.bar_section.search.aria', default='Search bars') }}">
         <i class="bi bi-search" aria-hidden="true"></i>
         <input id="barSearch" type="search" inputmode="search" autocomplete="off" placeholder="{{ _('admin_new_notification.bar_section.search.placeholder', default='Search bars…') }}" aria-label="{{ _('admin_new_notification.bar_section.search.input_aria', default='Search bars') }}">
         <button class="clear" type="button" aria-label="{{ _('admin_new_notification.bar_section.search.clear', default='Clear search') }}">
           <i class="bi bi-x-circle" aria-hidden="true"></i>
         </button>
-      </div>
+      </form>
       <div class="table-card">
         <table class="bars-table">
           <thead>


### PR DESCRIPTION
## Summary
- replace inline onsubmit attributes on admin search toolbars with semantic form wrappers
- update admin edit user and admin new notification scripts to prevent submits and keep search behaviour in JS
- document the new form-based toolbars in the project AGENT notes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da86ef35bc8320b91733dd9f7e8404