### PR TITLE
Remove unused Google Maps key

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - Phone validation errors must use English messaging; see `app/phone.py` and `tests/test_register_phone_validation.py`.
 - Dark mode functionality has been removed; the site theme is fixed to light.
 - Product image uploads surface English errors: "No file uploaded", "Uploaded file must be an image", and "File too large (>5MB)".
+- Google Maps integrations no longer expect a `GOOGLE_MAPS_API_KEY`; map widgets should work without it.
 - Review recent commit history before starting new tasks.
 - Admin edit pages now offload inline assets:
   - `templates/admin_edit_bar_options.html` imports `/static/css/pages/admin-edit-bar-options.css`.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ Optional variables:
 
 - `FRONTEND_ORIGINS` – comma-separated list of allowed frontend URLs for CORS
   (defaults to `http://localhost:5173`).
-- `GOOGLE_MAPS_API_KEY` – required if map widgets are used.
 - `WALLEE_SPACE_ID`, `WALLEE_USER_ID`, `WALLEE_API_SECRET` – credentials for
   Wallee transactions.
 - `BASE_URL` – public base URL of the app used for payment callbacks.

--- a/main.py
+++ b/main.py
@@ -2305,11 +2305,6 @@ def render_template(template_name: str, **context) -> HTMLResponse:
                         recent_bars.append(bar)
                 context.setdefault("recent_bars", recent_bars)
 
-    # Ensure Google Maps API key is available to templates from environment.
-    api_key = os.getenv("GOOGLE_MAPS_API_KEY")
-    if api_key:
-        context.setdefault("GOOGLE_MAPS_API_KEY", api_key)
-
     language_code = DEFAULT_LANGUAGE
     translator = create_translator(DEFAULT_LANGUAGE)
     if request is not None:


### PR DESCRIPTION
## Summary
- stop injecting the GOOGLE_MAPS_API_KEY into template context since it is unused
- remove the environment variable from the README and note the change in AGENTS.md

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da93461e708320ac738fe15d717348