### PR TITLE
Restructure agent handbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,493 +1,233 @@
-# AGENT Notes
+# WEBSITE Agent Handbook (Repo Root)
 
-- Commit messages subject line must not exceed 30 characters.
-- Notification subject line must not exceed 30 characters.
-- Admin notifications form subject input enforces this with `maxlength=30`.
-- Bar admin edit pages send bar admins back to `/dashboard`; super admins continue to use `/admin/bars` for navigation.
-- Phone validation errors must use English messaging; see `app/phone.py` and `tests/test_register_phone_validation.py`.
-- Dark mode functionality has been removed; the site theme is fixed to light.
-- Product image uploads surface English errors: "No file uploaded", "Uploaded file must be an image", and "File too large (>5MB)".
-- Google Maps integrations no longer expect a `GOOGLE_MAPS_API_KEY`; map widgets should work without it.
-- Review recent commit history before starting new tasks.
-- Admin edit pages now offload inline assets:
-  - `templates/admin_edit_bar_options.html` imports `/static/css/pages/admin-edit-bar-options.css`.
-  - `templates/bar_edit_product.html` imports `/static/css/pages/bar-edit-product.css`.
-  - `templates/admin_new_notification.html` imports `/static/css/pages/admin-new-notification.css` and `/static/js/admin-new-notification.js`.
-  - `templates/admin_edit_user.html` imports `/static/js/admin-edit-user.js`.
-  - `templates/admin_edit_user.html` also imports `/static/css/pages/admin-edit-user.css` to handle delete action spacing and hide the post form.
-  - `templates/admin_edit_bar.html` imports `/static/css/pages/admin-edit-bar.css` and `/static/js/admin-edit-bar.js` (Leaflet assets stay on the CDN).
-  - `templates/order_history.html` imports `/static/css/pages/order-history.css` and `/static/js/order-history.js` alongside `orders.js`.
-  - `templates/admin_edit_welcome.html` imports `/static/css/pages/admin-edit-welcome.css` and `/static/js/admin-edit-welcome.js`.
-  - `templates/bar_new_category.html` imports `/static/css/pages/bar-new-category.css` and `/static/js/bar-new-category.js`.
-  - `templates/bar_edit_category.html` imports `/static/css/pages/bar-edit-category.css`.
-  - `templates/bar_edit_category_description.html`, `templates/bar_edit_category_name.html`, and `templates/bar_edit_product_description.html` import `/static/css/pages/translation-editor.css`.
-  - `templates/bar_manage_categories.html` imports `/static/css/pages/bar-manage-categories.css` and `/static/js/bar-manage-categories.js`.
-  - `templates/admin_edit_bar_description.html` imports `/static/css/pages/admin-edit-bar-description.css`.
-  - `templates/admin_analytics.html` imports `/static/css/pages/admin-analytics.css` and `/static/js/admin-analytics.js` (Chart.js stays on the CDN and page data hydrates via `#adminAnalyticsData`).
-  - `templates/admin_dashboard.html` imports `/static/js/admin-dashboard.js` to handle the delete-all-orders confirmation without inline handlers.
-  - `templates/admin_notifications.html` imports `/static/js/admin-notifications.js` for delete confirmation handling.
-  - `templates/admin_bars.html` imports `/static/js/admin-bars.js` for table filtering and deletion confirmation.
-  - `templates/admin_bars.html` also imports `/static/css/pages/admin-bars.css` to keep hidden delete forms out of the layout flow.
-  - `templates/admin_bar_users.html` imports `/static/js/admin-bar-users.js` for staff filtering and removal confirmation dialogs.
-  - `templates/admin_notification_view.html` imports `/static/js/admin-notification-view.js` for delete confirmation handling.
-  - `templates/admin_notification_view.html` also imports `/static/css/pages/admin-notification-view.css` for action spacing and hidden delete form styling.
-  - `templates/admin_audit_logs.html` imports `/static/js/admin-audit-logs.js` and `/static/css/pages/admin-audit-logs.css` to keep the filter form responsive without inline styles.
-  - Admin edit user and admin new notification search toolbars now use `<form class="...-search">` wrappers; page scripts prevent submissions so inline handlers are no longer needed.
-  - Their parent forms keep controls connected via the HTML `form="..."` attribute so the search wrappers remain valid without nesting `<form>` tags.
-  - `templates/admin_ip_block.html` imports `/static/js/admin-ip-block.js` for delete confirmation handling.
-  - `templates/admin_new_bar.html` imports `/static/css/pages/admin-new-bar.css` for map sizing alongside Leaflet assets.
-  - `templates/register_step1.html` imports `/static/css/pages/register-step1.css` to handle the login prompt alignment.
-  - `templates/bar_category_products.html` imports `/static/css/pages/bar-category-products.css` and `/static/js/bar-category-products.js` for delete form handling.
-- Footer marketing pages (About, Help Center, For Bars, Terms) live in `templates/about.html`, `templates/help_center.html`, `templates/for_bars.html`, and `templates/terms.html`; they share the `.static-page` styles defined in `static/css/components.css`.
-  - Support contact details for these static pages pull from Jinja globals defined in `main.py` (`SUPPORT_EMAIL`, `SUPPORT_NUMBER`, `TERMS_VERSION`, etc.); update those constants to change emails, phone numbers, or term dates sitewide.
-  - The About page intro copy reads "Built and operated by Siply..." followed by "We’re building a modern ordering experience..." to highlight Siply's role and hospitality focus.
-- Homepage image stored in photo/homepage.png.
-- `/photo` static path serves the homepage image.
-- Homepage hero displays the artwork as a single `<img class="hero-art">` absolutely positioned under the content with pointer-events disabled.
-- Homepage hero copy is centered via `.home-hero .hero__content` using `margin-inline:auto` and `text-align:center`.
-- Hero image is non-draggable (`draggable="false"` and `user-select:none`) so it can't shift text or cards.
-- Hero art is centered and rotated via `transform:translateX(-50%) rotate(70deg)`.
-- Hero art is positioned 450px to the left via `left:calc(50% - 450px)`.
-- The image extends 12rem beyond the hero (8rem on mobile) with no mask, clip, or fade.
-- Hero image is shifted an additional 150px downward and 450px left from the hero section.
-- Mobile layout lowers the hero art an extra 100px so the mobile offset is `bottom:calc(-8rem - 200px)`.
-- Hero art displays at a fixed 819x819 size (20% smaller) regardless of screen width.
-- Hero art uses `z-index:-1` to sit behind cards.
-- Header sits at `z-index:1050` so it renders above mobile menu blur backdrops.
-- Language backdrop overlay uses `z-index:1250` so the header stays under the blur when the language dialog is open.
-- Bar and info sections use `position:relative;z-index:1` so the hero image remains behind "Nearby Open Bars" and later content.
-- Mobile menu panel anchors 89px below the header on small screens (97px on viewports ≥ 769px).
-- Hero art styles live in `static/css/components.css` under `.home-hero .hero-art`.
-- Homepage hero no longer hides overflow, letting the image extend beyond the hero section.
-- Homepage hero only shows a Browse Bars button linking to `/search`; Search and How it works buttons and promo chips were removed.
-- Browse Bars button is centered in the hero section.
-- Horizontal scrolling is locked with `overflow-x: clip` on `html, body`, and header width uses `100%` to avoid viewport overflow.
-- Body uses a column flex layout with `min-height: 100dvh` and grows `<main>` so the footer always anchors to the bottom even on sparse pages.
-- Display orders page uses `/static/css/pages/display-orders.css` for layout adjustments and `/static/js/display-page.js` to bootstrap `initDisplay` via the `data-bar-id` attribute.
-- Bartender and bar admin order dashboards share `/static/css/pages/bar-orders.css` for layout and `/static/js/bar-orders.js` to bootstrap `initBartender` (reading the `data-bar-id` attribute) and handle pause toggles.
-- `templates/bar_detail.html` imports `/static/js/bar-detail.js` to sync pause state, choose the best directions link, and apply fallback imagery when bar assets fail to load.
-- `templates/home.html` loads `/static/js/home.js` to attach fallback handlers to hero and bar card images.
-- `templates/search.html` relies on `/static/js/search.js` for filtering, card metadata rendering, and image fallback handling instead of inline events.
-- Wallet top-up page `templates/topup.html` imports `/static/js/topup.js` for preset amounts and checkout redirects.
-- Admin payments search logic now lives in `/static/js/admin-payments.js`; templates only render markup.
-- Admin users search filtering now runs through `/static/js/admin-users.js` loaded with `defer`.
-- Registration username lowercase enforcement is handled by `/static/js/register.js` loaded with `defer`.
-- Registration is a two-step flow. `/register` collects email and password and assigns a temporary `REGISTERING` role. Users are redirected to `/register/details` to supply username, phone prefix, and number, and cannot access other pages until this step completes.
-  - Once step two succeeds and the role becomes `CUSTOMER`, the user stays signed in and is redirected to the homepage (`/`).
-  - Each registration step displays a disclaimer stating that creating an account accepts the Terms of Service, with the link pointing to `/terms`.
-- Username input on `/register/details` forces lowercase on every keystroke so pasted or typed uppercase characters are normalised before submission. The behaviour is managed by `/static/js/register.js`.
-- Registering users hitting any other route are redirected back to `/register/details` by middleware until step two finishes.
-- Super admins can create users directly from the Admin Users page by entering only an email and password; this bypasses the normal registration flow and checks.
-- Authenticated users are redirected away from `/login` and `/register`; use `redirect_for_authenticated_user` in `main.py` when adding new entry points.
-- Blocked and IP-blocked users cannot log out; BlockRedirectMiddleware denies `/logout` and the layout hides the link for these roles.
-- Startup ensures the `roleenum` type contains `REGISTERING` via `ensure_role_enum()`.
-- Display role users see only a two-column live orders screen (preparing/ready) at `/dashboard/bar/{id}/orders` with order codes only and no footer or cart links.
-- Display role header removes navigation links and menu toggles; the logo is not clickable and only a Logout link remains.
-- Display users are redirected from any non-display route to their bar's display orders page.
-- The display orders page stretches to the full viewport width and doubles the size of order headers for clearer visibility.
-- Display orders include 10px horizontal margins and center the order text within each card.
-- Block role users are limited to notifications and the `/blocked` help screen; BlockRedirectMiddleware in `main.py` enforces
-  redirects and the template lives at `templates/blocked.html`.
-- IP block entries are managed from `/admin/ip-block` with UI in `templates/admin_ip_block.html`; blocked addresses are stored via the `BlockedIP` model and cached in `blocked_ips` / `blocked_ip_lookup`.
-- Users logging in from a blocked IP receive the `ip_block` role, are redirected to `/ip-blocked`, and only see notifications and the IP block notice.
-- Super admins are immune to IP block enforcement; they keep the `super_admin` role even when signing in from blocked addresses and cannot be assigned `blocked` or `ip_block` roles.
+This guide covers **every directory in `/workspace/WEBSITE`**. Use it as the
+single reference for workflow rules, template locations, and asset mappings.
+Sections are grouped so you can jump straight to the files you need.
 
-- `common.weekdays.<day>` translations drive the opening hours day labels on bar pages. Use these keys instead of hard-coded
-  weekday names.
-- `cart.errors.other_bar` localises the warning shown when trying to order from a different bar while the cart is full.
+## 1. Quick Reference
 
-- Wallet page UI lives in `templates/wallet.html` using a `.wallet-page` wrapper and inline scoped styles. Transaction rows render inside `<ul id="txList">` as static `.tx` divs with no detail links. "Load more," "Export CSV," "Manage payment methods," and all filters have been removed; the "Top Up" button uses `text-decoration:none` to avoid an underline.
-- Wallet top-ups must be at least 10 CHF; enforce this in both API validation and client-side forms.
-- Transaction detail views have been removed, so there is no `/wallet/tx/{index}` route or `transaction_detail.html` template.
-- Wallet Recent Activity shows all transactions with the newest first, and wallet cards override the base mobile `max-height` so the feed length isn't capped.
-- The balance card's meta now only shows an `Available` badge and omits any "last updated" text.
-- Wallet transactions for orders begin in a `PROCESSING` state and update to `COMPLETED` once the order is accepted or to `CANCELED` if the order is canceled. Canceled transactions display a `- CHF 0.00` amount.
-- Order cancellations capture a `cancellation_reason` (`bartender`, `customer`, or `timeout`) and order cards display the translated reason under "Cancellation reason" when applicable.
-- Card payments finalized by the Wallee webhook are added to the wallet feed so card orders appear alongside wallet transactions. Pay-at-bar orders are excluded from the wallet feed.
-- Top-ups append a `topup` transaction in a `PROCESSING` state during `/api/topup/init`; the Wallee webhook updates it to `COMPLETED` and refreshes the user's cached credit.
-- The `/topup` form submits with a "Top up with card" button so the call-to-action stays in English.
-- Failed top-ups display a red `Failed` pill and a `+ CHF 0.00` amount in the wallet.
-- Wallet transactions persist across restarts via the `wallet_transactions` table; login hydrates cached transactions from this table.
-- User sessions survive server restarts by reloading missing user data from the database on demand.
+| Topic | Summary | Key Files |
+| --- | --- | --- |
+| Commit & PR titles | Max 30 characters. | `.git/` (enforced via instructions) |
+| Phone validation copy | Must stay in English. | `app/phone.py`, `tests/test_register_phone_validation.py` |
+| Dark mode | Removed; site is light-only. | Global |
+| Recent work context | Always review latest commits. | `git log` |
 
-- Core modules:
-  - `main.py` – routes and helpers
-  - `/cart/checkout` stores card order details in `Payment.raw_payload` and only creates the order when the Wallee webhook reports a successful payment; card payment failures leave the cart intact and skip order creation
-    - The Wallee webhook clears the user's cart only after a `COMPLETED` payment so canceled or failed transactions leave items in the cart for retrying
-  - `models.py` – data models
-  - `database.py` – database utilities
-  - `audit.py` – records user actions to `AuditLog`
-    - Login and cart checkout log `login` and `order_create` actions via `log_action`
-    - `AuditLogMiddleware` logs authenticated requests excluding `.css`, `.js`, `.png`, and `.ico` files with IP, user agent, and phone, but omits phone for `/login` requests
-    - Startup ensures `audit_logs` has `ip`, `user_agent`, and `phone` via `ensure_audit_log_columns()`
-    - Audit logs capture `actor_credit` to record a user's credit at action time; pass `credit` to `log_action`
-    - `ensure_audit_log_columns` adds the `actor_credit` column when missing
-    - Admin audit logs display times with `format_time` to honor local time
-  - `finance.py` – VAT and payout calculations
-  - `payouts.py` – schedule periodic payouts for bars
-  - `app/webhooks/wallee.py` – webhook endpoint for Wallee payments
-    - Failed payment webhooks mark orders as `CANCELED` and set `cancelled_at`
-- Wallet top-ups use Wallee: `/api/topup/init` creates `wallet_topups` records and credits the user when the webhook reports a completed transaction
-    - Webhook `/webhooks/wallee` updates `wallet_topups` by `wallee_tx_id` with a row-level lock; processed records are skipped so repeated calls stay idempotent.
-    - `wallet_topups` columns include `id`, `user_id`, `amount_decimal`, `currency`, `wallee_tx_id` (unique BIGINT), `status`, `processed_at`, `created_at`, and `updated_at`.
-    - Save `int(tx.id)` to `wallet_topups.wallee_tx_id` and query by this field in the webhook.
-    - Transaction payloads send the user's username via `billing_address`, `customer_id`, and `meta_data['username']` so Wallee's dashboard shows who initiated each payment.
-      - Leave `billing_address.family_name` unset so Wallee only displays the username once in its customer name field.
-    - Startup ensures these fields via `ensure_wallet_topup_columns()` which renames any legacy `wallee_transaction_id` column and sets the `status` default to `PENDING`.
-    - The `payments` table tracks order payments only and no longer defines a `user_id` column.
-    - Wallee API clients live in `app/wallee_client.py`; reuse the module's `tx_service`, `pp_service`, and `whenc_srv` instead of creating new clients.
-    - Public keys returned by Wallee are base64‑encoded DER; signature checks should call `load_der_public_key` via `app/webhooks/wallee_verify.py`.
-    - Amounts for `LineItemCreate` must be floats; passing `Decimal` values causes Wallee's SDK to raise an `AttributeError` during serialization.
-    - Provide `amount_including_tax` for each `LineItemCreate`; the field is required by Wallee and replaces the deprecated `amount`.
-  - `node-topup/` contains a TypeScript example service for initiating top-ups
-  - Top-up flow:
-    - `templates/topup.html` posts to `/api/topup/init`; non-2xx responses trigger a client alert "Unable to start top-up".
-    - The submit button hides and disables after submission to prevent duplicate requests.
-    - The endpoint requires authentication and accepts amounts between 1 and 1000 CHF.
-    - Wallee integration uses `WALLEE_SPACE_ID`, `WALLEE_USER_ID`, and `WALLEE_API_SECRET`; misconfiguration results in an error.
-    - If any of these variables are missing or invalid, `/api/topup/init` returns 503 "Top-up service unavailable".
-    - `tests/test_topup_init.py` demonstrates record creation with patched Wallee services.
-    - `/wallet/topup/failed` and `/wallet/topup/success` redirect to `/wallet` with `notice*` query parameters consumed by `static/js/app.js` to show cart-style popups.
-  - Cart checkout:
-    - `templates/cart.html` hides the "Place Order" button after form submission to prevent duplicate orders.
-  - Front-end mapping:
-    - Styles in `static/css/components.css` (`components.min.css` for minified)
-    - Templates live under `templates/`
-    - JavaScript: `static/js/app.js` (shared/carousels), `static/js/search.js`, `static/js/view-all.js`
-    - Bar & product card size: 400×450 desktop, 300×400 mobile
-  - Global footer: `templates/layout.html` uses `.site-footer` styled in `static/css/components.css`
-- Shared fallback image handler lives in `/static/js/image-fallback.js`; templates should add `data-fallback-src` on `<img>` tags and include the script when they need automatic swap behaviour.
-- Bars:
-  - `/bars` page uses `templates/all_bars.html`, `static/js/image-fallback.js`, and `static/js/view-all.js`
-  - Filters apply automatically on change; the old "Apply" button and its handler were removed
-  - Public `/bars` listings show only bar names without numeric IDs, while admin listings keep each bar's `bar.id` zero-padded to three digits to match order codes
-  - Admin Manage Bars page uses `templates/admin_bars.html` with `.bars-page` styles in `static/css/components.css`. The page header stacks the title above the search and Add Bar controls
-- Admin Manage Bars page includes a client-side name search via `#barsSearch`
-- Admin Manage Bars actions use uppercase text-only pill buttons that expand to fit text; links and buttons inherit the base font so Delete matches Edit sizing while employing a brighter `.btn-danger-soft` red to deter accidental clicks
-- Admin Manage Payments page uses `templates/admin_payments.html`, reusing the `.users-page` layout classes (`.users-toolbar`, `.users-search`, `.users-table`) alongside `.payments-page` for admin tweaks. It includes a client-side bar search via `#paymentsSearch` and grouped action pills (`.btn-outline` for View/Add Test Closing, `.btn-danger-soft` for Delete Test Closing). The page header stacks the title above the search controls, and the template imports `/static/css/pages/admin-payments.css` to keep auxiliary test-closing forms hidden.
-- Admin Audit Logs page uses `templates/admin_audit_logs.html` with `.users-page` layout and filters for username, bar name, and action. Username and bar searches submit on Enter; the action dropdown submits on change. The table shows usernames and bar names instead of numeric IDs.
-- Admin Manage Categories page uses `templates/bar_manage_categories.html` with `.menu-page` styles in `static/css/components.css`, a client-side category search via `#categorySearch`, and grouped uppercase action pills (`.btn-outline` for Products and Edit, `.btn-danger-soft` for Delete). The page header stacks the title above the search and Add Category controls
-- Category edit and create forms live in `templates/bar_edit_category.html` and `templates/bar_new_category.html`; both now expose translation panels for name and description that post `name_<lang>` and `description_<lang>` inputs alongside the base fields.
-- Category names and descriptions persist per-language in the `name_translations` and `description_translations` JSON columns on `categories`; keep these maps populated for every code in `LANGUAGES` and refresh in-memory bars after updates with `normalise_translation_map`.
-- Product edit and create forms live in `templates/bar_edit_product.html` and `templates/bar_new_product.html`; the description field uses a `<textarea>` styled by the `.form textarea` rule in `static/css/components.css`. `bar_edit_product.html` now imports `/static/js/image-fallback.js` to handle preview fallbacks.
-- Admin Manage Menu Items page uses `templates/bar_category_products.html`; wrapped in `.menu-page` with a `.menu-toolbar` header and Add Product button, listing products in a `.table-card`-wrapped `menu-table` with text-only pill buttons (`.btn-outline`, `.btn-danger-soft`) and a prominent Delete. The template imports `/static/js/image-fallback.js` plus `/static/js/bar-category-products.js` for delete confirmation.
-- Admin Manage Users page uses `templates/admin_bar_users.html` with `.users-page` styles in `static/css/components.css`, a client-side username/email search via `#userSearch`, and grouped action pills. The page header stacks the title above an Add Existing User form and the search controls; new user creation has been removed
-- Manage Bar Users list now shows only a red `Remove` button to unassign staff from the current bar; user editing is handled on the main Admin Users page
-- Removing a user triggers a popup confirmation using `.cart-blocker` and `.cart-popup`
-- Cart popups stack action buttons vertically via `.cart-popup-actions`, and buttons expand full-width with consistent font size
-- Admin Edit User page (`templates/admin_edit_user.html`) lists assigned bars separately from available bars, each with its own search (`#assignedBarSearch` and `#availableBarSearch`) and shows bar ID and city columns. Rows use Add/Remove pill buttons and hidden `bar_ids` checkboxes to track selections before save.
-- Admin Edit User page includes a Delete button that opens a confirmation popup before removing the user.
-- Super admins can assign the `Display` role from the Admin Edit User page, and any validation errors appear in a popup.
-- Admin Manage Bars delete links open a popup confirmation using `.cart-blocker` and `.cart-popup`
-- `BAR_CATEGORIES` defined in `main.py`; reused in `search.js` and `view-all.js`
-- Categories stored in `bars.bar_categories`
-- Edit Bar basic info page uses `.editbar` layout with `.grid-2` and `.card` sections (Map, Details, Media & Hours).
-- Edit Bar cards remove the base mobile `max-height` so all content is visible on small screens.
-- Categories are shown as always-visible chips synchronized with a hidden `<select id="categoriesNative" name="categories" multiple>`.
-- Manual close checkbox (`#manual_closed`) toggles the `.hours-table` inputs.
-- Manually closing a bar preserves its opening hours so they restore when reopened.
-- Category chips allow selecting up to 5 items, disable others at the limit, and show a running count.
-- Input fields on this page use a rounded "premium" style with a soft focus ring and invalid states.
-- Name, Address, City, Canton, and Rating inputs share the pill-shaped `input-pill` style; `#description` textarea retains the focus ring.
-- Save button sits at the bottom of the form in a `.save-inline` wrapper (non-sticky) and only appears once.
-- Save button uses `.btn--primary` styling consistent with product and category forms.
-- `Promo Label` and `Tags` fields have been removed from the project.
-  - Opening hours data is sanitized; invalid or non-dict values are treated as closed
-  - Category `sort_order` defaults to `0` when missing to avoid menu sorting errors
-  - Bar detail page uses bar-card metadata for rating and geolocated distance
-  - Bar detail page displays the bar's description beneath the address
-  - Bar detail page shows open/closed status using `bar.is_open_now`
-  - Bar detail page uses the same `.status` classes as bar cards for open/closed labels
-  - Bar detail page lists weekly opening hours beneath the description
-  - Bar detail info is rendered in `.bar-detail` (no card styling)
-  - Bar detail layout: `.bar-cover` image (16/9), `.bar-meta` row with status/rating/distance, `.clamp`ed description, and `.bar-hours-card` grid (Mon–Thu / Fri–Sun)
-  - `.bar-detail` has `margin-bottom: var(--space-4)` to add space before product categories
-  - Open status uses `.status-open` (green) and closed status uses `.status-closed` (red)
-  - Bar ordering pause state stored in `bars.ordering_paused` (BOOLEAN, defaults to FALSE)
-  - Bar edit options page links to table management (`templates/admin_bar_tables.html`) where staff can add, edit, and delete tables. Add and edit forms live in `templates/admin_bar_new_table.html` and `templates/admin_bar_edit_table.html`; table descriptions use a `<textarea>` styled by the `.form textarea` rule and are for staff only
-  - Admin Manage Tables page uses `templates/admin_bar_tables.html` with `.menu-page` styles, a client-side table search via `#tableSearch`, and grouped action pills (`.btn-outline` for Edit, `.btn-danger-soft` for Delete). The template imports `/static/css/pages/admin-bar-tables.css` to size the index column and keep delete forms hidden until triggered.
-  - Deleting a table triggers a confirmation popup using `.cart-blocker` and `.cart-popup` like other admin pages
-  - Edit Bar options UI uses `templates/admin_edit_bar_options.html` with `.bar-edit-page` and `.action-card` links in a 2-column grid (1 column on mobile)
-- Products:
-  - Images stored in `menu_items.photo` and served via `/api/products/{id}/image`
-  - `templates/bar_detail.html` shows products with carousels handled by `static/js/app.js`
-- Cart:
-  - `/bars/{bar_id}/add_to_cart` accepts POST form submissions
-    and returns JSON `{count, totalFormatted, items[]}` when `Accept: application/json`
-  - `/cart/update` and `/cart/checkout` also expect POST form data
-  - `/cart/update` returns JSON when `Accept: application/json`
-  - Cart quantity "Update" button uses `.btn-outline` with black text for contrast
-  - `static/js/app.js` uses a delegated submit listener on `.add-to-cart-form`
-    to prevent page reloads. Rebuild `app.min.js` after changes.
-  - After adding a product, the "Add to Cart" button becomes quantity controls
-    handled in `static/js/app.js` and styled via `.qty-controls` in `static/css/components.css`
-  - `/cart` returns JSON when `Accept: application/json` to hydrate quantity controls on load.
-  - Quantity buttons `.qty-minus`/`.qty-plus` use the same `btn--primary btn--small` styling as "Add to Cart".
-  - Quantity button clicks are delegated with `closest()` to support nested elements and desktop interactions.
-  - Cart contents persist in the database via the `user_carts` table so they survive server restarts.
-  - Cart items are limited to one bar at a time.
-  - Navigating away from the active bar shows a blocking popup in `templates/layout.html` styled via `.cart-blocker` and `.cart-popup`.
-  - The cart-blocker displays whenever the cart contains items from another bar, even if that bar's ordering is paused.
-  - Bartenders can pause ordering from the orders dashboard; paused bars return 409 on `/bars/{id}/add_to_cart` and `app.js` shows a "service paused" popup.
-  - The layout sets `window.orderingPaused` when the cart's bar is paused; `window.showServicePausedOnLoad` controls whether the popup opens automatically.
-  - Menu pages pass `pause_popup_close` so the popup can be dismissed, while the cart page sets `pause_popup_back` and shows the popup on load with a "Back to the menu" button. The message advises contacting a staff member for more info.
-  - `cart.html` lists available tables for selection and shows a wallet link for adding funds.
-  - `cart.html` text is fully in English, including subtitle "Review your order, choose your table, and confirm payment." and payment method notes.
-  - `cart.html` includes a disabled "Select table" placeholder so no table is chosen by default; checkout fails until a table is selected.
-  - The `/cart` route clears `cart.table_id` when it doesn't match an available table so the placeholder remains the default.
-  - The order total appears below the cart item list for quick review before selecting a table.
-  - The checkout form places the "Message to bartender" textarea immediately after the table dropdown.
-  - The cart product list is rendered inside a `.table-card` with a `.menu-table` for consistent styling with other lists.
-  - Mobile view (≤768px) stacks cart, table form, notes, payment options, and summary in one column; the cart table scrolls horizontally inside a wrapper to preserve columns. The `.btn-primary.place-order` button sits at the end of the summary card above the global footer and does not stick to the viewport.
-  - Checkout form asks for payment method (credit card, wallet credit, or pay at bar);
-    selection is handled by `/cart/checkout` and stored in `Transaction.payment_method`.
-  - The cart page uses a premium `.cart-page` wrapper with a wallet banner, summary sidebar, and scoped styles defined inline.
-    Quantity update forms wrap inputs and buttons in `.qty-group` for compact stepper styling.
-  - Credit card payments use Wallee; when credentials are present,
-    `/cart/checkout` records a `payments` row with `wallee_tx_id` and
-    redirects to Wallee's payment page. The `/webhooks/wallee` endpoint
-    updates `payments.state` from webhook events.
-  - Card orders are only broadcast after the webhook reports a successful
-    state; failed payments automatically cancel the order.
-  - Failed card payments redirect users back to `/cart` via Wallee's
-    `failed_url` with `notice=payment_failed` so `static/js/app.js`
-    shows a popup and the cart remains available for retrying.
-  - Checkout form includes an optional "notes" textarea for special requests;
-    notes are saved on orders and shown on bartender and user order cards.
-  - The popup offers "Remove products" (clears cart via `POST /cart/clear`) or "Go to the bar menu".
-  - Wallet and top-up pages clear `cart_bar_id` to prevent the cart popup from appearing.
-  - The top-up page at `/topup` renders `templates/topup.html` and suppresses the cart popup by passing `cart_bar_id` and `cart_bar_name` as `None`.
-- Users:
-  - Credit stored in `users.credit`; ensured by `ensure_credit_column()` on startup
-  - Admin user edits clear old bar roles before saving new assignments
-  - Admin user edits persist credit and current bar assignment; `_load_demo_user` hydrates both from the database
-- Admin users list loads each user's `bar_id` and `credit` directly from the database so assignments survive restarts
-- Admin user edits update passwords and refresh user caches so new assignments replace old data
-- Admin Manage Users page uses `templates/admin_users.html` with `.users-page` styles, a client-side username/email search via `#userSearch`, and grouped action pills (`View`, `Edit`) in each row
-- Super admins can open `/admin/users/view/{id}` rendered by `templates/admin_view_user.html` to review a user's profile, orders, and audit logs. The template imports `/static/css/pages/admin-view-user.css` so history tables stay scrollable without inline styles.
-- The Orders table on this view displays each order's `public_order_code` or `#id` in the ID column to match order card formatting
-- Admin user view lists orders and audit logs in fixed-height scrollable tables so longer histories don't stretch the page
-- Admin user view also shows login activity with IP, user agent, phone, location, and date in a scrollable table
-- Login fetches the user's bar assignment from the database so the bar is available immediately after authentication
-- Login and Register pages show text prompts linking to each other: "Already registered? Log in" and "Not registered yet? Register"
-- Register form preserves entered username, email, phone number, and prefix when validation fails so users can correct errors without retyping.
-- Register and profile forms offer phone prefixes for Switzerland (+41), Italy (+39), Germany (+49), and France (+33); USA and UK options have been removed.
-- Register form requires a phone number with 9–10 digits; invalid entries show an error
-- Register form rejects duplicate phone numbers; the combination of prefix and phone must be unique
-- Register form requires an email in the format text@text.text; invalid entries show an error
-- Register form enforces username rules: 3–24 characters, lowercase letters, numbers, dot, hyphen or underscore with no spaces or consecutive punctuation; reserved names (admin, root, api, login, support, www, siplygo) are rejected
-- Register form requires passwords 8–128 characters long; common passwords like `12345678` are rejected. Passwords are hashed with Argon2id. Forms include show/hide toggles and a Caps Lock indicator.
-- Register form includes a required `confirm_password` field that must match the password.
-- Register and login forms use a flex `.password-wrapper` so the show/hide password toggle sits on the right side of the card.
-- Profile page (`templates/profile.html`) lets logged-in users update username, email, password, prefix, and phone using the same validation rules as registration. `/profile` GET renders the form and `/profile` POST saves changes to the database and in-memory cache, logging the user out after password changes. Each field shows a Bootstrap pencil icon to indicate editability, and changing the password requires the current password for verification.
-- Profile page UI wraps content in `.profile-page` and `.profile-card`, arranges fields in a responsive grid, groups phone prefix/number on desktop, includes a visual password strength meter, and keeps a sticky Save button inside the card.
-- Profile page text inputs reuse the registration `.auth-card` styles (padding, border, default focus) for consistent text box appearance.
-- Profile page edit pencils match the password toggle's minimal button style and sit on the right edge of each input.
-- Profile fields start disabled and are unlocked by clicking their pencil icons; `static/js/profile.js` handles enabling inputs and re-disabling them after saving with a success message.
-  - Admin user edit form: `templates/admin_edit_user.html` posts fields
-    (`username`, `email`, `prefix`, `phone`, `role`, `bar_ids`, `add_credit`, `remove_credit`)
-    to `/admin/users/edit/{id}`. Credit is adjusted by adding and subtracting these values. Password changes use
-    `templates/admin_change_user_password.html` via
-    `/admin/users/{id}/password` without requiring the current password.
-    Bar selection uses checkboxes for easier multi-bar assignment.
-  - Bar admins and bartenders may be assigned to multiple bars. `bar_ids` lists are used
-    throughout to manage permissions and dashboard views.
-- Orders:
-  - `/orders` page renders `templates/order_history.html` with past `Order` entries for the current user.
-  - Orders include a `public_order_code` formatted `BBB-DDMMAA-SEQ` using the bar's 3-digit ID, the Europe/Zurich order date, and a bar-local daily counter that resets at midnight.
-  - The page wraps content in `.orders-page`; pending and completed sections show counts and empty states, and order cards sit in a responsive `.orders-grid` without altering card markup. The previous status/date/search/sort/export toolbar has been removed.
-  - Desktop order grids expand to full width with wider cards (minimum 100px) while still capping at three columns.
-  - Mobile order grids show a single column with a 100px minimum card width.
-  - Order history lists all orders with no "Load more" button or "Back to top" link; the `.orders-actions` block was removed.
-  - Checkout persists orders to the database and redirects to `/orders`.
-  - Mobile hamburger menu links to order history via `bi bi-clock-history` icon.
-- Mobile menu drops the "How it works" entry and adds a `bi bi-person` Profile link for logged-in users.
-- Mobile menu close button sits on the left via `.menu-close{align-self:flex-start}`.
-- Bartenders manage live orders in `bartender_orders.html` using `static/js/orders.js`,
-    which loads with `defer` and initializes `initBartender(bar.id)` on `DOMContentLoaded`.
-  - `templates/bartender_orders.html` wraps content in `.orders-page` and groups
-    orders into `.orders-grid` containers with IDs `incoming-orders`,
-    `preparing-orders`, `ready-orders`, and `completed-orders` for real-time lists.
-  - The bartender dashboard lists assigned bars as `.bar-card` links to `/dashboard/bar/{id}/orders`.
-  - The bartender dashboard uses `admin-dashboard` `editbar` styling with an `admin-header`, `admin-identity` card, and `admin-section` to match other dashboards.
-  - The bar admin dashboard lists assigned bars as `.bar-card` items with edit and management links.
-  - The bar admin dashboard uses `admin-dashboard` `editbar` styling with an `admin-identity` card mirroring the admin dashboard.
-  - Each bar card includes buttons for editing the bar and managing orders via `/dashboard/bar/{id}/orders`.
-  - Bar admins view live orders in `bar_admin_orders.html`, which mirrors the bartender view and adds an
-    "Order History & Revenue" button linking to `/dashboard/bar/{id}/orders/history`.
-  - Bartender and bar admin live order pages reuse the order history grid styles
-    (`orders-page` wrapper with `orders-grid` for a single-column mobile layout and
-    100px minimum card width).
-  - Bars close automatically at their scheduled closing time based on `opening_hours`, moving completed
-    orders into a `bar_closings` record (see `BarClosing` model). Canceled or rejected orders are also
-    attached to the closing but do not count toward `total_revenue`. Editing a bar's hours immediately
-    updates the automatic schedule.
-- The Order History & Revenue page groups closings by month, showing total collected, total earned,
-  and Siplygo commission (5% of total collected) for each month. Monthly "View" links point to
-  `/dashboard/bar/{id}/orders/history/{year}/{month}` with the list of that month's closings, and
-  individual daily summaries still link to `/dashboard/bar/{id}/orders/history/{closing_id}`.
-- Daily closing views list a payment breakdown (credit card, wallet, etc.) for completed orders.
-- Monthly and daily summary cards now also show payment breakdowns on their revenue cards.
-- Monthly and daily revenue cards display "Amount to pay to bar" calculated as total collected minus pay-at-bar totals minus the Siplygo commission. Commission is calculated on the total collected.
-- Revenue cards use `.revenue-card.rc` markup with `.rc-*` utility classes for layout and spacing. The header pairs the month label with a right-aligned "View" link, followed by four KPI rows and a payment breakdown list.
-- Revenue cards remove the base mobile `max-height` so all KPI rows and payment details are visible on small screens.
-- Order History & Revenue monthly cards use `card--placed` (blue) for the current month and `card--accepted` (orange) for past months; text color remains default.
-- Past months show a "Confirm Payment" button to super admins; confirmed months switch to `card--ready` (green).
-  - WebSocket endpoints `/ws/bar/{bar_id}/orders` and `/ws/user/{user_id}/orders` push real-time status updates.
-  - WebSocket support depends on `uvicorn[standard]` (or another backend that provides the `websockets` library).
-  - `static/js/orders.js` selects `ws` or `wss` based on the page protocol for secure deployments.
-    - API endpoints `/api/bars/{bar_id}/orders` (GET) and `/api/orders/{id}/status` (POST) list and update orders for bartenders and bar admins.
-    - `/api/bars/{bar_id}/orders` returns all statuses so completed orders remain visible after reloads.
-    - Orders attached to a `BarClosing` (`closing_id` set) are excluded from `/api/bars/{bar_id}/orders` so dashboards show only current orders.
-    - Order status updates return the updated order; `static/js/orders.js` re-renders immediately after POST so staff see new states without reloading.
-    - Bartenders and bar admins can accept or cancel incoming orders; after acceptance, actions progress Ready → Complete.
-  - Orders are grouped into four sections: Incoming (`PLACED`), Preparing (`ACCEPTED`), Ready (`READY`), and Completed (`COMPLETED`/`CANCELED`/`REJECTED`).
-  - The `/orders` route treats `CANCELED` and `REJECTED` orders as completed so they're excluded from pending.
-  - Order statuses progress `PLACED → ACCEPTED → READY → COMPLETED` (with optional `CANCELED/REJECTED`).
-  - Valid transitions are enforced server-side via `ALLOWED_STATUS_TRANSITIONS` in `main.py`.
-  - Order listings include customer name/phone, table, and line items for both bartender and user history.
-  - Bartender dashboards list orders chronologically: completed orders show newest first, while incoming, preparing, and ready orders show oldest first.
-  - Orders record `accepted_at` and `ready_at` timestamps; bartender cards show placement time and preparation duration via `orders.js`.
-  - User order cards show placement time and preparation duration using `order_history.html` and `orders.js`.
-  - `orders.js` sends a keep-alive ping every 30s so bartender WebSocket connections stay open and receive new orders instantly.
-  - Bartender WebSocket connections automatically reconnect if the socket closes.
-  - Orders store `payment_method`; `order.total` returns `subtotal + vat_total` and both fields are displayed in order listings.
-  - `order_history.html` uses `order.customer_name`, `order.customer_prefix`, `order.customer_phone`, and `order.table_name` to avoid `None` errors when related records are missing.
-  - `order_history.html` displays line items via `item.menu_item_name` to handle missing menu items gracefully.
-  - Order cards display the bar's name via `order.bar_name`.
-    - Order views render each order as an `<article class="order-card card">` with header, meta, and items sections. Orders are grouped in `#pending-orders` and `#completed-orders` containers that also carry an `orders-grid` class for responsive layout within `.orders-page`.
-    - Each order card exposes `data-status` with the raw status for client-side updates. Inline script `initOrderHistoryCounts` updates badge counts and toggles empty states when orders change.
-    - `.order-list` is a flex container that wraps so order cards can flow horizontally, but on the orders page this layout is overridden by `.orders-grid` to create a responsive grid without touching the cards.
-    - Order list cards are 1000px wide on desktop and 315px on mobile, with 10px internal padding (was 5px) while allowing their height to expand with content.
-    - Order cards override the base `card` max-height so they can grow to fit all text.
-    - Order card backgrounds reflect status via `card--placed` (blue), `card--accepted` (orange), `card--ready` (green), `card--completed` (default surface), and `card--canceled` (red).
-    - `.order-list .card__body` uses `gap: var(--space-1)` and removes default margins on child `p` and `ul` elements to tighten spacing.
-    - Order card styles live in `static/css/components.css` under the `.order-card` block and dynamic rendering is handled by `static/js/orders.js`.
-    - Order card headers stack the status chip under the order number using a column layout.
-    - Meta sections use a two-column grid (`.order-kv`) ordered: Total, Placed, Customer, Bar, Table, Payment, Notes, Prep time. Customer phones render as neutral `tel:` links and item lists align quantity/name with ellipsis truncation.
-  - `order_history.html` displays placement date and time via the `format_time` filter so displayed values honor `BAR_TIMEZONE`.
-  - `orders.js` uses `formatTime` to show `YYYY-MM-DD HH:MM` strings on bartender and user order cards for clearer chronology.
-  - Status labels are title-cased for display with `status status-<status>` classes (`formatStatus` in `orders.js`; `order.status|replace('_', ' ')|title` in templates).
-  - `ensure_order_columns()` in `main.py` adds missing columns (e.g., `table_id`, `status`) to the `orders` table at startup.
-- Cancelling an order refunds the total to the customer's wallet when paid by card or wallet; pay-at-bar orders are removed without refund.
-- User cache (`users`) is updated when an order is canceled so the wallet shows the refunded credit.
-- Order history and live order views display refund amounts for canceled orders.
-- Customers may cancel their own `PLACED` orders from the order history page using the cancel button; this posts `CANCELED` via `/api/orders/{id}/status`.
-- Reordering a past order clears any saved table selection so customers must choose a table again before checkout.
-- Admin dashboard includes a testing-only "Delete all orders" button at `/admin/orders/clear` to remove every order record.
-- Admin dashboard groups actions into `.admin-section` grids using `.quick-card` links for Bars, Users, Payments, Analytics, Profile, and a Danger Zone.
-- Super admin dashboard uses `editbar` styling and adds Bootstrap icons to card titles for Bars, Users, Payments, Analytics, Profile, and Danger Zone.
-- Super admins can review bar revenue and orders via `/admin/payments`, listing all bars with "View" links to `/dashboard/bar/{id}/orders`.
-- Super admins can view and update live orders for any bar using the same dashboards and APIs as bar admins and bartenders.
-- `/admin/payments` offers testing helpers:
-  - "Add Test Closing" creates a zero-revenue `BarClosing` dated to the first day of the previous month for the selected bar.
-  - "Delete Test Closing" removes that test `BarClosing`.
-- Testing:
-  - Run `pytest`
-- Meta:
-  - Reverted merge commit 9bc986e (PR #315) in commit 11e13a9 to restore the bar admin dashboard to its previous state; `static/js/bar_admin_dashboard.js` was removed.
-  - Reverted merge commit a169f9f (PR #359) and its fix commit 2617f16 to restore payout calculations to their previous logic.
-- Profile page now collects username, email, and phone prefix/number only; a "Change Password" button links to `/profile/password` which uses `templates/change_password.html` and dedicated routes in `main.py`.
-- Phone number fields on the profile page share the same rounded style as other inputs by styling `input[type="tel"]`.
-- Change Password now sits under the phone number help text, and the Save button appears at the bottom-left without sticky behavior.
-- Change Password button uses inline-flex styling to match the Save button size, and the password strength meter has been removed from the Change Password form.
-- Change Password button is 25% smaller than the Save button using reduced font size and padding.
-- Change Password fields stack in a single column on all screen sizes.
-- Change Password Save button has added top margin to separate it from the Confirm Password field.
-- Profile and Change Password pages display errors and warnings in red using `.alert-danger` or `.caps-warning`, and success messages in green via `.alert-success`.
-- Disposable email enforcement:
-  - Normalization and blocklist checks live in `app/utils/email_normalize.py` and `app/utils/disposable_email.py`.
-  - CLI `python -m app.scripts.refresh_disposable_domains --force` refreshes the cache and writes `app/data/disposable_domains.snapshot`.
-  - Dev endpoint `/internal/disposable-domains/stats` shows cache count and refresh time.
-- Notifications:
-  - `Notification` model in `models.py` stores per-user messages with optional image, attachment, and link.
-  - Super admins send messages via `/admin/notifications/new`, targeting all users, a single user, or users who ordered at a specific bar.
-  - The Admin Notifications page lists recent messages with a **New Message** button linking to the send form and an **Edit Welcome** button for updating the default welcome message.
-- The welcome message editor captures translated subjects and bodies for every supported language; updates are stored on `WelcomeMessage.subject_translations` and `WelcomeMessage.body_translations` with a 30-character limit per subject variant.
-- Welcome message subjects and bodies are edited solely through the per-language fields; the primary inputs and translate toggles were removed.
-  - The default-language subject input (English) is required on submit; `admin_welcome_post` falls back to the previous English copy if it isn't provided. Empty subject fields inherit the active language value or the English default.
-  - The default-language textarea (English) is required on submit; `admin_welcome_post` falls back to the previous English copy if it isn't provided. The handler keeps the active language's previous text when its textarea is submitted empty and clears other translations when their fields are blank.
-  - Each row includes **View** and **Delete** actions; Delete requires confirmation via `.cart-popup`.
-  - Viewing a notification at `/admin/notifications/{id}` shows full details and a list of recipient users.
-  - `register_details` resolves the active language via `translator_for_request` before sending welcome notifications so users receive the message in their chosen locale.
-  - Each send is logged to `NotificationLog` so broadcasts to all users appear once in the table instead of repeating per user.
-  - Selecting a specific user or bar uses searchable tables; choosing "All Users" hides these selectors and does not require an ID.
-  - The form disables hidden `user_id` and `bar_id` inputs when not targeting specific recipients and alerts if a required selection is missing.
-  - Users view messages at `/notifications` with downloadable attachments and inline images.
-- Notification detail bodies preserve line breaks and wrap text via `.notification-body`.
-- `/notifications` lists each message as a clickable card showing the subject and a truncated body; unread notes use `card--unread` styling and are marked read when opened at `/notifications/{id}`.
-- Notification lists use `.notifications-list` to remove bullets and padding; each `.notification-card` has a subtle border and unread cards display a light purple background (`#EDE9FE`).
-- Deleting a notification from `/admin/notifications` removes the corresponding `NotificationLog` and all recipient `Notification` rows so the message disappears from `/notifications` for every user.
-- Each `Notification` stores a `log_id` linking back to its `NotificationLog` so deletions reliably remove every user's copy.
-- Shared layout data hydrates through `/static/js/layout.js`, which reads JSON blobs from `#layoutState` and `#appI18nData` in `templates/layout.html` before `/static/js/app.min.js` executes.
-- Admin new bar page behaviour now lives in `/static/js/admin-new-bar.js`; the template only loads Leaflet and the new module.
-- Login geolocation now loads via `/static/js/login.js`, and the register prompt styling resides in `/static/css/pages/login.css`.
-  - Mobile menu includes `Notifications` link (`/notifications`) with `bi-bell` icon for accessing admin messages.
-- Mobile menu shows a red notification badge when the user has unread messages.
-- Notifications older than 30 days are purged automatically by `purge_old_notifications_worker`.
-- New users automatically receive the welcome message after completing registration.
-- Notification and NotificationLog rows persist `subject_translations` and `body_translations` JSON maps so user-facing views can localise message copy when switching languages.
-- Admin new notification form collects per-language subjects and bodies; submissions store translations on both `NotificationLog` and each recipient `Notification`.
-- Mobile menu now includes a **Language** entry (bi-translate icon) that opens an in-app dialog for choosing between English, Italiano, Français, and Deutsch; see `templates/layout.html`, `static/js/app.js`, and related styles in `static/css/components.css`.
+> **Reminder:** Inspect existing CSS/JS under `static/` before writing new
+> assets. Templates under `templates/` must **not** contain inline CSS or JS.
 
-## Internationalization
+## 2. Layout & Global Behaviour
 
-- Translation utilities live in `app/i18n/__init__.py`. Use `translator_for_request(request)` inside FastAPI endpoints to
-  access the request-aware translator or `create_translator("<code>")` for background tasks.
-- Language resources are stored as JSON files in `app/i18n/translations/`. Each language file currently contains metadata only;
-  add new keys under descriptive namespaces (e.g. `"home": {"hero_title": "..."}`) when localising copy.
-- `render_template` injects four helpers into every template context:
-  - `language_code` – currently active language code
-  - `available_languages` – list of `{code, name}` dictionaries for every supported locale (`en`, `it`, `fr`, `de`)
-  - `_` and `translate` – both reference the same translator callable supporting
-    `_("key.path", default="Fallback", name="Alice")` syntax with optional `str.format` keywords
-- Passing `?lang=<code>` in the query string updates the user's preferred language and persists it in the session for
-  subsequent requests. Absent an explicit choice, the resolver checks the stored session value followed by the
-  `Accept-Language` header before falling back to English.
-- About page strings live under the `about` namespace in `app/i18n/translations/*.json`; `templates/about.html` pulls from these keys.
-- Help Center page strings live under the `help_center` namespace in `app/i18n/translations/*.json`; `templates/help_center.html` pulls from these keys.
-- "For Bars", "Terms", and "Wallet" pages localize through `for_bars`, `terms`, and `wallet` namespaces inside `app/i18n/translations/*.json`.
+- Core FastAPI app lives in `main.py`, with shared helpers in `database.py`,
+  `models.py`, and `app/`.
+- Shared template: `templates/layout.html` loads global scripts and hydrates
+  JSON data via `static/js/layout.js` before `static/js/app.min.js` runs.
+- `static/css/components.css` and `static/js/app.js` provide reusable UI
+  patterns (mobile menu, language dialog, notification badges).
+- Horizontal overflow is locked with `overflow-x: clip` on `html, body`; the
+  header stretches to full width and sits at `z-index:1050`.
+- Body uses a flex column with `min-height:100dvh`, ensuring `<main>` grows to
+  keep the footer at the bottom.
 
-- Login page strings live under the `login` namespace in `app/i18n/translations/*.json`; `templates/login.html` pulls from these keys.
-- Registration step one page strings live under the `register_step1` namespace in `app/i18n/translations/*.json`; `templates/register_step1.html` pulls from these keys.
-- Registration details page strings live under the `register` namespace in `app/i18n/translations/*.json`; `templates/register.html` pulls from these keys.
-- Shared authentication UI strings (password toggles, caps lock warning) live under the `auth` namespace in `app/i18n/translations/*.json`.
-- Profile page strings live under the `profile` namespace in `app/i18n/translations/*.json`; `templates/profile.html` pulls from these keys and reuses the registration phone prefix options.
-- Change Password page strings live under the `change_password` namespace in `app/i18n/translations/*.json`; `templates/change_password.html` also uses shared `auth` password toggle labels.
-- Order confirmation copy in `templates/order_success.html` localises through the `order_success` namespace in `app/i18n/translations/*.json`.
-- Order history UI strings live under the `order_history` namespace in `app/i18n/translations/*.json`; `templates/order_history.html` pulls from these keys.
-- Notifications list strings use the `notifications` namespace in `app/i18n/translations/*.json`; `templates/notifications.html` references them.
-- Notification detail view strings use the `notification_detail` namespace in `app/i18n/translations/*.json`; `templates/notification_detail.html` uses these keys.
-- Cart, Search, and bar detail pages use the `cart`, `search`, and `bar_detail` namespaces in `app/i18n/translations/*.json` and their respective templates.
-- The "All bars" directory view localises via the `all_bars` namespace in `app/i18n/translations/*.json`; strings surface in `templates/all_bars.html` and supporting scripts.
-- Bartender dashboard copy pulls from the `bartender_dashboard` namespace, and bartender order management strings use the `bartender_orders` namespace.
-- Bar admin dashboard strings live under the `bar_admin_dashboard` namespace in `app/i18n/translations/*.json`; `templates/bar_admin_dashboard.html` references them.
-- Bartender confirmation strings live under the `bartender_confirm` namespace in `app/i18n/translations/*.json`; `templates/bartender_confirm.html` references them.
-- Display orders screen strings live under the `display_orders` namespace in `app/i18n/translations/*.json`; `templates/display_orders.html` references them.
-- Bar admin revenue history pages use the `bar_admin_history` namespace in `app/i18n/translations/*.json`; `templates/bar_admin_month_history.html`, `templates/bar_admin_order_history.html`, and `templates/bar_admin_order_history_view.html` reference these keys.
-- Bartender live orders page (`templates/bartender_orders.html`) uses the `bartender_orders.back` translation key for its dashboard return link; update all language JSON files when adjusting this label.
-- Bar admin live orders strings live under the `bar_admin_orders` namespace in `app/i18n/translations/*.json`; `templates/bar_admin_orders.html` pulls from these keys.
-- Bar category management pages use the `bar_categories` namespace in `app/i18n/translations/*.json`; see `templates/bar_manage_categories.html`, `templates/bar_new_category.html`, and `templates/bar_edit_category.html`.
-- Bar product management pages use the `bar_products` namespace in `app/i18n/translations/*.json`; `templates/bar_category_products.html`, `templates/bar_new_product.html`, and `templates/bar_edit_product.html` reference them.
-- Admin analytics, audit logs, table management, bar user management, admin bar listings, admin change password, admin dashboard, and admin user edit pages localise through the `admin_analytics`, `admin_audit_logs`, `admin_tables`, `admin_bar_users`, `admin_bars`, `admin_change_user_password`, `admin_dashboard`, and `admin_edit_user` namespaces in `app/i18n/translations/*.json`.
-- Admin users, profile summary, bar option chooser, notifications list, bar creation, welcome message editor, notification detail, and admin user overview pages localise through the `admin_users`, `admin_profile`, `admin_edit_bar_options`, `admin_notifications`, `admin_new_bar`, `admin_edit_welcome`, `admin_notification_view`, and `admin_view_user` namespaces in `app/i18n/translations/*.json`.
-- The `/topup` standalone page uses the `topup` namespace for headings, form labels, and alerts.
-- Admin bar editing and notification workflows use new namespaces in `app/i18n/translations/*.json`:
-  - `admin_edit_bar` covers the bar info form, including category chips and opening hours labels.
-  - `admin_new_notification` drives the broadcast form, search controls, and selection prompts.
-  - `admin_payments` defines the payouts list header, search inputs, and action buttons.
-- Bar descriptions now persist per language via the `description_translations` JSON column. The create flow seeds all languages with the initial copy and `/admin/bars/edit/{id}/description` provides a four-language editor linked from the info form.
-- Admin new bar form mirrors the edit bar card layout and gathers a single 120-character description in-line.
-- Shared live order widgets read translations from new namespaces in `app/i18n/translations/*.json`:
-  - `orders.statuses` and `orders.payment_methods` supply status and payment method labels for JS renderers.
-  - `bartender_orders.actions` now covers Accept, Cancel, Ready, and Complete buttons.
-  - `display_orders.card.title` localises the display screen order heading.
-  - `notices.payment_failed` provides the payment failure notice copy for global alerts.
-    - Include a `close` label so the wallet notice button renders in every language; reuse the same value for `notices.payment_success.close`.
-- Translation JSON files are verified by `tests/test_translations.py`, which ensures English, Italiano, Français, and Deutsch files all exist, share identical key paths (excluding `_meta`), and provide non-empty string values.
+## 3. Homepage (`templates/home.html`)
 
-- Notifications page cards now include a 25px margin on both sides via `.notifications-page .notification-card` in `static/css/components.css` to keep them from touching the viewport edges.
+- Hero art asset: `photo/homepage.png`, served via `/photo`.
+- Image markup: `<img class="hero-art" draggable="false">` with
+  `user-select:none`.
+- Positioning: `transform:translateX(-50%) rotate(70deg)`, offset
+  `left:calc(50% - 450px)` plus an extra 150px down / 450px left.
+- Size is fixed to 819×819 (20% smaller than original).
+- Mobile offset adds another 100px downward (`bottom:calc(-8rem - 200px)`).
+- `.home-hero .hero-art` styles live in `static/css/components.css`.
+- Hero copy centers via `.home-hero .hero__content` with `margin-inline:auto`
+  and `text-align:center`.
+- Buttons: only "Browse Bars" remains, linking to `/search` and centered.
 
-## Repository documentation
+## 4. Authentication & Account Flow
 
-- `README.md` now serves as a full product manual covering setup, routes, assets, and business flows. Update it whenever features change so engineering and ops stay aligned.
+| Route | Template | Assets | Notes |
+| --- | --- | --- | --- |
+| `/login` | `templates/login.html` | `static/js/login.js`, `static/css/pages/login.css` | Authenticated users redirect away. |
+| `/register` (step 1) | `templates/register_step1.html` | `static/css/pages/register-step1.css` | Collects email + password, assigns `REGISTERING` role. |
+| `/register/details` | `templates/register.html` | `static/js/register.js` | Forces lowercase usernames on input. |
+| `/profile` | `templates/profile.html` | Translations under `profile` namespace. | Reuses phone prefixes. |
+| `/change-password` | `templates/change_password.html` | Uses `auth` namespace for toggles. |
+
+- Registration remains a two-step flow. After step two succeeds, users stay
+  signed in and land on `/`.
+- Middleware keeps `REGISTERING` users on `/register/details` and blocks other
+  routes.
+- Blocked/IP-blocked users cannot log out; middleware intercepts `/logout` and
+  the layout hides that link.
+- Super admins can create users from the Admin Users page with email +
+  password only (bypasses registration flow).
+
+## 5. Notifications System
+
+- Templates: list at `templates/notifications.html`, detail at
+  `templates/notification_detail.html`.
+- Styling: `.notifications-list` and `.notification-card` in
+  `static/css/components.css`. Unread items use `.card--unread` with light
+  purple (`#EDE9FE`). Cards gain 25px horizontal margins in
+  `.notifications-page .notification-card`.
+- Behaviour: `/static/js/admin-notifications.js`,
+  `/static/js/admin-notification-view.js`, `/static/js/admin-new-notification.js`.
+- Admin form enforces subject maxlength 30, handles attachments (downloadable
+  in detail view) and optional targeting. Alerts when required recipient data
+  is missing.
+- Deleting a notification removes related `NotificationLog` plus all recipient
+  `Notification` rows so `/notifications` stays in sync.
+- Translations stored on both `NotificationLog` and each `Notification` via
+  `subject_translations` and `body_translations` JSON columns.
+- Users receive a welcome notification automatically after registration.
+- Purge worker `purge_old_notifications_worker` deletes notifications older
+  than 30 days.
+
+## 6. Bar, Bartender, and Display Dashboards
+
+| Area | Templates | CSS | JS | Notes |
+| --- | --- | --- | --- | --- |
+| Display orders | `templates/display_orders.html` | `static/css/pages/display-orders.css` | `static/js/display-page.js` | Two-column layout (preparing/ready), full-width, large headers. Display role redirects to this page only. |
+| Bartender orders | `templates/bartender_orders.html` | `static/css/pages/bar-orders.css` | `static/js/bar-orders.js` | Shares layout with bar admin order dashboards. |
+| Bar admin live orders | `templates/bar_admin_orders.html` | `static/css/pages/bar-orders.css` | `static/js/bar-orders.js` | Uses `initBartender` to manage pause toggles via `data-bar-id`. |
+| Bar detail | `templates/bar_detail.html` | Shared components CSS | `static/js/bar-detail.js` | Syncs pause state, sets directions links, fallback imagery. |
+| Bar search | `templates/search.html` | Shared components CSS | `static/js/search.js` | Handles filtering, metadata rendering, image fallbacks. |
+| Home bar lists | `templates/home.html` | Shared CSS | `static/js/home.js` | Adds fallback handlers for hero and bar card images. |
+
+- Display role header keeps only Logout, removes nav/menu links; logo is not
+  clickable.
+- Display orders page hides footer and cart links, doubling order header size
+  for readability.
+- Wallet top-up page (`templates/topup.html`) depends on `static/js/topup.js`
+  for preset amounts and redirect handling.
+
+## 7. Admin Area Overview
+
+All admin edit pages now load CSS/JS externally. Use this table to locate
+assets when working on admin templates under `templates/`.
+
+| Template | CSS | JS | Extra Notes |
+| --- | --- | --- | --- |
+| `templates/admin_dashboard.html` | — | `static/js/admin-dashboard.js` | Handles delete-all-orders confirmation. |
+| `templates/admin_analytics.html` | `static/css/pages/admin-analytics.css` | `static/js/admin-analytics.js` | Chart.js stays on CDN; data hydrates via `#adminAnalyticsData`. |
+| `templates/admin_audit_logs.html` | `static/css/pages/admin-audit-logs.css` | `static/js/admin-audit-logs.js` | Keeps filter form responsive. |
+| `templates/admin_notifications.html` | — | `static/js/admin-notifications.js` | Delete confirmation for notifications. |
+| `templates/admin_notification_view.html` | `static/css/pages/admin-notification-view.css` | `static/js/admin-notification-view.js` | Styles actions, hides delete form. |
+| `templates/admin_new_notification.html` | `static/css/pages/admin-new-notification.css` | `static/js/admin-new-notification.js` | Subject maxlength 30 enforced. |
+| `templates/admin_edit_user.html` | `static/css/pages/admin-edit-user.css` | `static/js/admin-edit-user.js` | Delete spacing fixes, hides post form. |
+| `templates/admin_edit_bar.html` | `static/css/pages/admin-edit-bar.css` | `static/js/admin-edit-bar.js` | Leaflet assets remain on CDN. |
+| `templates/admin_edit_bar_options.html` | `static/css/pages/admin-edit-bar-options.css` | — | — |
+| `templates/admin_edit_bar_description.html` | `static/css/pages/admin-edit-bar-description.css` | — | Handles multi-language bar descriptions. |
+| `templates/admin_edit_welcome.html` | `static/css/pages/admin-edit-welcome.css` | `static/js/admin-edit-welcome.js` | — |
+| `templates/admin_new_bar.html` | `static/css/pages/admin-new-bar.css` | `static/js/admin-new-bar.js` | Leaflet assets included separately; 120-character description inline. |
+| `templates/admin_bars.html` | `static/css/pages/admin-bars.css` | `static/js/admin-bars.js` | JS manages table filtering + deletion; CSS hides delete forms. |
+| `templates/admin_bar_users.html` | — | `static/js/admin-bar-users.js` | Handles staff filtering/removal dialogs. |
+| `templates/admin_ip_block.html` | — | `static/js/admin-ip-block.js` | Delete confirmation. |
+| `templates/admin_notifications_form` (search toolbars) | CSS via respective page | JS prevents submissions on `.form-search` wrappers. |
+| `templates/admin_notification_view.html` | `static/css/pages/admin-notification-view.css` | `static/js/admin-notification-view.js` | Maintains action spacing. |
+
+## 8. Bar Management (Admin + Bar Owner)
+
+| Template | CSS | JS | Purpose |
+| --- | --- | --- | --- |
+| `templates/bar_manage_categories.html` | `static/css/pages/bar-manage-categories.css` | `static/js/bar-manage-categories.js` | Category listing + deletion handling. |
+| `templates/bar_new_category.html` | `static/css/pages/bar-new-category.css` | `static/js/bar-new-category.js` | Category creation. |
+| `templates/bar_edit_category.html` | `static/css/pages/bar-edit-category.css` | — | Category editing. |
+| `templates/bar_edit_category_description.html` | `static/css/pages/translation-editor.css` | — | Translation editor shared with other description forms. |
+| `templates/bar_edit_category_name.html` | `static/css/pages/translation-editor.css` | — | Name translation editor. |
+| `templates/bar_category_products.html` | `static/css/pages/bar-category-products.css` | `static/js/bar-category-products.js` | Product deletion form handling. |
+| `templates/bar_new_product.html` | Shared CSS | — | Uses `bar_products` translations namespace. |
+| `templates/bar_edit_product.html` | `static/css/pages/bar-edit-product.css` | `static/js/bar-edit-product.js` (if added) | Loads via admin mapping above. |
+| `templates/bar_edit_product_description.html` | `static/css/pages/translation-editor.css` | — | Product description translations. |
+
+- Shared order widgets pull translations from `orders.statuses`,
+  `orders.payment_methods`, `bartender_orders.actions`, and
+  `display_orders.card.title` inside `app/i18n/translations/*.json`.
+- Bar descriptions persist per language via `description_translations` JSON
+  column. Creation seeds all languages; editing occurs at
+  `/admin/bars/edit/{id}/description`.
+
+## 9. Wallet & Finance
+
+- Wallet top-up page translations live under the `wallet` namespace.
+- Finance helpers located in `finance.py`, payouts handled in `payouts.py`, and
+  top-up logic in `node-topup/`.
+
+## 10. Static Marketing Pages
+
+| Route | Template | Notes |
+| --- | --- | --- |
+| `/about` | `templates/about.html` | Intro: "Built and operated by Siply... We’re building a modern ordering experience..." |
+| `/help` | `templates/help_center.html` | Pulls support contact from `main.py` constants. |
+| `/for-bars` | `templates/for_bars.html` | Shares `.static-page` styles. |
+| `/terms` | `templates/terms.html` | Uses `TERMS_VERSION` etc. from `main.py`. |
+
+All static marketing pages reuse `.static-page` rules in
+`static/css/components.css`. Support contact details live in Jinja globals inside
+`main.py` (`SUPPORT_EMAIL`, `SUPPORT_NUMBER`, `TERMS_VERSION`, etc.).
+
+## 11. Internationalisation
+
+- Translation utilities: `app/i18n/__init__.py` with
+  `translator_for_request(request)` for endpoints and `create_translator("<code>")`
+  for background tasks.
+- Resources stored in `app/i18n/translations/*.json`. Each language file includes
+  metadata plus namespaces for page copy.
+- `render_template` exposes helper context variables: `language_code`,
+  `available_languages`, `_`, and `translate` (accept keyword formatting).
+- Query parameter `?lang=<code>` updates session language; fallback order is
+  session → `Accept-Language` → English.
+- Namespaces per area (all in `app/i18n/translations/*.json`):
+  - `about`, `help_center`, `for_bars`, `terms`, `wallet`
+  - `login`, `register_step1`, `register`, `auth`
+  - `profile`, `change_password`, `order_success`, `order_history`
+  - `notifications`, `notification_detail`
+  - `cart`, `search`, `bar_detail`, `all_bars`
+  - `bartender_dashboard`, `bartender_orders`, `bartender_confirm`
+  - `bar_admin_dashboard`, `bar_admin_orders`, `bar_admin_history`
+  - `bar_categories`, `bar_products`
+  - `orders.statuses`, `orders.payment_methods`, `bartender_orders.actions`,
+    `display_orders.card.title`, `notices.payment_failed`,
+    `notices.payment_success.close`
+  - `admin_analytics`, `admin_audit_logs`, `admin_tables`, `admin_bar_users`,
+    `admin_bars`, `admin_change_user_password`, `admin_dashboard`,
+    `admin_edit_user`, `admin_users`, `admin_profile`, `admin_edit_bar_options`,
+    `admin_notifications`, `admin_new_bar`, `admin_edit_welcome`,
+    `admin_notification_view`, `admin_view_user`, `admin_edit_bar`,
+    `admin_new_notification`, `admin_payments`, `topup`
+- `tests/test_translations.py` ensures the four language files (English,
+  Italiano, Français, Deutsch) exist, share key paths (excluding `_meta`), and
+  contain non-empty strings.
+
+## 12. Authentication, Redirects, and Middleware Notes
+
+- `main.py` supplies `redirect_for_authenticated_user` to keep logged-in users
+  off `/login` and `/register`.
+- Registering users attempting other routes are redirected back to
+  `/register/details`.
+- Display users accessing non-display routes are redirected to their bar’s
+  `/dashboard/bar/{id}/orders` page.
+- Language menu now appears in the mobile navigation with a `bi-translate` icon
+  and is managed via `static/js/app.js` plus `static/css/components.css`.
+- Mobile menu `Notifications` entry uses `bi-bell`; unread counts show a red
+  badge.
+
+## 13. Orders & Payments
+
+- Shared live order JS modules read translation namespaces listed above.
+- Admin payments search logic moved to `static/js/admin-payments.js`; templates
+  only render markup.
+- Wallet top-up flow located in `templates/topup.html` with logic in
+  `static/js/topup.js`.
+- Node services for top-ups live under `node-topup/`.
+
+## 14. Repository Documentation
+
+- `README.md` functions as the complete product manual. Update it whenever
+  features, routes, or assets change so engineering and operations stay aligned.
+
+---
+
+If any instruction seems missing, re-check this file—everything links to the
+canonical location. For further context, inspect the file path referenced in
+each table cell or bullet.


### PR DESCRIPTION
## Summary
- rewrite the repository-wide AGENTS guide with quick-reference tables and grouped sections so contributors can immediately locate relevant templates, assets, and workflows.

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68da9935a428832090ddc9fedc85ee08