### PR TITLE
Fix admin edit user and notification forms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@
   - `templates/admin_notification_view.html` also imports `/static/css/pages/admin-notification-view.css` for action spacing and hidden delete form styling.
   - `templates/admin_audit_logs.html` imports `/static/js/admin-audit-logs.js` and `/static/css/pages/admin-audit-logs.css` to keep the filter form responsive without inline styles.
   - Admin edit user and admin new notification search toolbars now use `<form class="...-search">` wrappers; page scripts prevent submissions so inline handlers are no longer needed.
+  - Their parent forms keep controls connected via the HTML `form="..."` attribute so the search wrappers remain valid without nesting `<form>` tags.
   - `templates/admin_ip_block.html` imports `/static/js/admin-ip-block.js` for delete confirmation handling.
   - `templates/admin_new_bar.html` imports `/static/css/pages/admin-new-bar.css` for map sizing alongside Leaflet assets.
   - `templates/register_step1.html` imports `/static/css/pages/register-step1.css` to handle the login prompt alignment.

--- a/audit.py
+++ b/audit.py
@@ -39,6 +39,6 @@ def log_action(
         created_at=datetime.utcnow(),
     )
     db.add(log)
+    db.flush()
     db.commit()
-    db.refresh(log)
     return log

--- a/templates/admin_edit_user.html
+++ b/templates/admin_edit_user.html
@@ -15,17 +15,18 @@
   </div>
 </div>
 {% endif %}
-<form class="form" method="post" action="/admin/users/edit/{{ user.id }}">
+<form id="editUserForm" method="post" action="/admin/users/edit/{{ user.id }}"></form>
+<section class="form">
   <label for="username">{{ _('admin_edit_user.form.username', default='Username') }}</label>
-  <input id="username" name="username" type="text" value="{{ user.username }}" required>
+  <input id="username" name="username" type="text" value="{{ user.username }}" required form="editUserForm">
 
   <a class="btn-outline" href="/admin/users/{{ user.id }}/password">{{ _('admin_edit_user.actions.edit_password', default='Edit Password') }}</a>
 
   <label for="email">{{ _('admin_edit_user.form.email', default='Email') }}</label>
-  <input id="email" name="email" type="email" value="{{ user.email }}" required>
+  <input id="email" name="email" type="email" value="{{ user.email }}" required form="editUserForm">
 
   <label for="prefix">{{ _('admin_edit_user.form.prefix', default='Prefix') }}</label>
-  <select id="prefix" name="prefix" autocomplete="tel-country-code">
+  <select id="prefix" name="prefix" autocomplete="tel-country-code" form="editUserForm">
     <option value="+41" {% if user.prefix == "+41" %}selected{% endif %}>{{ _('admin_edit_user.prefixes.ch', default='+41 (Switzerland)') }}</option>
     <option value="+39" {% if user.prefix == "+39" %}selected{% endif %}>{{ _('admin_edit_user.prefixes.it', default='+39 (Italy)') }}</option>
     <option value="+49" {% if user.prefix == "+49" %}selected{% endif %}>{{ _('admin_edit_user.prefixes.de', default='+49 (Germany)') }}</option>
@@ -33,14 +34,11 @@
   </select>
 
   <label for="phone">{{ _('admin_edit_user.form.phone', default='Phone') }}</label>
-  <input id="phone" name="phone" type="tel" value="{{ user.phone }}">
+  <input id="phone" name="phone" type="tel" value="{{ user.phone }}" form="editUserForm">
 
   <label for="role">{{ _('admin_edit_user.form.role', default='Role') }}</label>
   {% if current.is_super_admin %}
-  <div id="barAssignments"
-       data-add-label="{{ _('admin_edit_user.actions.add', default='Add') }}"
-       data-remove-label="{{ _('admin_edit_user.actions.remove', default='Remove') }}">
-    <select id="role" name="role">
+  <select id="role" name="role" form="editUserForm">
       <option value="super_admin" {% if user.role=='super_admin' %}selected{% endif %}>{{ _('admin_edit_user.roles.super_admin', default='Super Admin') }}</option>
       <option value="bar_admin" {% if user.role=='bar_admin' %}selected{% endif %}>{{ _('admin_edit_user.roles.bar_admin', default='Bar Admin') }}</option>
       <option value="bartender" {% if user.role=='bartender' %}selected{% endif %}>{{ _('admin_edit_user.roles.bartender', default='Bartender') }}</option>
@@ -48,8 +46,20 @@
       <option value="customer" {% if user.role=='customer' %}selected{% endif %}>{{ _('admin_edit_user.roles.customer', default='Customer') }}</option>
       <option value="blocked" {% if user.role=='blocked' %}selected{% endif %}>{{ _('admin_edit_user.roles.blocked', default='Blocked') }}</option>
       <option value="ip_block" {% if user.role=='ip_block' %}selected{% endif %}>{{ _('admin_edit_user.roles.ip_block', default='IP Block') }}</option>
-    </select>
+  </select>
+  {% else %}
+  <select id="role" name="role" form="editUserForm">
+    <option value="bar_admin" {% if user.role=='bar_admin' %}selected{% endif %}>{{ _('admin_edit_user.roles.bar_admin', default='Bar Admin') }}</option>
+    <option value="bartender" {% if user.role=='bartender' %}selected{% endif %}>{{ _('admin_edit_user.roles.bartender', default='Bartender') }}</option>
+  </select>
+  <input type="hidden" name="add_credit" value="0" form="editUserForm">
+  <input type="hidden" name="remove_credit" value="0" form="editUserForm">
+  {% endif %}
 
+  {% if current.is_super_admin %}
+  <div id="barAssignments"
+       data-add-label="{{ _('admin_edit_user.actions.add', default='Add') }}"
+       data-remove-label="{{ _('admin_edit_user.actions.remove', default='Remove') }}">
     <h2>{{ _('admin_edit_user.sections.assigned', default='Assigned Bars') }}</h2>
     <div class="toolbar-actions">
       <form class="bars-search" role="search" aria-label="{{ _('admin_edit_user.assigned_search.aria', default='Search assigned bars') }}">
@@ -81,7 +91,7 @@
               <div class="actions-group">
                 <button type="button" class="btn-danger-soft js-remove-bar" data-bar-id="{{ b.id }}">{{ _('admin_edit_user.actions.remove', default='Remove') }}</button>
               </div>
-              <input type="checkbox" name="bar_ids" value="{{ b.id }}" checked hidden>
+              <input type="checkbox" name="bar_ids" value="{{ b.id }}" checked hidden form="editUserForm">
             </td>
           </tr>
           {% endfor %}
@@ -120,7 +130,7 @@
               <div class="actions-group">
                 <button type="button" class="btn-outline js-add-bar" data-bar-id="{{ b.id }}">{{ _('admin_edit_user.actions.add', default='Add') }}</button>
               </div>
-              <input type="checkbox" name="bar_ids" value="{{ b.id }}" hidden>
+              <input type="checkbox" name="bar_ids" value="{{ b.id }}" hidden form="editUserForm">
             </td>
           </tr>
           {% endfor %}
@@ -129,22 +139,15 @@
     </div>
 
     <label for="add_credit">{{ _('admin_edit_user.form.add_credit', default='Add Credit') }}</label>
-    <input id="add_credit" name="add_credit" type="number" step="0.01" value="0">
+    <input id="add_credit" name="add_credit" type="number" step="0.01" value="0" form="editUserForm">
 
     <label for="remove_credit">{{ _('admin_edit_user.form.remove_credit', default='Remove Credit') }}</label>
-    <input id="remove_credit" name="remove_credit" type="number" step="0.01" value="0">
+    <input id="remove_credit" name="remove_credit" type="number" step="0.01" value="0" form="editUserForm">
   </div>
-  {% else %}
-  <select id="role" name="role">
-    <option value="bar_admin" {% if user.role=='bar_admin' %}selected{% endif %}>{{ _('admin_edit_user.roles.bar_admin', default='Bar Admin') }}</option>
-    <option value="bartender" {% if user.role=='bartender' %}selected{% endif %}>{{ _('admin_edit_user.roles.bartender', default='Bartender') }}</option>
-  </select>
-  <input type="hidden" name="add_credit" value="0">
-  <input type="hidden" name="remove_credit" value="0">
   {% endif %}
 
-  <button class="btn btn--primary" type="submit">{{ _('admin_edit_user.actions.save', default='Save') }}</button>
-</form>
+  <button class="btn btn--primary" type="submit" form="editUserForm">{{ _('admin_edit_user.actions.save', default='Save') }}</button>
+</section>
 
 {% if current.is_super_admin %}
 <div class="actions-group admin-edit-user__danger-actions">

--- a/templates/admin_new_notification.html
+++ b/templates/admin_new_notification.html
@@ -19,16 +19,16 @@
   <p class="alert-danger">{{ error }}</p>
   {% endif %}
   <form id="notificationForm"
-        class="form"
         method="post"
         action="/admin/notifications"
         enctype="multipart/form-data"
         data-select-user="{{ _('admin_new_notification.alerts.select_user', default='Please select a user.') }}"
         data-select-bar="{{ _('admin_new_notification.alerts.select_bar', default='Please select a bar.') }}"
         data-select-label="{{ _('admin_new_notification.actions.select', default='Select') }}"
-        data-selected-label="{{ _('admin_new_notification.actions.selected', default='Selected') }}">
+        data-selected-label="{{ _('admin_new_notification.actions.selected', default='Selected') }}"></form>
+  <section class="form">
     <label>{{ _('admin_new_notification.form.target.label', default='Target') }}
-      <select name="target" id="target" required>
+      <select name="target" id="target" required form="notificationForm">
         <option value="all">{{ _('admin_new_notification.form.target.options.all', default='All Users') }}</option>
         <option value="user">{{ _('admin_new_notification.form.target.options.user', default='Specific User') }}</option>
         <option value="bar">{{ _('admin_new_notification.form.target.options.bar', default='Users of Bar') }}</option>
@@ -68,7 +68,7 @@
           </tbody>
         </table>
       </div>
-      <input type="hidden" name="user_id" id="user_id">
+      <input type="hidden" name="user_id" id="user_id" form="notificationForm">
     </section>
 
     <section id="barSection" hidden>
@@ -104,7 +104,7 @@
           </tbody>
         </table>
       </div>
-      <input type="hidden" name="bar_id" id="bar_id">
+      <input type="hidden" name="bar_id" id="bar_id" form="notificationForm">
     </section>
 
     <div class="field-group">
@@ -115,7 +115,7 @@
       <p class="translation-note">{{ _('admin_new_notification.form.subject_default_language_help', language=(default_lang.name if default_lang else default_language|upper), default='Provide the {language} subject. Other languages inherit it when no translation is set.') }}</p>
       {% for lang in available_languages %}
       <label for="subject_{{ lang.code }}">{{ _('admin_new_notification.form.language_subject_label', language=lang.name, default='{language} subject') }}
-        <input id="subject_{{ lang.code }}" name="subject_{{ lang.code }}" maxlength="30" value="{{ subject_map.get(lang.code, '') }}"{% if lang.code == default_language %} required aria-required="true"{% endif %}>
+        <input id="subject_{{ lang.code }}" name="subject_{{ lang.code }}" maxlength="30" value="{{ subject_map.get(lang.code, '') }}" form="notificationForm"{% if lang.code == default_language %} required aria-required="true"{% endif %}>
       </label>
       {% endfor %}
     </div>
@@ -127,21 +127,21 @@
       <p class="translation-note">{{ _('admin_new_notification.form.message_default_language_help', language=(default_lang.name if default_lang else default_language|upper), default='Provide the {language} message. Other languages inherit it when no translation is set.') }}</p>
       {% for lang in available_languages %}
       <label for="body_{{ lang.code }}">{{ _('admin_new_notification.form.language_message_label', language=lang.name, default='{language} message') }}
-        <textarea id="body_{{ lang.code }}" name="body_{{ lang.code }}" rows="4"{% if lang.code == default_language %} required aria-required="true"{% endif %}>{{ body_map.get(lang.code, '') }}</textarea>
+        <textarea id="body_{{ lang.code }}" name="body_{{ lang.code }}" rows="4" form="notificationForm"{% if lang.code == default_language %} required aria-required="true"{% endif %}>{{ body_map.get(lang.code, '') }}</textarea>
       </label>
       {% endfor %}
     </div>
     <label>{{ _('admin_new_notification.form.link_url', default='Link URL') }}
-      <input type="url" name="link_url">
+      <input type="url" name="link_url" form="notificationForm">
     </label>
     <label>{{ _('admin_new_notification.form.image', default='Image') }}
-      <input type="file" name="image" accept="image/*">
+      <input type="file" name="image" accept="image/*" form="notificationForm">
     </label>
     <label>{{ _('admin_new_notification.form.attachment', default='Attachment') }}
-      <input type="file" name="attachment">
+      <input type="file" name="attachment" form="notificationForm">
     </label>
-    <button class="btn btn--primary" type="submit">{{ _('admin_new_notification.form.submit', default='Send') }}</button>
-  </form>
+    <button class="btn btn--primary" type="submit" form="notificationForm">{{ _('admin_new_notification.form.submit', default='Send') }}</button>
+  </section>
 </section>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- keep admin edit user inputs bound to the submission form via the `form="editUserForm"` attribute so search widgets can remain real `<form>` elements
- do the same for the admin new notification workflow to restore the ability to send messages
- adjust audit logging to flush before commit so refresh failures no longer break admin requests and document the pattern in AGENTS.md

## Testing
- pytest tests/test_update_user.py tests/test_admin_notifications_all_users.py

------
https://chatgpt.com/codex/tasks/task_e_68da8a8e65008320b5306e7f12113e13